### PR TITLE
Export existing typescript type definitions

### DIFF
--- a/src/components/ResponsiveFrame.tsx
+++ b/src/components/ResponsiveFrame.tsx
@@ -29,6 +29,7 @@ function useElementSize(ref) {
     if (element != null) {
       let rect = element.getBoundingClientRect()
       setSize([rect.width, rect.height])
+      // @ts-ignore
       let observer = new ResizeObserver((entries) => {
         if (entries.length > 0) {
           let rect = entries[0].contentRect

--- a/src/components/semiotic.ts
+++ b/src/components/semiotic.ts
@@ -59,3 +59,90 @@ export {
   heatmapping,
   nodesEdgesFromHierarchy
 }
+
+export {
+  NodeType,
+  EdgeType,
+  GraphSettingsType,
+  NetworkSettingsType,
+  NetworkFrameState,
+  NetworkFrameProps
+} from "./types/networkTypes"
+
+export {
+  AnnotationType,
+  CustomHoverType,
+  AnnotationTypes,
+  AnnotationHandling,
+  AnnotationProps,
+  AxisProps,
+  AxisGeneratingFunction
+} from "./types/annotationTypes"
+
+export { ContextType } from "./types/canvasTypes"
+
+export {
+  GenericObject,
+  MarginType,
+  ProjectionTypes,
+  ExtentType,
+  ProjectedPoint,
+  PieceLayoutType,
+  ProjectedLine,
+  ProjectedSummary,
+  RoughType,
+  CanvasPostProcessTypes,
+  ExtentSettingsType,
+  accessorType,
+  AccessorFnType,
+  BasicLineTypes,
+  LineTypeSettings,
+  BasicSummaryTypes,
+  SummaryTypeSettings,
+  RawLine,
+  RawSummary,
+  RawPoint,
+  CustomAreaMarkProps,
+  ProjectedBin,
+  GenericAccessor,
+  VizLayerTypes,
+  RenderPipelineType,
+  OrdinalSummaryTypes,
+  OrdinalSummaryTypeSettings,
+  AxisSummaryTypeSettings,
+  GeneralFrameProps,
+  GeneralFrameState
+} from "./types/generalTypes"
+
+export {
+  AdvancedInteractionSettings,
+  Interactivity,
+  InteractionLayerProps,
+  VoronoiEntryType,
+  BaseColumnType,
+  InteractionLayerState
+} from "./types/interactionTypes"
+
+export {
+  SupportedLegendGlyphs,
+  ItemType,
+  LegendItem,
+  LegendGroup,
+  LegendProps
+} from "./types/legendTypes"
+
+export {
+  OExtentObject,
+  PieceTypes,
+  PieceTypeSettings,
+  ProjectedOrdinalSummary,
+  OrdinalFrameProps,
+  OrdinalFrameState
+} from "./types/ordinalTypes"
+
+export {
+  XYFrameProps,
+  AnnotatedSettingsProps,
+  XYFrameState,
+  SummaryLayoutType
+} from "./types/xyTypes"


### PR DESCRIPTION
As I published `rc18` and started testing it, I realized that with an updated structure and lack of access to internal files structure it is impossible to import TypeScript types (e.g. `MarginType`, `ProjectedBin`, etc) which may have negative impact on TS experience. While existing types and access to them was never documented, it is worth considering what experience we would like to provide: what kind of types need to be exported and made use of, what contracts developers are using for common tasks, etc.

In this PR I'm making all previously available types exported from the package, so we can continue testing new RCs in TypeScript environment. I'll be publishing `rc19` with these updates (and including the rest of recent updated in `main`). The exports do not affect the the library size, only `.d.ts` files.
