### PR TITLE
Add labelFormatter for oLabel

### DIFF
--- a/src/components/processing/ordinal.tsx
+++ b/src/components/processing/ordinal.tsx
@@ -22,7 +22,6 @@ import {
   pointLayout,
   swarmLayout,
   timelineLayout
-
 } from "../svg/pieceLayouts"
 
 import { stringToFn, stringToArrayFn } from "../data/dataFunctions"
@@ -32,7 +31,8 @@ import {
   OrdinalFrameState,
   PieceTypeSettings,
   OExtentObject,
-  ProjectedOrdinalSummary
+  ProjectedOrdinalSummary,
+  LabelSettingsType
 } from "../types/ordinalTypes"
 
 import { AxisProps } from "../types/annotationTypes"
@@ -671,7 +671,7 @@ export const calculateOrdinalFrame = (
 
   const pieArcs = []
 
-  const labelSettings =
+  const labelSettings: LabelSettingsType =
     typeof oLabel === "object"
       ? Object.assign({ label: true, padding: 5 }, oLabel)
       : { orient: "default", label: oLabel, padding: 5 }
@@ -817,8 +817,12 @@ export const calculateOrdinalFrame = (
         }
       }
 
+      const labelValue = labelSettings.labelFormatter
+        ? labelSettings.labelFormatter(d)
+        : d
+
       const label = labelingFn(
-        d,
+        labelValue,
         projectedColumns[d].pieceData.map((d) => d.data),
         i,
         projectedColumns[d]

--- a/src/components/types/ordinalTypes.ts
+++ b/src/components/types/ordinalTypes.ts
@@ -116,3 +116,10 @@ export interface OrdinalFrameState extends GeneralFrameState {
   summaryType: object
   props: OrdinalFrameProps
 }
+
+export interface LabelSettingsType {
+  orient?: string
+  padding?: number
+  label?: any
+  labelFormatter?: Function
+}

--- a/src/docs/components/DonutChartRaw.js
+++ b/src/docs/components/DonutChartRaw.js
@@ -9,7 +9,7 @@ const data3 = [
   { x: 1, y: 115698 }
 ]
 
-export default state => {
+export default (state) => {
   const donutSettings = {
     size: [600, 400],
     data: state.changeData ? data2 : data,
@@ -20,8 +20,21 @@ export default state => {
       strokeWidth: 1
     }),
     type: { type: "bar", innerRadius: +state.innerRadius },
-    oLabel: true,
-    margin: { left: 20, top: 20, bottom: 20, right: 20 },
+    oLabel: {
+      orient: "stem",
+      labelFormatter: (d) => (
+        <>
+          <tspan>Hey</tspan>
+          <tspan x="0" y="16">
+            Hey
+          </tspan>
+          <tspan x="0" y="32">
+            {d}
+          </tspan>
+        </>
+      )
+    },
+    margin: { left: 100, top: 100, bottom: 100, right: 100 },
     tooltipContent: "pie",
     hoverAnnotation: true
   }
@@ -33,7 +46,7 @@ export default state => {
   if (state.kind !== "pie") {
     donutSettings.axes = {
       orient: "left",
-      tickFormat: d => +(d * 10) / 10,
+      tickFormat: (d) => +(d * 10) / 10,
       label: { name: "Radial Label", locationDistance: 15 }
     }
   } else {


### PR DESCRIPTION
Adds a `labelFormatter` option to the `oLabel` settings that allows you to adjust the actual displayed SVG elements (so that you could add ellipsis or split and stack them or do whatever else you want). It will be sent the column name and should return a string or `tspan` elements (since they will be placed within a positioned `text` element).