### PR TITLE
Correct incorrect image filename for Axis under All Frames in docs

### DIFF
--- a/docs/src/App.js
+++ b/docs/src/App.js
@@ -160,7 +160,7 @@ export const PAGES = [
         name: "Axis",
         url: "axis",
         component: AxisSettings,
-        img: "axis"
+        img: "axis-settings"
       },
       {
         name: "Annotations",


### PR DESCRIPTION
This PR fixes:

<img width="608" alt="Screen Shot 2021-12-22 at 5 47 " src="https://user-images.githubusercontent.com/2680980/147103074-83734c74-c958-4a04-8a06-ed9142329330.png">

Click the green preview link in the Vercel bot message below to see the corrected view.