### PR TITLE
Fix react-annotation imports to avoid bundling its dependencies

### DIFF
--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import AnnotationLabel from "react-annotation/lib/Types/AnnotationLabel"
+import { AnnotationLabel } from "react-annotation"
 
 import { AnnotationProps } from "./types/annotationTypes"
 import { GenericObject } from "./types/generalTypes"

--- a/src/components/annotationRules/baseRules.tsx
+++ b/src/components/annotationRules/baseRules.tsx
@@ -1,7 +1,9 @@
 import * as React from "react"
-import AnnotationCalloutCircle from "react-annotation/lib/Types/AnnotationCalloutCircle"
-import AnnotationCalloutRect from "react-annotation/lib/Types/AnnotationCalloutRect"
-import AnnotationCalloutCustom from "react-annotation/lib/Types/AnnotationCalloutCustom"
+import {
+  AnnotationCalloutCircle,
+  AnnotationCalloutRect,
+  AnnotationCalloutCustom
+} from "react-annotation"
 
 import Annotation from "../Annotation"
 import { polygonHull } from "d3-polygon"

--- a/src/components/annotationRules/networkframeRules.tsx
+++ b/src/components/annotationRules/networkframeRules.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import Annotation from "../Annotation"
-import AnnotationCalloutCircle from "react-annotation/lib/Types/AnnotationCalloutCircle"
+import { AnnotationCalloutCircle } from "react-annotation"
 
 import { packEnclose } from "d3-hierarchy"
 import { circleEnclosure, rectangleEnclosure, hullEnclosure } from "./baseRules"

--- a/src/components/annotationRules/orframeRules.tsx
+++ b/src/components/annotationRules/orframeRules.tsx
@@ -2,9 +2,11 @@ import * as React from "react"
 import { Mark } from "semiotic-mark"
 import Annotation from "../Annotation"
 
-import AnnotationCalloutCircle from "react-annotation/lib/Types/AnnotationCalloutCircle"
-import AnnotationBracket from "react-annotation/lib/Types/AnnotationBracket"
-import AnnotationXYThreshold from "react-annotation/lib/Types/AnnotationXYThreshold"
+import {
+  AnnotationCalloutCircle,
+  AnnotationBracket,
+  AnnotationXYThreshold
+} from "react-annotation"
 
 import { packEnclose } from "d3-hierarchy"
 import { max, min, sum, extent } from "d3-array"

--- a/src/components/annotationRules/xyframeRules.tsx
+++ b/src/components/annotationRules/xyframeRules.tsx
@@ -1,8 +1,7 @@
 import * as React from "react"
 import { Mark } from "semiotic-mark"
 import Annotation from "../Annotation"
-import AnnotationCalloutRect from "react-annotation/lib/Types/AnnotationCalloutRect"
-import AnnotationXYThreshold from "react-annotation/lib/Types/AnnotationXYThreshold"
+import { AnnotationCalloutRect, AnnotationXYThreshold } from "react-annotation"
 
 import { line, area } from "d3-shape"
 import { packEnclose } from "d3-hierarchy"

--- a/src/components/processing/network.ts
+++ b/src/components/processing/network.ts
@@ -12,7 +12,7 @@ import { scaleLinear } from "d3-scale"
 
 import { min, max } from "d3-array"
 
-import AnnotationLabel from "react-annotation/lib/Types/AnnotationLabel"
+import { AnnotationLabel } from "react-annotation"
 
 import {
   calculateMargin,

--- a/src/components/processing/xyDrawing.tsx
+++ b/src/components/processing/xyDrawing.tsx
@@ -18,7 +18,7 @@ import {
   stringToArrayFn
 } from "../data/dataFunctions"
 
-import AnnotationCallout from "react-annotation/lib/Types/AnnotationCallout"
+import { AnnotationCallout } from "react-annotation"
 
 import {
   createPoints,


### PR DESCRIPTION
After I published `semiotic@2.0.0-rc.17` and went to test it out, I spotted a weird bug right away during a build: for some reason Semiotic attempted to use default import from `d3-shape` which doesn't have one. That was very weird since looking at Semiotic code you can't find a single import of `d3-shape` that uses default import. So I started digging into `2.0.0-rc.17` bundle to seek the truth. I've looking at the code that uses the default import and tried to match it with the code in `src/components` which gave me nothing. My next step was to do a global search in whole Semiotic repo and this is where I found following thing: the default import is being used by `viz-annotation` which is a direct dependency of `react-annotation` and is using different (older) version of `d3-shape` that _does_ have a default export. Which should be okay, but got me thinking why do we see this code as a part of Semiotic bundle? We started using `auto-external` rollup plugin to avoid bundling Semiotic dependencies and this thing still slipped through. Apparently, the reason for this was a couple of components that were doing direct imports from within `react-annotation` modules. Rollup just bundled those as they didn't appear in the external dependencies list.

In this PR I'm fixing the imports to avoid bundling `viz-annotation`. I made a build and tested it directly, to ensure the fix is working. Seems like we can make Semiotic package even smaller :D 

Moving forward, we'll need to look into some defense line for such cases. It may make sense to check if `auto-external` plugin has necessary option to warn us about such imports.

Another todo item is to upgrade direct and transitive dependencies wherever possible.
