### PR TITLE
add more tooltip attributes for more flexible customization

### DIFF
--- a/src/components/TooltipPositioner.tsx
+++ b/src/components/TooltipPositioner.tsx
@@ -7,7 +7,8 @@ type Props = {
 
 type State = {
   offset: object,
-  tooltipContainerInitialDimensions: object
+  tooltipContainerInitialDimensions: object,
+  tooltipContentArgsCurrent: object
 }
 
 class TooltipPositioner extends React.Component<Props, State> {
@@ -15,7 +16,8 @@ class TooltipPositioner extends React.Component<Props, State> {
 
   state = {
     offset: null,
-    tooltipContainerInitialDimensions: null
+    tooltipContainerInitialDimensions: null,
+    tooltipContentArgsCurrent: null
   }
 
   // simple heuristics to check if the tooltip container exceeds the viewport
@@ -45,7 +47,8 @@ class TooltipPositioner extends React.Component<Props, State> {
 
     this.setState({
       offset,
-      tooltipContainerInitialDimensions
+      tooltipContainerInitialDimensions,
+      tooltipContentArgsCurrent: this.props.tooltipContentArgs
     })
   }
 
@@ -59,7 +62,8 @@ class TooltipPositioner extends React.Component<Props, State> {
     // if new args, reset offset state
     if(pp.tooltipContentArgs !== this.props.tooltipContentArgs){
       this.setState({
-        offset: null
+        offset: null,
+        tooltipContainerInitialDimensions: null
       })
     }
     else if(this.containerRef.current && !this.state.offset){
@@ -75,10 +79,11 @@ class TooltipPositioner extends React.Component<Props, State> {
 
     const {
       offset,
-      tooltipContainerInitialDimensions
+      tooltipContainerInitialDimensions,
+      tooltipContentArgsCurrent
     } = this.state
 
-    const containerStyle = offset?
+    const containerStyle = offset && (tooltipContentArgsCurrent===tooltipContentArgs)?
       {
         transform: `translate(${offset.x}px,${offset.y}px)`
       } :
@@ -87,7 +92,7 @@ class TooltipPositioner extends React.Component<Props, State> {
       }
 
     const tooltipContainerAttributes = {
-      offset,
+      offset: offset || {x:0, y:0},
       tooltipContainerInitialDimensions
     }
 

--- a/src/components/TooltipPositioner.tsx
+++ b/src/components/TooltipPositioner.tsx
@@ -9,7 +9,8 @@ class TooltipPositioner extends React.Component<Props> {
   private containerRef = React.createRef<HTMLDivElement>()
 
   state = {
-    offset: null
+    offset: null,
+    tooltipDimensions: null
   }
 
   // simple heuristics to check if the tooltip container exceeds the viewport
@@ -19,7 +20,8 @@ class TooltipPositioner extends React.Component<Props> {
       x: 0,
       y: 0
     }
-    const { right, left, top, bottom } = this.containerRef.current.getBoundingClientRect()
+    const tooltipContainerInitialDimensions = this.containerRef.current.getBoundingClientRect()
+    const { right, left, top, bottom } = tooltipContainerInitialDimensions
     const containerWidth = right - left
     const containerHeight = bottom - top
 
@@ -37,7 +39,8 @@ class TooltipPositioner extends React.Component<Props> {
     }
 
     this.setState({
-      offset
+      offset,
+      tooltipContainerInitialDimensions
     })
   }
 
@@ -66,7 +69,8 @@ class TooltipPositioner extends React.Component<Props> {
     } = this.props
 
     const {
-      offset
+      offset,
+      tooltipContainerInitialDimensions
     } = this.state
 
     const containerStyle = offset?
@@ -77,10 +81,15 @@ class TooltipPositioner extends React.Component<Props> {
         opacity: 0
       }
 
+    const tooltipContainerAttributes = {
+      offset,
+      tooltipContainerInitialDimensions
+    }
+
     return (
       <div ref={this.containerRef} style={containerStyle}>
         {tooltipContent({...tooltipContentArgs,
-          tooltipContainerOffset: offset? offset: {x:0, y:0}})}
+          tooltipContainerAttributes})}
       </div>
     )
   }


### PR DESCRIPTION
added tooltip container dimensions `tooltipContainerInitialDimensions` based on `getBoundingClientRect()` as another set of attributes to pass back to tooltipContent function. This allows users to further customize their tooltip positions. 

Wrap both `offset` and `tooltipContainerInitialDimensions` under key `tooltipContainerAttributes`.