### PR TITLE
Trendlines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4970,12 +4970,6 @@
       "integrity": "sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g==",
       "dev": true
     },
-    "element-resize-event": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/element-resize-event/-/element-resize-event-2.0.9.tgz",
-      "integrity": "sha1-L14VgaKW61J1IQwUG8VjQuIY+HY=",
-      "dev": true
-    },
     "elliptic": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
@@ -10415,12 +10409,6 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
-    },
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -14314,14 +14302,6 @@
         }
       }
     },
-    "react-dimensions": {
-      "version": "git://github.com/AlesJiranek/react-dimensions.git#9cd7cd8c7086ef61d0f4e31bb0fa84ac5ff03cbb",
-      "dev": true,
-      "requires": {
-        "element-resize-event": "2.0.9",
-        "lodash.debounce": "4.0.8"
-      }
-    },
     "react-dom": {
       "version": "16.8.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.4.tgz",
@@ -14937,6 +14917,11 @@
           "dev": true
         }
       }
+    },
+    "regression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regression/-/regression-2.0.1.tgz",
+      "integrity": "sha1-jSnD6CJKEIUMNeM36FqLL6w7DIc="
     },
     "relateurl": {
       "version": "0.2.7",

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "promise": "8.0.1",
     "prop-types": "15.6.0",
     "react-annotation": "2.1.5",
+    "regression": "^2.0.1",
     "roughjs-es5": "0.1.0",
     "semiotic-mark": "0.3.1",
     "svg-path-bounding-box": "1.0.4"

--- a/src/components/Axis.tsx
+++ b/src/components/Axis.tsx
@@ -309,8 +309,9 @@ class Axis extends React.Component<AxisProps, AxisState> {
         ? () => decoratedSummaryType.summaryClass
         : () => ""
 
-      const forSummaryData = this.props.xyPoints.map(
-        (d: { x: number; y: number }) => ({
+      const forSummaryData = this.props.xyPoints
+        .filter((p: { x?: number; y?: number }) => p.x && p.y)
+        .map((d: { x: number; y: number }) => ({
           ...d,
           xy: {
             x: orient === "top" || orient === "bottom" ? scale(d.x) : 0,
@@ -324,8 +325,7 @@ class Axis extends React.Component<AxisProps, AxisState> {
             orient === "top" || orient === "bottom" ? scale(d.y) : scale(d.x),
           scaledValue: scale(d.x),
           scaledVerticalValue: scale(d.y)
-        })
-      )
+        }))
 
       const renderedSummary = drawSummaries({
         data: {
@@ -353,21 +353,26 @@ class Axis extends React.Component<AxisProps, AxisState> {
       let points
 
       if (decoratedSummaryType.showPoints === true) {
-        points = marginalPointMapper(orient, summaryWidth, forSummaryData).map(
-          d => (
-            <circle
-              cx={d[0]}
-              cy={d[1]}
-              r={decoratedSummaryType.r || 3}
-              style={
-                decoratedSummaryType.pointStyle || {
-                  fill: "black",
-                  fillOpacity: 0.1
-                }
-              }
-            />
-          )
+        const mappedPoints = marginalPointMapper(
+          orient,
+          summaryWidth,
+          forSummaryData
         )
+
+        points = mappedPoints.map((d, i) => (
+          <circle
+            key={`axis-summary-point-${i}`}
+            cx={d[0]}
+            cy={d[1]}
+            r={decoratedSummaryType.r || 3}
+            style={
+              decoratedSummaryType.pointStyle || {
+                fill: "black",
+                fillOpacity: 0.1
+              }
+            }
+          />
+        ))
       }
 
       summaryGraphic = (

--- a/src/components/Axis.tsx
+++ b/src/components/Axis.tsx
@@ -292,6 +292,13 @@ class Axis extends React.Component<AxisProps, AxisState> {
           ? { type: marginalSummaryType }
           : marginalSummaryType
 
+      if (
+        decoratedSummaryType.flip === undefined &&
+        (orient === "bottom" || orient === "right")
+      ) {
+        decoratedSummaryType.flip = true
+      }
+
       const summaryStyle = decoratedSummaryType.summaryStyle
         ? () => decoratedSummaryType.summaryStyle
         : () => ({

--- a/src/components/data/dataFunctions.ts
+++ b/src/components/data/dataFunctions.ts
@@ -17,7 +17,12 @@ import {
   cumulativeLine
 } from "../svg/lineDrawing"
 
-import { contouring, hexbinning, heatmapping } from "../svg/areaDrawing"
+import {
+  contouring,
+  hexbinning,
+  heatmapping,
+  trendlining
+} from "../svg/areaDrawing"
 import { max, min } from "d3-array"
 
 import { extentValue } from "./unflowedFunctions"
@@ -441,6 +446,27 @@ export const calculateDataExtent = ({
     ]
   } else if (summaryType.type && summaryType.type === "heatmap") {
     projectedSummaries = heatmapping({
+      summaryType,
+      data: projectedSummaries,
+      processedData: summaries && !!summaries[0].processedData,
+      preprocess: false,
+      finalXExtent,
+      finalYExtent,
+      size,
+      margin,
+      baseMarkProps,
+      styleFn: summaryStyleFn,
+      classFn: summaryClassFn,
+      renderFn: summaryRenderModeFn,
+      chartSize
+    })
+
+    fullDataset = [
+      ...projectedSummaries.map(d => ({ ...d })),
+      ...fullDataset.filter(d => !d.parentSummary)
+    ]
+  } else if (summaryType.type && summaryType.type === "trendline") {
+    projectedSummaries = trendlining({
       summaryType,
       data: projectedSummaries,
       processedData: summaries && !!summaries[0].processedData,

--- a/src/components/svg/SvgHelper.tsx
+++ b/src/components/svg/SvgHelper.tsx
@@ -136,8 +136,6 @@ export const groupBarMark = ({
   type,
   baseMarkProps
 }) => {
-  let xProp = -columnWidth / 2
-
   const mappedBins = []
   const mappedPoints = []
   const actualMax = (relativeBuckets && relativeBuckets[summary.name]) || binMax
@@ -158,6 +156,10 @@ export const groupBarMark = ({
     const finalColumnWidth =
       type.type === "heatmap" ? columnWidth : columnWidth * opacity
     let yProp = d.y + barPadding
+    let xProp =
+      type.type === "heatmap" || type.flip
+        ? -columnWidth / 2
+        : columnWidth / 2 - finalColumnWidth
     let height = thickness
     let width = finalColumnWidth
     let xOffset =
@@ -167,6 +169,8 @@ export const groupBarMark = ({
     if (projection === "horizontal") {
       yProp =
         type.type === "heatmap"
+          ? -columnWidth / 2
+          : type.flip
           ? -columnWidth / 2
           : columnWidth / 2 - finalColumnWidth
       xProp = d.y - d.y1 + barPadding

--- a/src/components/svg/areaDrawing.tsx
+++ b/src/components/svg/areaDrawing.tsx
@@ -3,6 +3,8 @@ import { contourDensity } from "d3-contour"
 import { scaleLinear } from "d3-scale"
 import polylabel from "@mapbox/polylabel"
 import { hexbin } from "d3-hexbin"
+import regression from "regression"
+import { curveCardinal } from "d3-shape"
 
 import { ProjectedPoint, GenericObject } from "../types/generalTypes"
 
@@ -387,6 +389,97 @@ export function heatmapping({
       binMax: maxValue
     }
   }
+
+  return projectedSummaries
+}
+
+export function trendlining({
+  preprocess = true,
+  processedData = false,
+  summaryType,
+  data: baseData,
+  finalXExtent = [
+    Math.min(...baseData.coordinates.map(d => d.x)),
+    Math.max(...baseData.coordinates.map(d => d.x))
+  ],
+  finalYExtent = [
+    Math.min(...baseData.coordinates.map(d => d.y)),
+    Math.max(...baseData.coordinates.map(d => d.y))
+  ],
+  size,
+  xScaleType = scaleLinear(),
+  yScaleType = scaleLinear(),
+  margin,
+  baseMarkProps,
+  styleFn,
+  classFn,
+  renderFn,
+  chartSize
+}) {
+  if (processedData) {
+    return baseData[0].coordinates
+  }
+
+  let projectedSummaries = []
+  if (!summaryType.type) {
+    summaryType = { type: summaryType }
+  }
+
+  const {
+    regressionType: baseRegressionType = "linear",
+    order = 2,
+    precision = 2,
+    controlPoints = 20,
+    curve = curveCardinal
+  } = summaryType
+
+  let regressionType = baseRegressionType
+
+  if (
+    finalXExtent[0] < 0 &&
+    (baseRegressionType === "logarithmic" ||
+      baseRegressionType === "power" ||
+      baseRegressionType === "exponential")
+  ) {
+    console.error(
+      `Cannot use this ${baseRegressionType} regressionType type with value range that goes below 0, defaulting to linear`
+    )
+    regressionType = "linear"
+  }
+
+  if (baseData.coordinates && !baseData._xyfCoordinates) {
+    baseData._xyfCoordinates = baseData.coordinates.map(d => [d.x, d.y])
+  }
+
+  const data = Array.isArray(baseData) ? baseData : [baseData]
+
+  const xScale = xScaleType.domain([0, 1]).range(finalXExtent)
+
+  projectedSummaries = []
+  data.forEach(bdata => {
+    const regressionLine = regression[regressionType](bdata._xyfCoordinates, {
+      order,
+      precision
+    })
+    const controlStep = 1 / controlPoints
+
+    const controlPointArray = []
+
+    for (let step = 0; step < 1 + controlStep; step += controlStep) {
+      controlPointArray.push(regressionLine.predict(xScale(step)))
+    }
+
+    projectedSummaries.push({
+      centroid: false,
+      customMark: undefined,
+      data: bdata,
+      parentSummary: bdata,
+      value: regressionLine.string,
+      r2: regressionLine.r2,
+      curve,
+      _xyfCoordinates: controlPointArray
+    })
+  })
 
   return projectedSummaries
 }

--- a/src/components/svg/areaDrawing.tsx
+++ b/src/components/svg/areaDrawing.tsx
@@ -457,10 +457,16 @@ export function trendlining({
 
   projectedSummaries = []
   data.forEach(bdata => {
-    const regressionLine = regression[regressionType](bdata._xyfCoordinates, {
-      order,
-      precision
-    })
+    const regressionLine = regression[regressionType](
+      bdata._xyfCoordinates.map(d => [
+        d[0].getTime ? d[0].getTime() : d[0],
+        d[1].getTime ? d[1].getTime() : d[1]
+      ]),
+      {
+        order,
+        precision
+      }
+    )
     const controlStep = 1 / controlPoints
 
     const controlPointArray = []

--- a/src/components/svg/summaryLayouts.tsx
+++ b/src/components/svg/summaryLayouts.tsx
@@ -1140,9 +1140,12 @@ export function bucketizedRenderingFn({
       if (projection === "horizontal") {
         joyBins.forEach((summaryPoint, i) => {
           const xValue = summaryPoint.y - bucketSize / 2
-          const yValue =
-            (-summaryPoint.value / actualMax) * (columnWidth + joyHeight) +
-            columnWidth / 2
+
+          const yValue = type.flip
+            ? (summaryPoint.value / actualMax) * (columnWidth + joyHeight) -
+              columnWidth / 2
+            : (-summaryPoint.value / actualMax) * (columnWidth + joyHeight) +
+              columnWidth / 2
 
           joyPoints.push({
             y: yValue,
@@ -1164,8 +1167,11 @@ export function bucketizedRenderingFn({
         joyBins.forEach(summaryPoint => {
           const yValue = summaryPoint.y + bucketSize / 2
           const xValue =
-            (-summaryPoint.value / actualMax) * (columnWidth + joyHeight) +
-            columnWidth / 2
+            type.flip === true
+              ? (summaryPoint.value / actualMax) * (columnWidth + joyHeight) -
+                columnWidth / 2
+              : (-summaryPoint.value / actualMax) * (columnWidth + joyHeight) +
+                columnWidth / 2
 
           joyPoints.push({
             y: yValue,

--- a/src/components/types/generalTypes.ts
+++ b/src/components/types/generalTypes.ts
@@ -57,6 +57,7 @@ export interface ProjectedSummary {
   bounds: object[] | number[]
   customMark: Function
   type?: string
+  curve?: Function
 }
 
 export type CanvasPostProcessTypes = Function | "chuckClose"

--- a/src/components/types/generalTypes.ts
+++ b/src/components/types/generalTypes.ts
@@ -172,6 +172,7 @@ export type OrdinalSummaryTypeSettings = {
   type: OrdinalSummaryTypes
   amplitude?: number
   eventListenersGenerator?: Function
+  flip?: boolean
 }
 
 export interface AxisSummaryTypeSettings extends OrdinalSummaryTypeSettings {

--- a/src/components/visualizationLayerBehavior/general.tsx
+++ b/src/components/visualizationLayerBehavior/general.tsx
@@ -464,9 +464,17 @@ export function createSummaries({
       shouldBeValid = true
     } else {
       const xyfCoords = d._xyfCoordinates as number[][]
-      drawD = `M${xyfCoords
-        .map(p => `${xScale(p[0])},${yScale(p[1])}`)
-        .join("L")}Z`
+      if (d.curve) {
+        const lineDrawing = line()
+          .x(d => xScale(d[0]))
+          .y(d => yScale(d[1]))
+          .curve(d.curve)
+        drawD = lineDrawing(xyfCoords)
+      } else {
+        drawD = `M${xyfCoords
+          .map(p => `${xScale(p[0])},${yScale(p[1])}`)
+          .join("L")}Z`
+      }
     }
 
     const renderKey = renderKeyFn ? renderKeyFn(d, i) : `summary-${i}`

--- a/src/docs/components/AppleStockChartRaw.js
+++ b/src/docs/components/AppleStockChartRaw.js
@@ -158,7 +158,7 @@ export default (editMode, overridePosition, setNewPosition) => {
         hoverAnnotation={!editMode}
         areaType={{
           type: "trendline",
-          regressionType: "exponential",
+          regressionType: "polynomial",
           order: 8
         }}
         areas={{ label: "Apple Stock", coordinates: data }}

--- a/src/docs/components/AppleStockChartRaw.js
+++ b/src/docs/components/AppleStockChartRaw.js
@@ -5,7 +5,13 @@ import { scaleTime } from "d3-scale"
 
 const chartAxes = [
   { orient: "left", tickFormat: d => `$${d}` },
-  { orient: "bottom", ticks: 6, tickFormat: d => d.getFullYear() }
+  { orient: "bottom", ticks: 6, tickFormat: d => d.getFullYear() },
+  {
+    orient: "right",
+    marginalSummaryType: {
+      type: "boxplot"
+    }
+  }
 ]
 
 const thresholdLine = ({ d, i, xScale, yScale }) => {
@@ -38,11 +44,12 @@ const appleChart = {
   size: [700, 300],
   xScaleType: scaleTime(),
   xAccessor: d => new Date(d.date),
+  yExtent: [0],
   yAccessor: "close",
   lines: [{ label: "Apple Stock", coordinates: data }],
   customLineMark: thresholdLine,
   axes: chartAxes,
-  margin: { top: 50, left: 40, right: 10, bottom: 40 },
+  margin: { top: 50, left: 40, right: 50, bottom: 40 },
   tooltipContent: customTooltip,
   additionalDefs: (
     <linearGradient id="bubbleGradient">
@@ -149,6 +156,18 @@ export default (editMode, overridePosition, setNewPosition) => {
         {...appleChart}
         annotations={annotations}
         hoverAnnotation={!editMode}
+        areaType={{
+          type: "trendline",
+          regressionType: "exponential",
+          order: 8
+        }}
+        areas={{ label: "Apple Stock", coordinates: data }}
+        areaStyle={{
+          fill: "none",
+          stroke: "darkred",
+          strokeWidth: 3,
+          strokeOpacity: 0.5
+        }}
       />
     </div>
   )

--- a/src/docs/components/CreatingXYPlots.js
+++ b/src/docs/components/CreatingXYPlots.js
@@ -99,7 +99,7 @@ export default class CreatingXYPlots extends React.Component {
               {
                 orient: "bottom",
                 marginalSummaryType: {
-                  type: "boxplot",
+                  type: "ridgeline",
                   showPoints: true,
                   summaryStyle: {
                     fill: "orange",
@@ -115,15 +115,22 @@ export default class CreatingXYPlots extends React.Component {
               },
               {
                 orient: "left",
-                marginalSummaryType: { type: "boxplot", showPoints: true }
+                marginalSummaryType: {
+                  type: "ridgeline",
+                  bins: 4,
+                  showPoints: true
+                }
               },
               {
                 orient: "right",
-                marginalSummaryType: { type: "boxplot", showPoints: true }
+                marginalSummaryType: {
+                  type: "ridgeline",
+                  showPoints: true
+                }
               },
               {
                 orient: "top",
-                marginalSummaryType: { type: "boxplot", showPoints: true }
+                marginalSummaryType: { type: "ridgeline", showPoints: true }
               }
             ]}
           />

--- a/src/docs/components/CreatingXYPlots.js
+++ b/src/docs/components/CreatingXYPlots.js
@@ -93,6 +93,8 @@ export default class CreatingXYPlots extends React.Component {
             yAccessor="y"
             pointStyle={d => ({ fill: d.color })}
             yExtent={[-8500, 8500]}
+            areaType={{ type: "trendline", regressionType: "logarithmic" }}
+            areaStyle={{ stroke: "darkred" }}
             axes={[
               {
                 orient: "bottom",


### PR DESCRIPTION
Add trendlines via `regression`. This supports `power`, `linear`, `logarithmic`, `polynomial` & `exponential` options. The way this works in Semiotic is that XYFrame supports a `trendline` value for `summaryType` and it will default to a linear trendline. You can change the trendline via a `regressionType` like `areaType={{ type: "trendline", regressionType: "logarithmic" }}`. If you specify a regression type that won't work with negative data, it will default back to linear.