### PR TITLE
Add backwards compatibility behavior for new summaries key in MinimapXYFrame

### DIFF
--- a/src/components/MinimapXYFrame.js
+++ b/src/components/MinimapXYFrame.js
@@ -49,7 +49,8 @@ class MinimapXYFrame extends React.Component {
       yAccessor: yAccessor,
       points: points,
       lines: lines,
-      summaries: summaries,
+      areas: areas,
+      summaries: "areas" in minimap ? minimap.areas : summaries, // for backwards compatibility
       lineDataAccessor: lineDataAccessor,
       xBrushable: true,
       yBrushable: true,
@@ -101,6 +102,7 @@ MinimapXYFrame.propTypes = {
   yAccessor: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   points: PropTypes.array,
   lines: PropTypes.array,
+  areas: PropTypes.array,
   summaries: PropTypes.array,
   lineDataAccessor: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   lineType: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),


### PR DESCRIPTION
This is an attempt to make the new `summaries` key in the `MinimapXYFrame` backwards compatible. There are likely better ways to handle this - this PR is intended to start the conversation rather than necessarily propose the best path forward.

In previous versions up Semiotic, up to v1.16.8, there was an `areas` option for the minimap. Starting in v1.17.0, a new `summaries` option was added. Code which previously overrode the `areas` minimap option was no longer overriding the default behavior after this change was made.

See https://github.com/nteract/semiotic/issues/395 for more information.

