### PR TITLE
don't add points if d is undefined

### DIFF
--- a/src/components/InteractionLayer.js
+++ b/src/components/InteractionLayer.js
@@ -147,7 +147,8 @@ class InteractionLayer extends React.Component<Props, State> {
 
   constructDataObject = (d?: Object) => {
     const { points } = this.props
-    return d && d.data ? { points, ...d.data, ...d } : { points, ...d }
+    return d && d.data ? { points, ...d.data, ...d }
+      : (d ? { points, ...d } : d)
   }
 
   changeVoronoi = (d?: Object, customHoverTypes?: CustomHoverType) => {


### PR DESCRIPTION
`d === undefined` might be used by clients as a check to determine that it's a mouseout event. In that scenario, `points` shouldn't be added as it might cause an issue on the client's callback function.  