### PR TITLE
Dynamic tooltip react popper

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "react-dom": "^16.9.0"
   },
   "dependencies": {
+    "@popperjs/core": "^2.5.4",
     "d3-array": "^1.2.0",
     "d3-brush": "^2.1.0",
     "d3-chord": "^1.0.4",
@@ -178,6 +179,7 @@
     "object-assign": "4.1.1",
     "polygon-offset": "0.3.1",
     "react-annotation": "3.0.0-beta.4",
+    "react-popper": "^2.2.3",
     "regression": "^2.0.1",
     "semiotic-mark": "0.5.0",
     "svg-path-bounding-box": "1.0.4"


### PR DESCRIPTION
I've evaluated Popper.js and React-Popper ([docs](https://popper.js.org/docs/v2/tutorial/)), and they seem to be a solid library to use to support dynamic tooltips. It supports optimized arrow placement too. In the future we can open up a few of their settings if make sense. 

This will be a breaking change to the previous version that I implemented from scratch. Let me know if we need to be backward compatible. 

![tooltip](https://user-images.githubusercontent.com/6054688/98057489-45cb2180-1df7-11eb-801b-1cd74ff19b4b.gif)



Here is the suggested CSS (very similar to their tutorials, with a few tweaks and comments to support borders):

```
/* 
The CSS mostly follows the popper.js docs: https://popper.js.org/docs/v2/tutorial/ , 
but with a few modifications to support borders.
If borders are used, don't define any padding otherwise the arrow's diamond will be visible. 
Use your tooltip content container to control the padding instead. 
*/
.tooltip {
  border: 1px solid black;
  border-radius: 4px;
  box-sizing: border-box;
}

/* The class of your tooltip content (you need to add it to the HTML element yourself). */
.tooltip-content {
  width: 150px;
  height: 200px;
  background: lightgrey;
  box-sizing: border-box;
  padding: 8px;
  border-radius: 4px;
}

.tooltip-arrow, .tooltip-arrow::before {
  position: absolute;
  width: 16px; /*set the dimensions of the arrow div*/
  height: 16px; /*set the dimensions of the arrow div*/
  z-index: -1;
  box-sizing: border-box;
}

.tooltip-arrow::before {
  content: '';
  transform: rotate(45deg);
  background: lightgrey; /* This should match with the tooltip content */
  border: 1px solid black;
}

.tooltip[data-popper-placement^='top'] > .tooltip-arrow {
  bottom: -8px; /*half the length of the arrow div*/
}

.tooltip[data-popper-placement^='bottom'] > .tooltip-arrow {
  top: -8px;
}

.tooltip[data-popper-placement^='left'] > .tooltip-arrow {
  right: -8px;
}

#tooltip[data-popper-placement^='right'] > .tooltip-arrow {
  left: -8px;
}
```

(cc @emeeks , @MichielDeMey)