### PR TITLE
Convert XYFrame from class to function component

### DIFF
--- a/src/components/XYFrame.tsx
+++ b/src/components/XYFrame.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { useMemo } from "react"
 
 import { scaleLinear } from "d3-scale"
 
@@ -64,6 +65,8 @@ import { AnnotationType } from "./types/annotationTypes"
 import { XYFrameProps, XYFrameState } from "./types/xyTypes"
 
 import { AnnotationLayerProps } from "./AnnotationLayer"
+import { useDerivedStateFromProps } from "./useDerivedStateFromProps"
+import { useLegacyUnmountCallback } from "./useLegacyUnmountCallback"
 
 let xyframeKey = ""
 const chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -81,160 +84,268 @@ const projectedCoordinateNames = {
   xBottom: projectedXBottom
 }
 
-class XYFrame extends React.Component<XYFrameProps, XYFrameState> {
-  static defaultProps = {
-    annotations: [],
-    foregroundGraphics: undefined,
+const defaultProps = {
+  annotations: [],
+  foregroundGraphics: undefined,
+  size: [500, 500],
+  className: "",
+  lineType: "line",
+  name: "xyframe",
+  dataVersion: undefined
+}
+
+export default React.memo(function XYFrame_(allProps: XYFrameProps) {
+  const props = { ...defaultProps, ...allProps }
+  const baseState = {
+    SpanOrDiv: HOCSpanOrDiv(props.useSpans),
     size: [500, 500],
-    className: "",
-    lineType: "line",
-    name: "xyframe",
-    dataVersion: undefined
+    dataVersion: undefined,
+    lineData: undefined,
+    pointData: undefined,
+    summaryData: undefined,
+    projectedLines: undefined,
+    projectedPoints: undefined,
+    projectedSummaries: undefined,
+    fullDataset: [],
+    adjustedPosition: [0, 0],
+    adjustedSize: [500, 500],
+    backgroundGraphics: null,
+    foregroundGraphics: null,
+    axesData: undefined,
+    axes: undefined,
+    axesTickLines: undefined,
+    renderNumber: 0,
+    margin: { top: 0, bottom: 0, left: 0, right: 0 },
+    calculatedXExtent: [0, 0],
+    calculatedYExtent: [0, 0],
+    xAccessor: [(d: { x: number }) => d.x],
+    yAccessor: [(d: { y: number }) => d.y],
+    xExtent: [0, 0],
+    yExtent: [0, 0],
+    areaAnnotations: [],
+    xScale: scaleLinear(),
+    yScale: scaleLinear(),
+    title: null,
+    legendSettings: undefined,
+    xyFrameRender: {},
+    canvasDrawing: [],
+    annotatedSettings: {
+      xAccessor: undefined,
+      yAccessor: undefined,
+      summaryDataAccessor: undefined,
+      lineDataAccessor: undefined,
+      renderKeyFn: undefined,
+      lineType: undefined,
+      summaryType: undefined,
+      lineIDAccessor: undefined,
+      summaries: undefined,
+      lines: undefined,
+      title: undefined,
+      xExtent: undefined,
+      yExtent: undefined
+    },
+    overlay: undefined,
+    props
   }
 
-  static displayName: string = "XYFrame"
+  const initialState = useMemo(
+    () => ({
+      ...baseState,
+      ...calculateXYFrame(props, baseState, true)
+    }),
+    []
+  )
+  const state = useDerivedStateFromProps(
+    deriveXYFrameState,
+    props,
+    initialState
+  )
 
-  constructor(props: XYFrameProps) {
-    super(props)
+  const {
+    size,
+    className,
+    annotationSettings,
+    annotations,
+    additionalDefs,
+    hoverAnnotation,
+    interaction,
+    customClickBehavior,
+    customHoverBehavior,
+    customDoubleClickBehavior,
+    canvasPostProcess,
+    baseMarkProps,
+    useSpans,
+    canvasSummaries,
+    canvasPoints,
+    canvasLines,
+    afterElements,
+    beforeElements,
+    renderOrder,
+    matte,
+    frameKey,
+    showLinePoints,
+    sketchyRenderingEngine,
+    disableContext,
+    frameRenderOrder,
+    disableCanvasInteraction,
+    interactionSettings,
+    disableProgressiveRendering
+  } = props
 
-    const baseState = {
-      SpanOrDiv: HOCSpanOrDiv(props.useSpans),
-      size: [500, 500],
-      dataVersion: undefined,
-      lineData: undefined,
-      pointData: undefined,
-      summaryData: undefined,
-      projectedLines: undefined,
-      projectedPoints: undefined,
-      projectedSummaries: undefined,
-      fullDataset: [],
-      adjustedPosition: [0, 0],
-      adjustedSize: [500, 500],
-      backgroundGraphics: null,
-      foregroundGraphics: null,
-      axesData: undefined,
-      axes: undefined,
-      axesTickLines: undefined,
-      renderNumber: 0,
-      margin: { top: 0, bottom: 0, left: 0, right: 0 },
-      calculatedXExtent: [0, 0],
-      calculatedYExtent: [0, 0],
-      xAccessor: [(d: { x: number }) => d.x],
-      yAccessor: [(d: { y: number }) => d.y],
-      xExtent: [0, 0],
-      yExtent: [0, 0],
-      areaAnnotations: [],
-      xScale: scaleLinear(),
-      yScale: scaleLinear(),
-      title: null,
-      legendSettings: undefined,
-      xyFrameRender: {},
-      canvasDrawing: [],
-      annotatedSettings: {
-        xAccessor: undefined,
-        yAccessor: undefined,
-        summaryDataAccessor: undefined,
-        lineDataAccessor: undefined,
-        renderKeyFn: undefined,
-        lineType: undefined,
-        summaryType: undefined,
-        lineIDAccessor: undefined,
-        summaries: undefined,
-        lines: undefined,
-        title: undefined,
-        xExtent: undefined,
-        yExtent: undefined
-      },
-      overlay: undefined,
-      props
-    }
+  const {
+    backgroundGraphics,
+    foregroundGraphics,
+    adjustedPosition,
+    adjustedSize,
+    margin,
+    axes,
+    axesTickLines,
+    xScale,
+    yScale,
+    fullDataset,
+    dataVersion,
+    areaAnnotations,
+    legendSettings,
+    xyFrameRender,
+    annotatedSettings,
+    overlay
+  } = state
 
-    this.state = { ...baseState, ...calculateXYFrame(props, baseState, true) }
-  }
+  useLegacyUnmountCallback(props, state)
 
-  componentWillUnmount() {
-    const { onUnmount } = this.props
-    if (onUnmount) {
-      onUnmount(this.props, this.state)
-    }
-  }
+  return (
+    <Frame
+      name="xyframe"
+      renderPipeline={xyFrameRender}
+      adjustedPosition={adjustedPosition}
+      size={size}
+      projectedCoordinateNames={projectedCoordinateNames}
+      xScale={xScale}
+      yScale={yScale}
+      axes={axes}
+      axesTickLines={axesTickLines}
+      title={annotatedSettings.title}
+      dataVersion={dataVersion}
+      matte={matte}
+      className={className}
+      adjustedSize={adjustedSize}
+      frameKey={frameKey || xyframeKey}
+      additionalDefs={additionalDefs}
+      hoverAnnotation={hoverAnnotation}
+      defaultSVGRule={(args) => defaultXYSVGRule(props, state, args)}
+      defaultHTMLRule={(args) => defaultXYHTMLRule(props, state, args)}
+      annotations={
+        areaAnnotations.length > 0
+          ? [...annotations, ...areaAnnotations]
+          : annotations
+      }
+      annotationSettings={annotationSettings}
+      legendSettings={legendSettings}
+      projectedYMiddle={projectedYMiddle}
+      interaction={interaction}
+      customClickBehavior={customClickBehavior}
+      customHoverBehavior={customHoverBehavior}
+      customDoubleClickBehavior={customDoubleClickBehavior}
+      points={fullDataset}
+      showLinePoints={
+        typeof showLinePoints === "string" ? showLinePoints : undefined
+      }
+      margin={margin}
+      backgroundGraphics={backgroundGraphics}
+      foregroundGraphics={foregroundGraphics}
+      beforeElements={beforeElements}
+      afterElements={afterElements}
+      disableContext={disableContext}
+      canvasPostProcess={canvasPostProcess}
+      baseMarkProps={baseMarkProps}
+      useSpans={useSpans}
+      canvasRendering={!!(canvasSummaries || canvasPoints || canvasLines)}
+      renderOrder={renderOrder}
+      overlay={overlay}
+      sketchyRenderingEngine={sketchyRenderingEngine}
+      frameRenderOrder={frameRenderOrder}
+      disableCanvasInteraction={disableCanvasInteraction}
+      interactionSettings={interactionSettings}
+      disableProgressiveRendering={disableProgressiveRendering}
+    />
+  )
+})
 
-  static getDerivedStateFromProps(
-    nextProps: XYFrameProps,
-    prevState: XYFrameState
+function deriveXYFrameState(nextProps: XYFrameProps, prevState: XYFrameState) {
+  const { props } = prevState
+  const {
+    xExtent: oldXExtent = [],
+    yExtent: oldYExtent = [],
+    size: oldSize,
+    dataVersion: oldDataVersion,
+    lineData,
+    summaryData,
+    pointData
+  } = prevState
+  const {
+    xExtent: baseNewXExtent,
+    yExtent: baseNewYExtent,
+    size: newSize,
+    dataVersion: newDataVersion,
+    lines: newLines,
+    summaries: newSummaries,
+    points: newPoints
+  } = nextProps
+
+  const newXExtent: number[] = extentValue(baseNewXExtent)
+
+  const newYExtent: number[] = extentValue(baseNewYExtent)
+
+  const extentChange =
+    (oldXExtent[0] !== newXExtent[0] && newXExtent[0] !== undefined) ||
+    (oldYExtent[0] !== newYExtent[0] && newYExtent[0] !== undefined) ||
+    (oldXExtent[1] !== newXExtent[1] && newXExtent[1] !== undefined) ||
+    (oldYExtent[1] !== newYExtent[1] && newYExtent[1] !== undefined)
+
+  const lineChange = basicDataChangeCheck(lineData, newLines)
+
+  const summaryChange = basicDataChangeCheck(summaryData, newSummaries)
+
+  const pointChange = basicDataChangeCheck(pointData, newPoints)
+
+  if (
+    (oldDataVersion && oldDataVersion !== newDataVersion) ||
+    !prevState.fullDataset
   ) {
-    const { props } = prevState
-    const {
-      xExtent: oldXExtent = [],
-      yExtent: oldYExtent = [],
-      size: oldSize,
-      dataVersion: oldDataVersion,
-      lineData,
-      summaryData,
-      pointData
-    } = prevState
-    const {
-      xExtent: baseNewXExtent,
-      yExtent: baseNewYExtent,
-      size: newSize,
-      dataVersion: newDataVersion,
-      lines: newLines,
-      summaries: newSummaries,
-      points: newPoints
-    } = nextProps
-
-    const newXExtent: number[] = extentValue(baseNewXExtent)
-
-    const newYExtent: number[] = extentValue(baseNewYExtent)
-
-    const extentChange =
-      (oldXExtent[0] !== newXExtent[0] && newXExtent[0] !== undefined) ||
-      (oldYExtent[0] !== newYExtent[0] && newYExtent[0] !== undefined) ||
-      (oldXExtent[1] !== newXExtent[1] && newXExtent[1] !== undefined) ||
-      (oldYExtent[1] !== newYExtent[1] && newYExtent[1] !== undefined)
-
-    const lineChange = basicDataChangeCheck(lineData, newLines)
-
-    const summaryChange = basicDataChangeCheck(summaryData, newSummaries)
-
-    const pointChange = basicDataChangeCheck(pointData, newPoints)
-
-    if (
-      (oldDataVersion && oldDataVersion !== newDataVersion) ||
-      !prevState.fullDataset
-    ) {
-      return calculateXYFrame(nextProps, prevState, true)
-    } else if (
+    return calculateXYFrame(nextProps, prevState, true)
+  } else if (
+    lineChange ||
+    summaryChange ||
+    pointChange ||
+    oldSize[0] !== newSize[0] ||
+    oldSize[1] !== newSize[1] ||
+    extentChange ||
+    (!oldDataVersion &&
+      xyFrameChangeProps.find((d) => props[d] !== nextProps[d]))
+  ) {
+    const dataChanged =
       lineChange ||
       summaryChange ||
       pointChange ||
-      oldSize[0] !== newSize[0] ||
-      oldSize[1] !== newSize[1] ||
       extentChange ||
-      (!oldDataVersion &&
-        xyFrameChangeProps.find((d) => props[d] !== nextProps[d]))
-    ) {
-      const dataChanged =
-        lineChange ||
-        summaryChange ||
-        pointChange ||
-        extentChange ||
-        !!xyFrameChangeProps.find((d) => props[d] !== nextProps[d])
+      !!xyFrameChangeProps.find((d) => props[d] !== nextProps[d])
 
-      return calculateXYFrame(nextProps, prevState, dataChanged)
-    }
-
-    return null
-
+    return calculateXYFrame(nextProps, prevState, dataChanged)
   }
 
-  defaultXYSVGRule = ({
+  return null
+}
+
+function defaultXYSVGRule(
+  props: XYFrameProps,
+  state: XYFrameState,
+  {
     d: baseD,
     i,
-    annotationLayer,
     lines,
     summaries,
-    points
+    points,
+    annotationLayer
   }: {
     d: AnnotationType
     i: number
@@ -245,224 +356,228 @@ class XYFrame extends React.Component<XYFrameProps, XYFrameState> {
       data: []
       styleFn: (args?: GenericObject, index?: number) => GenericObject
     }
-  }) => {
-    const {
-      showLinePoints,
-      defined,
-      margin: baseMargin,
-      size,
-      svgAnnotationRules
-    } = this.props
+  }
+) {
+  const {
+    showLinePoints,
+    defined,
+    margin: baseMargin,
+    size,
+    svgAnnotationRules
+  } = props
 
-    const {
-      xyFrameRender,
+  const {
+    xyFrameRender,
+    xScale,
+    yScale,
+    xAccessor,
+    yAccessor,
+    axesData,
+    annotatedSettings
+  } = state
+
+  let screenCoordinates: number[] | number[][] = []
+  const idAccessor = annotatedSettings.lineIDAccessor
+
+  if (baseD.type === "highlight") {
+    return svgHighlight({
+      d: baseD,
+      i,
+      idAccessor,
+      lines,
+      summaries,
+      points,
       xScale,
       yScale,
-      xAccessor,
-      yAccessor,
-      axesData,
-      annotatedSettings
-    } = this.state
+      xyFrameRender,
+      defined
+    })
+  }
 
-    let screenCoordinates: number[] | number[][] = []
-    const idAccessor = annotatedSettings.lineIDAccessor
-
-    if (baseD.type === "highlight") {
-      return svgHighlight({
-        d: baseD,
-        i,
+  const d: AnnotationType = baseD.coordinates
+    ? baseD
+    : findPointByID({
+        point: baseD,
         idAccessor,
         lines,
-        summaries,
-        points,
         xScale,
-        yScale,
-        xyFrameRender,
-        defined
+        projectedX,
+        xAccessor
       })
-    }
 
-    const d: AnnotationType = baseD.coordinates
-      ? baseD
-      : findPointByID({
-          point: baseD,
-          idAccessor,
-          lines,
-          xScale,
-          projectedX,
-          xAccessor
-        })
+  if (!d) return null
 
-    if (!d) return null
+  const margin = calculateMargin({
+    margin: baseMargin,
+    axes: axesData,
+    title: annotatedSettings.title,
+    size: size
+  })
+  const { adjustedPosition, adjustedSize } = adjustedPositionSize({
+    size: size,
+    margin
+  })
 
-    const margin = calculateMargin({
-      margin: baseMargin,
-      axes: axesData,
-      title: annotatedSettings.title,
-      size: size
-    })
-    const { adjustedPosition, adjustedSize } = adjustedPositionSize({
-      size: size,
-      margin
-    })
-
-    if (!d.coordinates && !d.bounds) {
-      screenCoordinates = [
-        relativeX({
-          point: d,
+  if (!d.coordinates && !d.bounds) {
+    screenCoordinates = [
+      relativeX({
+        point: d,
+        projectedXMiddle,
+        projectedX,
+        xAccessor,
+        xScale
+      }) || 0,
+      relativeY({
+        point: d,
+        projectedYMiddle,
+        projectedY,
+        yAccessor,
+        yScale,
+        showLinePoints
+      }) || 0
+    ]
+  } else if (!d.bounds) {
+    screenCoordinates = d.coordinates.reduce(
+      (coords: number[], p: AnnotationType | ProjectedPoint) => {
+        const xCoordinate = relativeX({
+          point: p,
           projectedXMiddle,
           projectedX,
           xAccessor,
           xScale
-        }) || 0,
-        relativeY({
-          point: d,
+        })
+
+        const yCoordinate = relativeY({
+          point: p,
           projectedYMiddle,
           projectedY,
           yAccessor,
-          yScale,
-          showLinePoints
-        }) || 0
-      ]
-    } else if (!d.bounds) {
-      screenCoordinates = d.coordinates.reduce(
-        (coords: number[], p: AnnotationType | ProjectedPoint) => {
-          const xCoordinate = relativeX({
-            point: p,
-            projectedXMiddle,
-            projectedX,
-            xAccessor,
-            xScale
-          })
-
-          const yCoordinate = relativeY({
-            point: p,
-            projectedYMiddle,
-            projectedY,
-            yAccessor,
-            yScale
-          })
-          if (Array.isArray(yCoordinate)) {
-            return [
-              ...coords,
-              [xCoordinate, Math.min(...yCoordinate)],
-              [xCoordinate, Math.max(...yCoordinate)]
-            ]
-          } else if (Array.isArray(xCoordinate)) {
-            return [
-              ...coords,
-              [Math.min(...xCoordinate), yCoordinate],
-              [Math.max(...xCoordinate), yCoordinate]
-            ]
-          } else {
-            return [...coords, [xCoordinate, yCoordinate]]
-          }
-        },
-        [] as number[]
-      ) as number[]
-    }
-
-    const { voronoiHover } = annotationLayer
-
-    const customSVG =
-      svgAnnotationRules &&
-      svgAnnotationRules({
-        d,
-        i,
-        screenCoordinates,
-        xScale,
-        yScale,
-        xAccessor,
-        yAccessor,
-        xyFrameProps: this.props,
-        xyFrameState: this.state,
-        summaries,
-        points,
-        lines,
-        voronoiHover,
-        adjustedPosition,
-        adjustedSize,
-        annotationLayer
-      })
-    if (svgAnnotationRules !== undefined && customSVG !== null) {
-      return customSVG
-    } else if (d.type === "desaturation-layer") {
-      return desaturationLayer({
-        style: d.style instanceof Function ? d.style(d, i) : d.style,
-        size: adjustedSize,
-        i,
-        key: d.key
-      })
-    } else if (d.type === "xy" || d.type === "frame-hover") {
-      return svgXYAnnotation({ d, i, screenCoordinates })
-    } else if (d.type === "react-annotation" || typeof d.type === "function") {
-      return basicReactAnnotation({ d, screenCoordinates, i })
-    } else if (d.type === "enclose") {
-      return svgEncloseAnnotation({ d, screenCoordinates, i })
-    } else if (d.type === "enclose-rect") {
-      return svgRectEncloseAnnotation({ d, screenCoordinates, i })
-    } else if (d.type === "enclose-hull") {
-      return svgHullEncloseAnnotation({ d, screenCoordinates, i })
-    } else if (d.type === "x") {
-      return svgXAnnotation({
-        d,
-        screenCoordinates,
-        i,
-        adjustedSize
-      })
-    } else if (d.type === "y") {
-      return svgYAnnotation({
-        d,
-        screenCoordinates,
-        i,
-        adjustedSize,
-        adjustedPosition
-      })
-    } else if (d.type === "bounds") {
-      return svgBoundsAnnotation({
-        d,
-        i,
-        adjustedSize,
-        xAccessor,
-        yAccessor,
-        xScale,
-        yScale
-      })
-    } else if (d.type === "line") {
-      return svgLineAnnotation({ d, i, screenCoordinates })
-    } else if (d.type === "area") {
-      return svgAreaAnnotation({
-        d,
-        i,
-        xScale,
-        xAccessor,
-        yScale,
-        yAccessor,
-        annotationLayer
-      })
-    } else if (d.type === "horizontal-points") {
-      return svgHorizontalPointsAnnotation({
-        d,
-        lines: lines.data,
-        points: points.data,
-        xScale,
-        yScale,
-        pointStyle: points.styleFn
-      })
-    } else if (d.type === "vertical-points") {
-      return svgVerticalPointsAnnotation({
-        d,
-        lines: lines.data,
-        points: points.data,
-        xScale,
-        yScale,
-        pointStyle: points.styleFn
-      })
-    }
-    return null
+          yScale
+        })
+        if (Array.isArray(yCoordinate)) {
+          return [
+            ...coords,
+            [xCoordinate, Math.min(...yCoordinate)],
+            [xCoordinate, Math.max(...yCoordinate)]
+          ]
+        } else if (Array.isArray(xCoordinate)) {
+          return [
+            ...coords,
+            [Math.min(...xCoordinate), yCoordinate],
+            [Math.max(...xCoordinate), yCoordinate]
+          ]
+        } else {
+          return [...coords, [xCoordinate, yCoordinate]]
+        }
+      },
+      [] as number[]
+    ) as number[]
   }
 
-  defaultXYHTMLRule = ({
+  const { voronoiHover } = annotationLayer
+
+  const customSVG =
+    svgAnnotationRules &&
+    svgAnnotationRules({
+      d,
+      i,
+      screenCoordinates,
+      xScale,
+      yScale,
+      xAccessor,
+      yAccessor,
+      xyFrameProps: props,
+      xyFrameState: state,
+      summaries,
+      points,
+      lines,
+      voronoiHover,
+      adjustedPosition,
+      adjustedSize,
+      annotationLayer
+    })
+  if (svgAnnotationRules !== undefined && customSVG !== null) {
+    return customSVG
+  } else if (d.type === "desaturation-layer") {
+    return desaturationLayer({
+      style: d.style instanceof Function ? d.style(d, i) : d.style,
+      size: adjustedSize,
+      i,
+      key: d.key
+    })
+  } else if (d.type === "xy" || d.type === "frame-hover") {
+    return svgXYAnnotation({ d, i, screenCoordinates })
+  } else if (d.type === "react-annotation" || typeof d.type === "function") {
+    return basicReactAnnotation({ d, screenCoordinates, i })
+  } else if (d.type === "enclose") {
+    return svgEncloseAnnotation({ d, screenCoordinates, i })
+  } else if (d.type === "enclose-rect") {
+    return svgRectEncloseAnnotation({ d, screenCoordinates, i })
+  } else if (d.type === "enclose-hull") {
+    return svgHullEncloseAnnotation({ d, screenCoordinates, i })
+  } else if (d.type === "x") {
+    return svgXAnnotation({
+      d,
+      screenCoordinates,
+      i,
+      adjustedSize
+    })
+  } else if (d.type === "y") {
+    return svgYAnnotation({
+      d,
+      screenCoordinates,
+      i,
+      adjustedSize,
+      adjustedPosition
+    })
+  } else if (d.type === "bounds") {
+    return svgBoundsAnnotation({
+      d,
+      i,
+      adjustedSize,
+      xAccessor,
+      yAccessor,
+      xScale,
+      yScale
+    })
+  } else if (d.type === "line") {
+    return svgLineAnnotation({ d, i, screenCoordinates })
+  } else if (d.type === "area") {
+    return svgAreaAnnotation({
+      d,
+      i,
+      xScale,
+      xAccessor,
+      yScale,
+      yAccessor,
+      annotationLayer
+    })
+  } else if (d.type === "horizontal-points") {
+    return svgHorizontalPointsAnnotation({
+      d,
+      lines: lines.data,
+      points: points.data,
+      xScale,
+      yScale,
+      pointStyle: points.styleFn
+    })
+  } else if (d.type === "vertical-points") {
+    return svgVerticalPointsAnnotation({
+      d,
+      lines: lines.data,
+      points: points.data,
+      xScale,
+      yScale,
+      pointStyle: points.styleFn
+    })
+  }
+  return null
+}
+
+function defaultXYHTMLRule(
+  props: XYFrameProps,
+  state: XYFrameState,
+  {
     d: baseD,
     i,
     lines,
@@ -479,269 +594,154 @@ class XYFrame extends React.Component<XYFrameProps, XYFrameState> {
       data: ProjectedPoint[]
       styleFn: (args?: GenericObject, index?: number) => GenericObject
     }
-  }) => {
-    const {
-      xAccessor,
-      yAccessor,
-      xScale,
-      yScale,
-      SpanOrDiv,
-      annotatedSettings,
-      axesData
-    } = this.state
+  }
+) {
+  const {
+    xAccessor,
+    yAccessor,
+    xScale,
+    yScale,
+    SpanOrDiv,
+    annotatedSettings,
+    axesData
+  } = state
 
-    const { voronoiHover } = annotationLayer
+  const { voronoiHover } = annotationLayer
 
-    let screenCoordinates = []
+  let screenCoordinates = []
 
-    const {
-      useSpans,
-      tooltipContent,
-      optimizeCustomTooltipPosition,
-      htmlAnnotationRules,
-      size,
-      showLinePoints,
-      margin: baseMargin
-    } = this.props
+  const {
+    useSpans,
+    tooltipContent,
+    optimizeCustomTooltipPosition,
+    htmlAnnotationRules,
+    size,
+    showLinePoints,
+    margin: baseMargin
+  } = props
 
-    const idAccessor = annotatedSettings.lineIDAccessor
-    const d: AnnotationType = findPointByID({
-      point: baseD,
-      idAccessor,
-      lines,
-      xScale,
-      projectedX,
-      xAccessor
-    })
+  const idAccessor = annotatedSettings.lineIDAccessor
+  const d: AnnotationType = findPointByID({
+    point: baseD,
+    idAccessor,
+    lines,
+    xScale,
+    projectedX,
+    xAccessor
+  })
 
-    if (!d) {
-      return null
-    }
-
-    const xCoord =
-      d[projectedXMiddle] ||
-      d[projectedX] ||
-      findFirstAccessorValue(xAccessor, d)
-    const yCoord =
-      d[projectedYMiddle] ||
-      d[projectedY] ||
-      findFirstAccessorValue(yAccessor, d)
-
-    const xString = xCoord && xCoord.toString ? xCoord.toString() : xCoord
-    const yString = yCoord && yCoord.toString ? yCoord.toString() : yCoord
-
-    const margin = calculateMargin({
-      margin: baseMargin,
-      axes: axesData,
-      title: annotatedSettings.title,
-      size: size
-    })
-    const { adjustedPosition, adjustedSize } = adjustedPositionSize({
-      size,
-      margin
-    })
-    if (!d.coordinates) {
-      screenCoordinates = [
-        xScale(xCoord) || 0,
-        relativeY({
-          point: d,
-          projectedYMiddle,
-          projectedY,
-          showLinePoints,
-          yAccessor,
-          yScale
-        }) || 0
-      ]
-    } else {
-      screenCoordinates = d.coordinates.map((p) => {
-        const foundP = findPointByID({
-          point: { x: 0, y: 0, ...p },
-          idAccessor,
-          lines,
-          xScale,
-          projectedX,
-          xAccessor
-        })
-        return [
-          (xScale(findFirstAccessorValue(xAccessor, d)) || 0) +
-            adjustedPosition[0],
-          (relativeY({
-            point: foundP,
-            projectedYMiddle,
-            projectedY,
-            yAccessor,
-            yScale
-          }) || 0) + adjustedPosition[1]
-        ]
-      })
-    }
-
-    const customAnnotation =
-      htmlAnnotationRules &&
-      htmlAnnotationRules({
-        d,
-        i,
-        screenCoordinates,
-        xScale,
-        yScale,
-        xAccessor,
-        yAccessor,
-        xyFrameProps: this.props,
-        xyFrameState: this.state,
-        summaries,
-        points,
-        lines,
-        voronoiHover,
-        adjustedPosition,
-        adjustedSize,
-        annotationLayer
-      })
-
-    if (htmlAnnotationRules && customAnnotation !== null) {
-      return customAnnotation
-    }
-    if (d.type === "frame-hover") {
-      let content = (
-        <SpanOrDiv span={useSpans} className="tooltip-content">
-          <p key="html-annotation-content-1">{xString}</p>
-          <p key="html-annotation-content-2">{yString}</p>
-          {d.percent ? (
-            <p key="html-annotation-content-3">
-              {Math.floor(d.percent * 1000) / 10}%
-            </p>
-          ) : null}
-        </SpanOrDiv>
-      )
-
-      if (d.type === "frame-hover" && tooltipContent) {
-        content = optimizeCustomTooltipPosition ? (
-          <TooltipPositioner
-            tooltipContent={tooltipContent}
-            tooltipContentArgs={d}
-          />
-        ) : (
-          tooltipContent(d)
-        )
-      }
-      return htmlTooltipAnnotation({
-        content,
-        screenCoordinates,
-        i,
-        d,
-        useSpans
-      })
-    }
+  if (!d) {
     return null
   }
 
-  render() {
-    const {
-      size,
-      className,
-      annotationSettings,
-      annotations,
-      additionalDefs,
-      hoverAnnotation,
-      interaction,
-      customClickBehavior,
-      customHoverBehavior,
-      customDoubleClickBehavior,
-      canvasPostProcess,
-      baseMarkProps,
-      useSpans,
-      canvasSummaries,
-      canvasPoints,
-      canvasLines,
-      afterElements,
-      beforeElements,
-      renderOrder,
-      matte,
-      frameKey,
-      showLinePoints,
-      sketchyRenderingEngine,
-      disableContext,
-      frameRenderOrder,
-      disableCanvasInteraction,
-      interactionSettings,
-      disableProgressiveRendering
-    } = this.props
+  const xCoord =
+    d[projectedXMiddle] || d[projectedX] || findFirstAccessorValue(xAccessor, d)
+  const yCoord =
+    d[projectedYMiddle] || d[projectedY] || findFirstAccessorValue(yAccessor, d)
 
-    const {
-      backgroundGraphics,
-      foregroundGraphics,
-      adjustedPosition,
-      adjustedSize,
-      margin,
-      axes,
-      axesTickLines,
+  const xString = xCoord && xCoord.toString ? xCoord.toString() : xCoord
+  const yString = yCoord && yCoord.toString ? yCoord.toString() : yCoord
+
+  const margin = calculateMargin({
+    margin: baseMargin,
+    axes: axesData,
+    title: annotatedSettings.title,
+    size: size
+  })
+  const { adjustedPosition, adjustedSize } = adjustedPositionSize({
+    size,
+    margin
+  })
+  if (!d.coordinates) {
+    screenCoordinates = [
+      xScale(xCoord) || 0,
+      relativeY({
+        point: d,
+        projectedYMiddle,
+        projectedY,
+        showLinePoints,
+        yAccessor,
+        yScale
+      }) || 0
+    ]
+  } else {
+    screenCoordinates = d.coordinates.map((p) => {
+      const foundP = findPointByID({
+        point: { x: 0, y: 0, ...p },
+        idAccessor,
+        lines,
+        xScale,
+        projectedX,
+        xAccessor
+      })
+      return [
+        (xScale(findFirstAccessorValue(xAccessor, d)) || 0) +
+          adjustedPosition[0],
+        (relativeY({
+          point: foundP,
+          projectedYMiddle,
+          projectedY,
+          yAccessor,
+          yScale
+        }) || 0) + adjustedPosition[1]
+      ]
+    })
+  }
+
+  const customAnnotation =
+    htmlAnnotationRules &&
+    htmlAnnotationRules({
+      d,
+      i,
+      screenCoordinates,
       xScale,
       yScale,
-      fullDataset,
-      dataVersion,
-      areaAnnotations,
-      legendSettings,
-      xyFrameRender,
-      annotatedSettings,
-      overlay
-    } = this.state
+      xAccessor,
+      yAccessor,
+      xyFrameProps: props,
+      xyFrameState: state,
+      summaries,
+      points,
+      lines,
+      voronoiHover,
+      adjustedPosition,
+      adjustedSize,
+      annotationLayer
+    })
 
-    return (
-      <Frame
-        name="xyframe"
-        renderPipeline={xyFrameRender}
-        adjustedPosition={adjustedPosition}
-        size={size}
-        projectedCoordinateNames={projectedCoordinateNames}
-        xScale={xScale}
-        yScale={yScale}
-        axes={axes}
-        axesTickLines={axesTickLines}
-        title={annotatedSettings.title}
-        dataVersion={dataVersion}
-        matte={matte}
-        className={className}
-        adjustedSize={adjustedSize}
-        frameKey={frameKey || xyframeKey}
-        additionalDefs={additionalDefs}
-        hoverAnnotation={hoverAnnotation}
-        defaultSVGRule={this.defaultXYSVGRule}
-        defaultHTMLRule={this.defaultXYHTMLRule}
-        annotations={
-          areaAnnotations.length > 0
-            ? [...annotations, ...areaAnnotations]
-            : annotations
-        }
-        annotationSettings={annotationSettings}
-        legendSettings={legendSettings}
-        projectedYMiddle={projectedYMiddle}
-        interaction={interaction}
-        customClickBehavior={customClickBehavior}
-        customHoverBehavior={customHoverBehavior}
-        customDoubleClickBehavior={customDoubleClickBehavior}
-        points={fullDataset}
-        showLinePoints={
-          typeof showLinePoints === "string" ? showLinePoints : undefined
-        }
-        margin={margin}
-        backgroundGraphics={backgroundGraphics}
-        foregroundGraphics={foregroundGraphics}
-        beforeElements={beforeElements}
-        afterElements={afterElements}
-        disableContext={disableContext}
-        canvasPostProcess={canvasPostProcess}
-        baseMarkProps={baseMarkProps}
-        useSpans={useSpans}
-        canvasRendering={!!(canvasSummaries || canvasPoints || canvasLines)}
-        renderOrder={renderOrder}
-        overlay={overlay}
-        sketchyRenderingEngine={sketchyRenderingEngine}
-        frameRenderOrder={frameRenderOrder}
-        disableCanvasInteraction={disableCanvasInteraction}
-        interactionSettings={interactionSettings}
-        disableProgressiveRendering={disableProgressiveRendering}
-      />
-    )
+  if (htmlAnnotationRules && customAnnotation !== null) {
+    return customAnnotation
   }
-}
+  if (d.type === "frame-hover") {
+    let content = (
+      <SpanOrDiv span={useSpans} className="tooltip-content">
+        <p key="html-annotation-content-1">{xString}</p>
+        <p key="html-annotation-content-2">{yString}</p>
+        {d.percent ? (
+          <p key="html-annotation-content-3">
+            {Math.floor(d.percent * 1000) / 10}%
+          </p>
+        ) : null}
+      </SpanOrDiv>
+    )
 
-export default XYFrame
+    if (d.type === "frame-hover" && tooltipContent) {
+      content = optimizeCustomTooltipPosition ? (
+        <TooltipPositioner
+          tooltipContent={tooltipContent}
+          tooltipContentArgs={d}
+        />
+      ) : (
+        tooltipContent(d)
+      )
+    }
+    return htmlTooltipAnnotation({
+      content,
+      screenCoordinates,
+      i,
+      d,
+      useSpans
+    })
+  }
+  return null
+}

--- a/src/components/XYFrame.tsx
+++ b/src/components/XYFrame.tsx
@@ -43,13 +43,13 @@ import {
 
 import { extentValue } from "./data/unflowedFunctions"
 
-import { basicPropDiffing, basicDataChangeCheck } from "./processing/diffing"
+import { basicDataChangeCheck } from "./processing/diffing"
 
 import { findFirstAccessorValue } from "./data/multiAccessorUtils"
 
 import { calculateXYFrame } from "./processing/xyDrawing"
 
-import { xyFrameChangeProps, xyFrameDataProps } from "./constants/frame_props"
+import { xyFrameChangeProps } from "./constants/frame_props"
 
 import { HOCSpanOrDiv } from "./SpanOrDiv"
 
@@ -94,7 +94,7 @@ const defaultProps = {
   dataVersion: undefined
 }
 
-export default React.memo(function XYFrame_(allProps: XYFrameProps) {
+export default React.memo(function XYFrame(allProps: XYFrameProps) {
   const props = { ...defaultProps, ...allProps }
   const baseState = {
     SpanOrDiv: HOCSpanOrDiv(props.useSpans),

--- a/src/components/data/dataFunctions.ts
+++ b/src/components/data/dataFunctions.ts
@@ -638,8 +638,15 @@ export const calculateDataExtent = ({
   }
 }
 
-const differenceCatch = (olineType, data) =>
-  olineType === "difference" && data.length !== 2 ? "line" : olineType
+const differenceCatch = (olineType, data) => {
+  if (
+    !builtInTransformations[olineType] ||
+    (olineType === "difference" && data.length !== 2)
+  ) {
+    return "line"
+  }
+  return olineType
+}
 
 function lineTransformation(lineType, options) {
   return (data) =>

--- a/src/components/types/xyTypes.ts
+++ b/src/components/types/xyTypes.ts
@@ -35,7 +35,7 @@ export interface XYFrameProps extends GeneralFrameProps {
   yAccessor?: accessorType<number>
   lineDataAccessor?: accessorType<RawPoint[]>
   summaryDataAccessor?: accessorType<RawPoint[]>
-  lineType?: LineTypeSettings
+  lineType?: LineTypeSettings | string
   summaryType?: SummaryTypeSettings
   lineRenderMode?: string | object | Function
   pointRenderMode?: string | object | Function

--- a/src/components/useDerivedStateFromProps.ts
+++ b/src/components/useDerivedStateFromProps.ts
@@ -1,0 +1,26 @@
+import { useRef, useMemo } from "react"
+
+// this hooks should only be used for transitioning from class to function components
+// this hooks is supposed to replicate behavior of getDerivedStateFromProps
+// and some assumptions related to it:
+// 1. initial state, defined in "constructor" should not trigger additional computation
+// 2. the computation function can opt-out if it thinks that nothing has changed, so the existing state should be used
+//
+// ideally, the state must be refactored to be function component friendly, so this hooks should become irrelevant
+export function useDerivedStateFromProps<Props, State>(
+  fn: (nextProps: Props, prevState: State) => Partial<State> | null,
+  props: Props,
+  initialState: State
+): State {
+  let prevRef = useRef(initialState)
+  let state = useMemo(() => {
+    let state = prevRef.current
+    let patch = fn(props, state)
+    if (patch != null) {
+      return { ...state, ...patch }
+    }
+    return state
+  }, [props])
+  prevRef.current = state
+  return state
+}

--- a/src/components/useLegacyUnmountCallback.ts
+++ b/src/components/useLegacyUnmountCallback.ts
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from "react"
+
+// to properly replicate behavior of componentWillUnmount, the effect must not have dependencies
+// which is why we need to store latest props and state values in ref that can be accessible during unmount
+// TODO get rid of the behavior and props.onUnmount
+export function useLegacyUnmountCallback(props: any, state: any) {
+  let ref = useRef<[any, any]>()
+  ref.current = [props, state]
+  useEffect(() => {
+    ;() => {
+      const [props, state] = ref.current
+      const onUnmount = props.onUnmount
+      if (onUnmount) {
+        onUnmount(props, state)
+      }
+    }
+  }, [])
+}


### PR DESCRIPTION
Alright, this one might seem messy, gonna try to describe all the details I've encountered.

The main reason to do this _right now_ was the idea to make top level frames responsive by default (see #601). It would be a neat trick if it was possible by just changing the behavior inside `<Frame />`, but what makes it not that easy is that `<XYFrame />` and others also need `size` as a part of their rendering phase. Thus, the proper place to modify to responsive-by-default behavior are those actual frames. Recently introduced hook for element size is great, but can't be used by class components. I have zero motivation to implement something new for _class_ components, so the only way to go is to convert the rest of classes to functions.

There are a bunch of aspects I noticed that are similar to all top level frames that are currently implemented as classes:

1. They use `getDerivedStateFromProps` to change the state based on changed props and none of them actually have state (that is controlled by `setState`)
2. Initial state is computed in `constructor` and additional mechanic is implemented in `getDerivedStateFromProps` to avoid any possibility to rewrite existing state if underlying data from props haven't changed.
3. There are a bunch of class methods that don't have too much dependencies on the rest of the class, so they can be treated as "functions" (and possibly become them)
4. `onUnmount` prop. I'm seeing that some frames have this prop and I'm not sure about how it is supposed to be used (or should it be used by the users at all). in any case, I'd consider getting rid of it as it's domain itself is defined based on the notion and assumptions of class components. Basically, it feels like a code smell. cc @emeeks 

Technically it wasn't hard to convert `<XYFrame />` to function component. But there are still plenty of things to change inside this new component to make it benefiting more from being a function. These can be addressed in the following PRs:

1. Separate state computation by state domains, don't keep everything in a single function that expects the whole set of `props` and `state`
2. (Enabled by the previous item) get rid of custom state/props comparison logic. We can now rely on basic hook memoization
3. Eliminate `onUnmount` prop
