### PR TITLE
Update docs build script for local dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
     "lint:fix": "eslint src --fix",
     "create-release-branch": "sh ./scripts/create-release-branch.sh",
     "publish-release": "sh ./scripts/publish-release.sh",
-    "docs:dev-badcss": "parcel serve --target docs",
-    "docs:dev-error": "parcel build --target docs",
-    "gh-pages": "PUBLIC_URL=semiotic npm run build -- --public-url semiotic",
+    "docs:localdev": "cd docs && yarn install && yarn build && serve -s build",
     "typescript": "tsc --noEmit",
     "dist": "rollup --config rollup.config.js",
     "prepublishOnly": "npm run typescript && npm run dist"


### PR DESCRIPTION
This PR provides a script to build the semiotic documentation for local development.

From Vercel's GUI, I also tweaked settings so that the Preview should work now. (Users will still see 1.x deploy from the semiotic-docs repo).

I'm going to merge so that I can work on doc fixes and new content.

Note: The docs `package.json` is still at 2.0.0rc0. We can address in a future PR.