### PR TITLE
added outbound tick lines option

### DIFF
--- a/src/components/XYFrame.tsx
+++ b/src/components/XYFrame.tsx
@@ -865,7 +865,8 @@ class XYFrame extends React.Component<XYFrameProps, XYFrameState> {
               baseMarkProps,
               className: axisClassname,
               jaggedBase: d.jaggedBase,
-              scale: axisScale
+              scale: axisScale,
+              showOutboundTickLines: d.showOutboundTickLines
             })}
             {d.baseline === "under" &&
               baselineGenerator(d.orient, adjustedSize, d.className)}

--- a/src/components/types/annotationTypes.tsx
+++ b/src/components/types/annotationTypes.tsx
@@ -149,6 +149,7 @@ export interface AxisProps {
   axisAnnotationFunction?: (args: any) => void
   xyPoints?: object[]
   marginalSummaryType?: AxisSummaryTypeSettings | OrdinalSummaryTypes
+  showOutboundTickLines?: boolean
 }
 
 export type AxisGeneratingFunction = (args: object) => AxisProps

--- a/src/components/visualizationLayerBehavior/axis.tsx
+++ b/src/components/visualizationLayerBehavior/axis.tsx
@@ -344,7 +344,6 @@ export const axisLines = ({
     })
   ) as React.ReactNode
 
-  //TODO: if attribute is true
   const outboundAxisLines = showOutboundTickLines?
     axisParts.map((axisPart, i) =>
       outboundTickLineGenerator({

--- a/src/components/visualizationLayerBehavior/axis.tsx
+++ b/src/components/visualizationLayerBehavior/axis.tsx
@@ -98,6 +98,33 @@ const defaultTickLineGenerator = ({
   )
 }
 
+const outboundTickLineGenerator = ({
+  xy,
+  orient,
+  i,
+  className = "",
+}) => {
+  const tickLength = 8
+  let genD = `M-4,${xy.y1}L${xy.x1},${xy.y2}`
+  if(orient==="left") { genD = `M${xy.x1-tickLength},${xy.y1}L${xy.x1},${xy.y2}` }
+  else if(orient==="right") { genD = `M${xy.x2},${xy.y1}L${xy.x2 + tickLength},${xy.y2}` }
+  else if(orient==="top") { genD = `M${xy.x1},${xy.y1 - tickLength}L${xy.x1},${xy.y1}` }
+  else if(orient==="bottom") { genD = `M${xy.x1},${xy.y2}L${xy.x1},${xy.y2 + tickLength}` }
+  return (
+    <Mark
+      key={i}
+      markType="path"
+      renderMode={xy.renderMode}
+      fill="none"
+      stroke="black"
+      strokeWidth="1px"
+      simpleInterpolate={true}
+      d={genD}
+      className={`outbound-tick-line tick ${orient} ${className}`}
+    />
+  )
+}
+
 export function generateTickValues(tickValues, ticks, scale) {
   const axisSize = Math.abs(scale.range()[1] - scale.range()[0])
 
@@ -293,7 +320,8 @@ export const axisLines = ({
   baseMarkProps,
   className,
   jaggedBase,
-  scale
+  scale,
+  showOutboundTickLines = false
 }: {
   axisParts: object[]
   orient: string
@@ -302,8 +330,9 @@ export const axisLines = ({
   className: string
   jaggedBase?: boolean
   scale: ScaleLinear<number, number>
+  showOutboundTickLines: boolean
 }) => {
-  return axisParts.map((axisPart, i) =>
+  const axisLines = axisParts.map((axisPart, i) =>
     tickLineGenerator({
       xy: axisPart,
       orient,
@@ -314,4 +343,21 @@ export const axisLines = ({
       scale
     })
   ) as React.ReactNode
+
+  //TODO: if attribute is true
+  const outboundAxisLines = showOutboundTickLines?
+    axisParts.map((axisPart, i) =>
+      outboundTickLineGenerator({
+        xy: axisPart,
+        orient,
+        i,
+        baseMarkProps,
+        className,
+        jaggedBase,
+        scale
+      })
+    ) as React.ReactNode
+    : []
+
+  return [...axisLines, outboundAxisLines]
 }

--- a/src/components/visualizationLayerBehavior/axis.tsx
+++ b/src/components/visualizationLayerBehavior/axis.tsx
@@ -330,7 +330,7 @@ export const axisLines = ({
   className: string
   jaggedBase?: boolean
   scale: ScaleLinear<number, number>
-  showOutboundTickLines: boolean
+  showOutboundTickLines?: boolean
 }) => {
   const axisLines = axisParts.map((axisPart, i) =>
     tickLineGenerator({

--- a/src/components/visualizationLayerBehavior/axis.tsx
+++ b/src/components/visualizationLayerBehavior/axis.tsx
@@ -102,7 +102,7 @@ const outboundTickLineGenerator = ({
   xy,
   orient,
   i,
-  className = "",
+  className = ""
 }) => {
   const tickLength = 8
   let genD = `M-4,${xy.y1}L${xy.x1},${xy.y2}`
@@ -350,10 +350,7 @@ export const axisLines = ({
         xy: axisPart,
         orient,
         i,
-        baseMarkProps,
-        className,
-        jaggedBase,
-        scale
+        className
       })
     ) as React.ReactNode
     : []


### PR DESCRIPTION
Adding options to show "outbound tick lines". 

![image](https://user-images.githubusercontent.com/6054688/67819764-cb452480-fa73-11e9-8c52-7e7955d7810e.png)

Note: I'm not sure if "outbound tick lines" is the best name to describe this, so let me know if there's a better term for this and I can make the changes (@emeeks)


