### PR TITLE
[feature][legend] Make Legend Items Clickable + Update Docs

### DIFF
--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -25,7 +25,7 @@ function renderType(
 }
 
 class Legend extends React.Component<LegendProps, null> {
-  renderLegendGroup(legendGroup: LegendGroup) {
+  renderLegendGroupVertical(legendGroup: LegendGroup) {
     const { type = "fill", styleFn, items } = legendGroup
     const renderedItems = []
     let itemOffset = 0
@@ -64,7 +64,7 @@ class Legend extends React.Component<LegendProps, null> {
     return { items: renderedItems, offset: itemOffset }
   }
 
-  renderGroup({
+  renderVerticalGroup({
     legendGroups,
     width
   }: {
@@ -108,7 +108,7 @@ class Legend extends React.Component<LegendProps, null> {
           className="legend-item"
           transform={`translate(0,${offset})`}
         >
-          {this.renderLegendGroup(l)}
+          {this.renderLegendGroupVertical(l)}
         </g>
       )
       offset += l.items.length * 25 + 10
@@ -202,7 +202,7 @@ class Legend extends React.Component<LegendProps, null> {
     } = this.props
     const renderedGroups =
       orientation === "vertical"
-        ? this.renderGroup({
+        ? this.renderVerticalGroup({
             legendGroups,
             width
           })

--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -25,14 +25,26 @@ function renderType(
 }
 
 class Legend extends React.Component<LegendProps, null> {
-  renderLegendGroupVertical(legendGroup: LegendGroup) {
+  renderLegendGroupVertical(
+    legendGroup: LegendGroup,
+    customClickBehavior?: Function
+  ) {
     const { type = "fill", styleFn, items } = legendGroup
     const renderedItems = []
     let itemOffset = 0
     items.forEach((item, i) => {
       const renderedType = renderType(item, i, type, styleFn)
       renderedItems.push(
-        <g key={`legend-item-${i}`} transform={`translate(0,${itemOffset})`}>
+        <g
+          key={`legend-item-${i}`}
+          transform={`translate(0,${itemOffset})`}
+          onClick={
+            customClickBehavior ? () => customClickBehavior(item) : undefined
+          }
+          style={{
+            cursor: customClickBehavior ? "pointer" : "default"
+          }}
+        >
           {renderedType}
           <text y={15} x={30}>
             {item.label}
@@ -44,14 +56,26 @@ class Legend extends React.Component<LegendProps, null> {
     return renderedItems
   }
 
-  renderLegendGroupHorizontal(legendGroup: LegendGroup) {
+  renderLegendGroupHorizontal(
+    legendGroup: LegendGroup,
+    customClickBehavior?: Function
+  ) {
     const { type = "fill", styleFn, items } = legendGroup
     const renderedItems = []
     let itemOffset = 0
     items.forEach((item, i) => {
       const renderedType = renderType(item, i, type, styleFn)
       renderedItems.push(
-        <g key={`legend-item-${i}`} transform={`translate(${itemOffset},0)`}>
+        <g
+          key={`legend-item-${i}`}
+          transform={`translate(${itemOffset},0)`}
+          onClick={
+            customClickBehavior ? () => customClickBehavior(item) : undefined
+          }
+          style={{
+            cursor: customClickBehavior ? 'pointer' : 'default'
+          }}
+        >
           {renderedType}
           <text y={15} x={25}>
             {item.label}
@@ -66,10 +90,12 @@ class Legend extends React.Component<LegendProps, null> {
 
   renderVerticalGroup({
     legendGroups,
-    width
+    width,
+    customClickBehavior
   }: {
     legendGroups: LegendGroup[]
     width: number
+    customClickBehavior?: Function
   }) {
     let offset = 30
 
@@ -108,7 +134,7 @@ class Legend extends React.Component<LegendProps, null> {
           className="legend-item"
           transform={`translate(0,${offset})`}
         >
-          {this.renderLegendGroupVertical(l)}
+          {this.renderLegendGroupVertical(l, customClickBehavior)}
         </g>
       )
       offset += l.items.length * 25 + 10
@@ -120,11 +146,13 @@ class Legend extends React.Component<LegendProps, null> {
   renderHorizontalGroup({
     legendGroups,
     title,
-    height
+    height,
+    customClickBehavior
   }: {
     legendGroups: LegendGroup[]
     title: string | boolean
     height: number
+    customClickBehavior?: Function
   }) {
     let offset = 0
 
@@ -147,7 +175,10 @@ class Legend extends React.Component<LegendProps, null> {
         offset += 20
       }
 
-      const renderedItems = this.renderLegendGroupHorizontal(l)
+      const renderedItems = this.renderLegendGroupHorizontal(
+        l,
+        customClickBehavior
+      )
 
       renderedGroups.push(
         <g
@@ -195,6 +226,7 @@ class Legend extends React.Component<LegendProps, null> {
   render() {
     const {
       legendGroups,
+      customClickBehavior,
       title = "Legend",
       width = 100,
       height = 20,
@@ -204,12 +236,14 @@ class Legend extends React.Component<LegendProps, null> {
       orientation === "vertical"
         ? this.renderVerticalGroup({
             legendGroups,
-            width
+            width,
+            customClickBehavior
           })
         : this.renderHorizontalGroup({
             legendGroups,
             title,
-            height
+            height,
+            customClickBehavior
           })
 
     return (

--- a/src/components/types/legendTypes.tsx
+++ b/src/components/types/legendTypes.tsx
@@ -15,6 +15,7 @@ export interface LegendGroup {
 
 export interface LegendProps {
   legendGroups?: LegendGroup[]
+  customClickBehavior?: Function
   title?: string
   width?: number
   height?: number

--- a/src/docs/components/LegendDocs.js
+++ b/src/docs/components/LegendDocs.js
@@ -60,11 +60,19 @@ export default class LegendDocs extends React.Component {
               legendGroups={[...lineLegendGroups, ...areaLegendGroups]}
             />
           </g>
-          <g transform={"translate(50,250)"}>
+          <g transform={"translate(50,220)"}>
             <Legend
               title={"Horizontal Legend"}
               legendGroups={[...lineLegendGroups, ...areaLegendGroups]}
               orientation="horizontal"
+            />
+          </g>
+          <g transform={"translate(50,320)"}>
+            <Legend
+              title={"Clickable Legend"}
+              legendGroups={[...lineLegendGroups, ...areaLegendGroups]}
+              orientation="horizontal"
+              customClickBehavior={(d) => window.alert(JSON.stringify(d))}
             />
           </g>
         </svg>
@@ -109,6 +117,21 @@ const lineLegendGroups = [
       <Legend
         title={"Both Legend"}
         legendGroups={[...lineLegendGroups, ...areaLegendGroups]}
+      />
+    </g>
+    <g transform={"translate(50,220)"}>
+      <Legend
+        title={"Horizontal Legend"}
+        legendGroups={[...lineLegendGroups, ...areaLegendGroups]}
+        orientation="horizontal"
+      />
+    </g>
+    <g transform={"translate(50,320)"}>
+      <Legend
+        title={"Clickable Legend"}
+        legendGroups={[...lineLegendGroups, ...areaLegendGroups]}
+        orientation="horizontal"
+        customClickBehavior={(d) => window.alert(JSON.stringify(d))}
       />
     </g>
   </svg>


### PR DESCRIPTION
## Summary

- Solution for #535 by adding an optional `customClickBehavior` property to the Legend component API. 
- Renames some internal code to make it clear that either the code for horizontal OR vertical related code is called, but not both.

## Example

- GIF of click behavior working on the old docs page: https://a.cl.ly/o0um9KdA

## Discussion / Future Proposals

- `customClickBehavior` is a bit verbose, but I chose it to match the pattern used by the top level `Frame` and `InteractionLayer` APIs. I felt it made more sense to put this prop on the whole legend rather than providing a custom customClickBehavior for each legend group (as I originally commented in the linked issue), but can revise this if needed later. 
- A future refactor could make the shared behavior between the vertical/horizontal renderers a bit more explicit
- We may want to port these legend docs over to the `semiotic-docs` repo
- We may want to document the existence of the Legend property on components like the NetworkFrame, otherwise it's unlikely people will discover this component
