### PR TITLE
Fix oSort on Dynamic Width bug

### DIFF
--- a/src/components/processing/ordinal.tsx
+++ b/src/components/processing/ordinal.tsx
@@ -311,40 +311,6 @@ export const calculateOrdinalFrame = (
 
   let maxColumnValues
 
-  if (dynamicColumnWidth) {
-    let columnValueCreator
-    if (typeof dynamicColumnWidth === "string") {
-      columnValueCreator = (d) => sum(d.map((p) => p.data[dynamicColumnWidth]))
-    } else {
-      columnValueCreator = (d) => dynamicColumnWidth(d.map((p) => p.data))
-    }
-    const thresholdDomain = [0]
-    maxColumnValues = 0
-    const columnValues = []
-
-    oExtent.forEach((d) => {
-      const oValues = allData.filter((p: { column: string }) => p.column === d)
-      const columnValue = columnValueCreator(oValues)
-
-      columnValues.push(columnValue)
-      maxColumnValues += columnValue
-    })
-
-    cwHash.total = 0
-    oExtent.forEach((d, i) => {
-      const oValue = columnValues[i]
-      const stepValue = (oValue / maxColumnValues) * (oDomain[1] - oDomain[0])
-      cwHash[d] = stepValue
-      cwHash.total += stepValue
-      if (i !== oExtent.length - 1) {
-        thresholdDomain.push(stepValue + thresholdDomain[i])
-      }
-    })
-    oScale.range(thresholdDomain)
-  } else {
-    oScale.range(oDomain)
-  }
-
   const rExtentSettings =
     baseRExtent === undefined || Array.isArray(baseRExtent)
       ? { extent: baseRExtent, onChange: undefined, includeAnnotations: false }
@@ -488,6 +454,40 @@ export const calculateOrdinalFrame = (
     )
 
     oScale.domain(oExtent)
+  }
+
+  if (dynamicColumnWidth) {
+    let columnValueCreator
+    if (typeof dynamicColumnWidth === "string") {
+      columnValueCreator = (d) => sum(d.map((p) => p.data[dynamicColumnWidth]))
+    } else {
+      columnValueCreator = (d) => dynamicColumnWidth(d.map((p) => p.data))
+    }
+    const thresholdDomain = [0]
+    const columnValues = []
+    maxColumnValues = 0
+
+    oExtent.forEach((d) => {
+      const oValues = allData.filter((p: { column: string }) => p.column === d)
+      const columnValue = columnValueCreator(oValues)
+
+      columnValues.push(columnValue)
+      maxColumnValues += columnValue
+    })
+
+    cwHash.total = 0
+    oExtent.forEach((d, i) => {
+      const oValue = columnValues[i]
+      const stepValue = (oValue / maxColumnValues) * (oDomain[1] - oDomain[0])
+      cwHash[d] = stepValue
+      cwHash.total += stepValue
+      if (i !== oExtent.length - 1) {
+        thresholdDomain.push(stepValue + thresholdDomain[i])
+      }
+    })
+    oScale.range(thresholdDomain)
+  } else {
+    oScale.range(oDomain)
   }
 
   const rDomain = (projection === "vertical" && [0, adjustedSize[1]]) || [

--- a/src/components/svg/areaDrawing.tsx
+++ b/src/components/svg/areaDrawing.tsx
@@ -395,7 +395,6 @@ export function heatmapping({
   ]
   let maxValue = -Infinity
 
-  console.log("summaryType", summaryType)
   data.forEach((heatmapData) => {
     const grid = []
     const flatGrid = []

--- a/src/docs/components/MarimekkoRaw.js
+++ b/src/docs/components/MarimekkoRaw.js
@@ -65,31 +65,36 @@ const mekkoChart = {
   oAccessor: "market",
   projection: "vertical",
   dynamicColumnWidth: "value",
-  style: d => ({
+  style: (d) => ({
     fill: colors[d.segment],
     stroke: "black",
     strokeWidth: 1
   }),
+  oSort: (d, i, a, b) => {
+    return -a[0].pct
+  },
   canvasPieces: true,
-  renderMode: d =>
+  /*  renderMode: d =>
     d.market === "Birmingham, AL"
       ? { renderMode: "sketchy", fillWeight: 3, bowing: 5 }
-      : { renderMode: "sketchy", fillWeight: 2 },
+      : { renderMode: "sketchy", fillWeight: 2 }, */
   type: "bar",
   axes: [
-    { orient: "left", tickFormat: d => d },
-    { orient: "bottom", tickFormat: d => `${d / 1000}k` }
+    { orient: "left", tickFormat: (d) => d },
+    { orient: "bottom", tickFormat: (d) => `${d / 1000}k` }
   ],
   rExtent: { includeAnnotations: true },
-  annotations: [{
-    type: "r",
-    value: 8500,
-    label: "An R threshold"
-  }],
+  annotations: [
+    {
+      type: "r",
+      value: 8500,
+      label: "An R threshold"
+    }
+  ],
   margin: { left: 55, top: 50, bottom: 80, right: 50 },
   oLabel: {
     orient: "top",
-    label: d => <text transform="rotate(-45)">{d}</text>
+    label: (d) => <text transform="rotate(-45)">{d}</text>
   },
   sketchyRenderingEngine: roughjs
 }


### PR DESCRIPTION
This fixes #599 where if you set `oSort` and have `dynamicColumnWidth` it does not sort the items properly. All the fix does is move the column range calculation after the sorting occurs (because sorting changes the way the dynamic column widths are calculated).