### PR TITLE
Eliminate infinite requestAnimationFrame cycle in VisualizationLayer

### DIFF
--- a/src/components/VisualizationLayer.tsx
+++ b/src/components/VisualizationLayer.tsx
@@ -94,8 +94,8 @@ const renderQueue = function (func) {
     function doFrame() {
       if (!valid) return true
       let chunk = _queue.splice(0, _rate)
-      chunk.map(func)
-      timer_frame(doFrame)
+      chunk.forEach(func)
+      if (_queue.length > 0) timer_frame(doFrame)
     }
 
     doFrame()


### PR DESCRIPTION
Whenever `VisualizationLayer` is used, it spawns `renderQueue` which handles non-blocking canvas rendering by slicing the data collection into chunks and feeding them to a rendering function. The way how `renderQueue` is designed right now, the rendering cycle can be aborted via `invalidate()` method, which is used in `componentDidMount` in order to stop existing rendering if new data have been received. However, if no update happened and `renderQueue` went through all the datapoints, there is no termination condition for `requestAnimationFrame()` calls. Thus, whenever `VisualizationLayer` is used, the web page will be spawning infinite `rAF` cycles on each data update which quickly start throttling the rest of the things in main thread just by the number of calls.

This PR adds termination condition to avoid the case where an infinite cycle can be created. Alternative solution would be to properly use `invalidate()` method when the rendering is done, but it would require some additional places to be updated and tested. I also used `forEach` for data chunk rendering calls to avoid unnecessary memory allocation caused by `Array::map()`.