### PR TITLE
Tooltip edge detection 

### DIFF
--- a/src/components/NetworkFrame.tsx
+++ b/src/components/NetworkFrame.tsx
@@ -1792,7 +1792,12 @@ class NetworkFrame extends React.Component<
     i: number
     annotationLayer: AnnotationLayerProps
   }) => {
-    const { tooltipContent, size, useSpans } = this.props
+    const {
+      tooltipContent,
+      optimizeCustomTooltipPosition, 
+      size,
+      useSpans
+    } = this.props
     const {
       projectedNodes,
       projectedEdges,
@@ -1842,6 +1847,7 @@ class NetworkFrame extends React.Component<
         d,
         i,
         tooltipContent,
+        optimizeCustomTooltipPosition,
         useSpans,
         nodes: projectedNodes,
         edges: projectedEdges,

--- a/src/components/OrdinalFrame.tsx
+++ b/src/components/OrdinalFrame.tsx
@@ -1737,6 +1737,7 @@ class OrdinalFrame extends React.Component<OrdinalFrameProps, State> {
         oAccessor,
         projection,
         tooltipContent,
+        optimizeCustomTooltipPosition,
         projectedColumns,
         useSpans,
         pieceIDAccessor,

--- a/src/components/TooltipPositioner.tsx
+++ b/src/components/TooltipPositioner.tsx
@@ -76,7 +76,7 @@ class TooltipPositioner extends React.Component<Props> {
       {
         opacity: 0
       }
-
+      
     return (
       <div ref={this.containerRef} style={containerStyle}>
         {tooltipContent({...tooltipContentArgs,

--- a/src/components/TooltipPositioner.tsx
+++ b/src/components/TooltipPositioner.tsx
@@ -20,7 +20,6 @@ class TooltipPositioner extends React.Component<Props> {
       y: 0
     }
     const { right, left, top, bottom } = this.containerRef.current.getBoundingClientRect()
-
     if(right>window.innerWidth){
       offset.x = window.innerWidth - right
     }
@@ -32,7 +31,7 @@ class TooltipPositioner extends React.Component<Props> {
       offset.y = - top
     }
     else if(bottom > window.innerHeight){
-      offset.x = window.innerHeight - bottom
+      offset.y = window.innerHeight - bottom
     }
 
     this.setState({

--- a/src/components/TooltipPositioner.tsx
+++ b/src/components/TooltipPositioner.tsx
@@ -20,18 +20,20 @@ class TooltipPositioner extends React.Component<Props> {
       y: 0
     }
     const { right, left, top, bottom } = this.containerRef.current.getBoundingClientRect()
-    if(right>window.innerWidth){
-      offset.x = window.innerWidth - right
-    }
-    else if(left<0){
-      offset.x = - left
-    }
+    const containerWidth = right - left
+    const containerHeight = bottom - top
 
-    if(top<0){
-      offset.y = - top
+    if(right > window.innerWidth){
+      offset.x = - containerWidth
     }
-    else if(bottom > window.innerHeight){
-      offset.y = window.innerHeight - bottom
+    else if(left < 0){
+      offset.x = containerWidth
+    }
+    if(bottom > window.innerHeight){
+      offset.y = - containerHeight
+    }
+    else if(top < 0){
+      offset.y = containerHeight
     }
 
     this.setState({
@@ -57,8 +59,6 @@ class TooltipPositioner extends React.Component<Props> {
     }
   }
 
-
-
   render() {
     const {
       tooltipContent,
@@ -76,7 +76,7 @@ class TooltipPositioner extends React.Component<Props> {
       {
         opacity: 0
       }
-      
+
     return (
       <div ref={this.containerRef} style={containerStyle}>
         {tooltipContent({...tooltipContentArgs,

--- a/src/components/XYFrame.tsx
+++ b/src/components/XYFrame.tsx
@@ -13,6 +13,7 @@ import {
 import Axis from "./Axis"
 import DownloadButton from "./DownloadButton"
 import Frame from "./Frame"
+import TooltipPositioner from './TooltipPositioner'
 import {
   svgXYAnnotation,
   svgHighlight,
@@ -141,6 +142,7 @@ export type XYFrameProps = {
   svgAnnotationRules?: Function
   htmlAnnotationRules?: Function
   tooltipContent?: Function
+  optimizeCustomTooltipPosition?: boolean
   annotations: object[]
   baseMarkProps?: object
   backgroundGraphics?: React.ReactNode | Function
@@ -1337,7 +1339,13 @@ class XYFrame extends React.Component<XYFrameProps, XYFrameState> {
 
     let screenCoordinates = []
 
-    const { useSpans } = this.props
+    const {
+      useSpans,
+      tooltipContent,
+      optimizeCustomTooltipPosition,
+      htmlAnnotationRules,
+      size
+    } = this.props
 
     const idAccessor = this.state.annotatedSettings.lineIDAccessor
     const d: AnnotationType = findPointByID({
@@ -1371,7 +1379,7 @@ class XYFrame extends React.Component<XYFrameProps, XYFrameState> {
       title: this.state.annotatedSettings.title
     })
     const { adjustedPosition, adjustedSize } = adjustedPositionSize({
-      size: this.props.size,
+      size,
       margin
     })
     if (!d.coordinates) {
@@ -1411,8 +1419,8 @@ class XYFrame extends React.Component<XYFrameProps, XYFrameState> {
     }
 
     const customAnnotation =
-      this.props.htmlAnnotationRules &&
-      this.props.htmlAnnotationRules({
+      htmlAnnotationRules &&
+      htmlAnnotationRules({
         d,
         i,
         screenCoordinates,
@@ -1431,7 +1439,7 @@ class XYFrame extends React.Component<XYFrameProps, XYFrameState> {
         annotationLayer
       })
 
-    if (this.props.htmlAnnotationRules && customAnnotation !== null) {
+    if (htmlAnnotationRules && customAnnotation !== null) {
       return customAnnotation
     }
     if (d.type === "frame-hover") {
@@ -1447,8 +1455,11 @@ class XYFrame extends React.Component<XYFrameProps, XYFrameState> {
         </SpanOrDiv>
       )
 
-      if (d.type === "frame-hover" && this.props.tooltipContent) {
-        content = this.props.tooltipContent(d)
+      if (d.type === "frame-hover" && tooltipContent) {
+        content = optimizeCustomTooltipPosition ? (<TooltipPositioner
+            tooltipContent={tooltipContent}
+            tooltipContentArgs={d}
+          />) : tooltipContent(d)
       }
       return htmlTooltipAnnotation({
         content,

--- a/src/components/annotationRules/networkframeRules.tsx
+++ b/src/components/annotationRules/networkframeRules.tsx
@@ -5,11 +5,13 @@ import AnnotationCalloutCircle from "react-annotation/lib/Types/AnnotationCallou
 import { packEnclose } from "d3-hierarchy"
 import { circleEnclosure, rectangleEnclosure, hullEnclosure } from "./baseRules"
 import SpanOrDiv from "../SpanOrDiv"
+import TooltipPositioner from '../TooltipPositioner'
 
 export const htmlFrameHoverRule = ({
   d: baseD,
   i,
   tooltipContent,
+  optimizeCustomTooltipPosition,
   useSpans,
   nodes,
   edges,
@@ -45,7 +47,10 @@ export const htmlFrameHoverRule = ({
   )
 
   if (d.type === "frame-hover" && tooltipContent) {
-    content = tooltipContent(d)
+    content = optimizeCustomTooltipPosition ? (<TooltipPositioner
+      tooltipContent={tooltipContent}
+      tooltipContentArgs={d}
+    />) : tooltipContent(d)
   }
 
   return (

--- a/src/components/annotationRules/orframeRules.tsx
+++ b/src/components/annotationRules/orframeRules.tsx
@@ -384,7 +384,7 @@ export const screenProject = ({
       idPiece && (idPiece.x || idPiece.scaledValue)
         ? idPiece.x === undefined
           ? idPiece.x
-          : idPiece.bottom + idPiece.scaledValue / 2
+          : ( idPiece.value >= 0? idPiece.bottom + idPiece.scaledValue / 2 : idPiece.bottom )
         : rScale(pValue),
       o
     ]
@@ -398,7 +398,8 @@ export const screenProject = ({
     o,
     idPiece && (idPiece.x || idPiece.scaledValue)
       ? idPiece.y === undefined
-        ? idPiece.bottom - idPiece.scaledValue
+        ? (idPiece.value >= 0? idPiece.bottom - idPiece.scaledValue
+          : idPiece.bottom )
         : idPiece.y
       : newScale(pValue)
   ]
@@ -640,6 +641,7 @@ export const htmlFrameHoverRule = ({
   oAccessor,
   projection,
   tooltipContent,
+  optimizeCustomTooltipPosition,
   useSpans,
   pieceIDAccessor,
   projectedColumns,
@@ -741,7 +743,12 @@ export const htmlFrameHoverRule = ({
   )
 
   if (d.type === "frame-hover" && tooltipContent && idPiece) {
-    content = tooltipContent({ ...idPiece, ...idPiece.data })
+    const tooltipContentArgs = { ...idPiece, ...idPiece.data }
+    content = optimizeCustomTooltipPosition ? (<TooltipPositioner
+      tooltipContent={tooltipContent}
+      tooltipContentArgs={tooltipContentArgs}
+    />) : tooltipContent(tooltipContentArgs)
+
   }
 
   return (

--- a/src/components/constants/frame_props.ts
+++ b/src/components/constants/frame_props.ts
@@ -177,6 +177,7 @@ const sharedframeproptypes = {
   svgAnnotationRules: true,
   htmlAnnotationRules: true,
   tooltipContent: true,
+  optimizeCustomTooltipPosition: true,
   annotations: true,
   baseMarkProps: true,
   backgroundGraphics: true,

--- a/src/components/types/networkTypes.ts
+++ b/src/components/types/networkTypes.ts
@@ -166,6 +166,7 @@ export interface NetworkFrameProps {
   svgAnnotationRules?: Function
   htmlAnnotationRules?: Function
   tooltipContent?: Function
+  NetworkFrameProps?: boolean
   annotations: object[]
   annotationSettings?: AnnotationHandling
   className?: string

--- a/src/components/types/networkTypes.ts
+++ b/src/components/types/networkTypes.ts
@@ -166,7 +166,7 @@ export interface NetworkFrameProps {
   svgAnnotationRules?: Function
   htmlAnnotationRules?: Function
   tooltipContent?: Function
-  NetworkFrameProps?: boolean
+  optimizeCustomTooltipPosition?: boolean
   annotations: object[]
   annotationSettings?: AnnotationHandling
   className?: string


### PR DESCRIPTION
2 changes: 
1. Continuation of the [enhancement](https://github.com/nteract/semiotic/pull/487) to position tooltip based on window edges. It is now supported in all frames. 
![tooltip_positioner](https://user-images.githubusercontent.com/6054688/62439262-16af9700-b700-11e9-9a85-77a6c5e5491b.gif)

2. Similar tooltip position [bug fix](https://github.com/nteract/semiotic/pull/486) when there are negative values in orframe. Found a similar issue for frame-hover type. 


