### PR TITLE
revamp TooltipPositioner for easier adoption

### DIFF
--- a/src/components/TooltipPositioner.tsx
+++ b/src/components/TooltipPositioner.tsx
@@ -5,58 +5,73 @@ type Props = {
   tooltipContentArgs?: object
 }
 
-class TooltipPositioner extends React.Component<Props> {
+type State = {
+  collision: object,
+  tooltipContainerInitialDimensions: object,
+  tooltipContentArgsCurrent: object
+}
+
+class TooltipPositioner extends React.Component<Props, State> {
   private containerRef = React.createRef<HTMLDivElement>()
 
   state = {
-    offset: null
+    collision:null,
+    tooltipContainerInitialDimensions: null,
+    tooltipContentArgsCurrent: null
   }
 
   // simple heuristics to check if the tooltip container exceeds the viewport
   // if so, capture the suggested offset
   checkPosition = () => {
-    let offset = {
-      x: 0,
-      y: 0
-    }
-    const { right, left, top, bottom } = this.containerRef.current.getBoundingClientRect()
-    const containerWidth = right - left
-    const containerHeight = bottom - top
 
-    if(right > window.innerWidth){
-      offset.x = - containerWidth
+    const tooltipContainerInitialDimensions = this.containerRef.current.getBoundingClientRect()
+
+    const { right, left, top, bottom, width, height, x, y } = tooltipContainerInitialDimensions
+
+    // flags to indicate whether the data point + tooltip dimension collides with the viewport
+    // on each of the 4 directions/sides
+    let collision = {
+      left: false,
+      right: false,
+      top: false,
+      bottom: false
     }
-    else if(left < 0){
-      offset.x = containerWidth
+
+    if( (x + width) > window.innerWidth){
+      collision.right = true
     }
-    if(bottom > window.innerHeight){
-      offset.y = - containerHeight
+    if( (x - width) < 0){
+      collision.left = true
     }
-    else if(top < 0){
-      offset.y = containerHeight
+    if( (y + height) > window.innerHeight){
+      collision.bottom = true
+    }
+    if( (y - height) < 0){
+      collision.top = true
     }
 
     this.setState({
-      offset
+      collision,
+      tooltipContainerInitialDimensions,
+      tooltipContentArgsCurrent: this.props.tooltipContentArgs
     })
   }
 
   componentDidMount(){
-    if(this.containerRef.current && !this.state.offset){
+    if(this.containerRef.current && !this.state.collision){
       this.checkPosition()
     }
   }
 
   componentDidUpdate(pp){
-    // if new args, reset offset state
-    const { tooltipContentArgs} = this.props
-    const { offset } = this.state
-    if(pp.tooltipContentArgs !== tooltipContentArgs){
+    // if new args, reset collision state
+    if(pp.tooltipContentArgs !== this.props.tooltipContentArgs){
       this.setState({
-        offset: null
+        collision: null,
+        tooltipContainerInitialDimensions: null
       })
     }
-    else if(this.containerRef.current && !offset){
+    else if(this.containerRef.current && !this.state.collision){
       this.checkPosition()
     }
   }
@@ -68,21 +83,41 @@ class TooltipPositioner extends React.Component<Props> {
     } = this.props
 
     const {
-      offset
+      collision,
+      tooltipContainerInitialDimensions,
+      tooltipContentArgsCurrent
     } = this.state
 
-    const containerStyle = offset?
-      {
-        transform: `translate(${offset.x}px,${offset.y}px)`
-      } :
-      {
-        opacity: 0
-      }
+    const containerStyle = {
+
+      //to handle issue when the tooltip content has margins set by client,
+      // which results in the tooltip container having smaller height,
+      // which in turn causes the css transform to be inaccurate
+      // (ref: https://www.w3.org/TR/css-box-3/#collapsing-margins)
+      overflow: 'hidden',
+
+      opacity: collision && (tooltipContentArgsCurrent===tooltipContentArgs)? 1 : 0
+    }
+
+    const tooltipContainerAttributes = {
+      tooltipContainerInitialDimensions,
+    }
+
+    const tooltipContainerClasses = collision ?
+    [
+      'tooltip-container',
+      'tooltip-collision-evaluated',
+      collision && collision.top && 'collision-top',
+      collision && collision.bottom && 'collision-bottom',
+      collision && collision.right && 'collision-right',
+      collision && collision.left && 'collision-left',
+    ].filter(el => el).join(' ')
+    : ['tooltip-container']
 
     return (
-      <div ref={this.containerRef} style={containerStyle}>
+      <div ref={this.containerRef} style={containerStyle} className={tooltipContainerClasses}>
         {tooltipContent({...tooltipContentArgs,
-          tooltipContainerOffset: offset? offset: {x:0, y:0}})}
+          tooltipContainerAttributes})}
       </div>
     )
   }


### PR DESCRIPTION
Originally this was supposed to be a migration of this [change](https://github.com/nteract/semiotic/pull/509/files), but decided to make more changes for easier adoption. Given this change, clients can control the tooltip positions using css if preferred. The attributes will still be passed to the tooltipContent function if client manipulation is still desired.

![tooltip](https://user-images.githubusercontent.com/6054688/79285112-676fb600-7e71-11ea-8f44-2fc920d69a52.gif)

Will update the doc with the corresponding "starter" CSS to achieve the behavior above, as well as applying the same changes to 1.0. 
 