### PR TITLE
Use generalized bounding rect query hook

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   verbose: true,
+  resetMocks: true,
   collectCoverage: true,
   setupFilesAfterEnv: ["<rootDir>/src/setupTests.js"],
   testMatch: [

--- a/src/components/FacetController.test.js
+++ b/src/components/FacetController.test.js
@@ -5,6 +5,8 @@ import OrdinalFrame from "./OrdinalFrame"
 import { ResponsiveXYFrame } from "./ResponsiveXYFrame"
 
 const SimpleDivPropsDisplay = props => (
+jest.mock("./useBoundingRect")
+
   <div style={{ padding: "20px" }}>
     <h3 style={{ fontSize: "14px", fontWeight: 900 }}>
       Component showing inherited facetprops
@@ -213,7 +215,7 @@ describe("FacetController", () => {
     )
   })
 
-  it.skip("renders mixed vanilla HTML & Semiotic frames", () => {
+  it("renders mixed vanilla HTML & Semiotic frames", () => {
     mount(
       <FacetController
         size={[300, 300]}

--- a/src/components/FacetController.test.js
+++ b/src/components/FacetController.test.js
@@ -4,9 +4,9 @@ import FacetController from "./FacetController"
 import OrdinalFrame from "./OrdinalFrame"
 import { ResponsiveXYFrame } from "./ResponsiveXYFrame"
 
-const SimpleDivPropsDisplay = props => (
 jest.mock("./useBoundingRect")
 
+const SimpleDivPropsDisplay = props => (
   <div style={{ padding: "20px" }}>
     <h3 style={{ fontSize: "14px", fontWeight: 900 }}>
       Component showing inherited facetprops

--- a/src/components/ResponsiveFrame.tsx
+++ b/src/components/ResponsiveFrame.tsx
@@ -5,6 +5,8 @@ import { OrdinalFrameProps } from "./types/ordinalTypes"
 import { XYFrameProps } from "./types/xyTypes"
 import { NetworkFrameProps } from "./types/networkTypes"
 
+import { useBoundingRect } from "./useBoundingRect"
+
 export interface ResponsiveFrameProps {
   debounce?: number
   responsiveWidth?: boolean
@@ -19,29 +21,6 @@ export interface ResponsiveFrameState {
 }
 
 type ActualFrameProps = OrdinalFrameProps | XYFrameProps | NetworkFrameProps
-
-/** ISC License (c) 2021 Alexey Raspopov */
-
-function useElementSize(ref) {
-  let [size, setSize] = useState([null, null])
-  useLayoutEffect(() => {
-    let element = ref.current
-    if (element != null) {
-      let rect = element.getBoundingClientRect()
-      setSize([rect.width, rect.height])
-      // @ts-ignore
-      let observer = new ResizeObserver((entries) => {
-        if (entries.length > 0) {
-          let rect = entries[0].contentRect
-          setSize([rect.width, rect.height])
-        }
-      })
-      observer.observe(element)
-      return () => observer.disconnect()
-    }
-  }, [])
-  return size
-}
 
 const createResponsiveFrame = (ParticularFrame) => {
   function ResponsiveFrame(props: ResponsiveFrameProps & ActualFrameProps) {
@@ -60,16 +39,16 @@ const createResponsiveFrame = (ParticularFrame) => {
     let returnEmpty = false
 
     let sceneRef = useRef()
-    let [containerWidth, containerHeight] = useElementSize(sceneRef)
+    let rect = useBoundingRect(sceneRef)
 
     if (responsiveWidth) {
-      if (!containerWidth) returnEmpty = true
-      actualSize[0] = containerWidth
+      if (rect == null) returnEmpty = true
+      else actualSize[0] = rect.width
     }
 
     if (responsiveHeight) {
-      if (!containerHeight) returnEmpty = true
-      actualSize[1] = containerHeight
+      if (rect == null) returnEmpty = true
+      else actualSize[1] = rect.height
     }
 
     const dataVersionWithSize = dataVersion + actualSize.toString() + debounce

--- a/src/components/useBoundingRect.ts
+++ b/src/components/useBoundingRect.ts
@@ -1,0 +1,21 @@
+import { useState, useLayoutEffect, RefObject } from "react"
+
+export function useBoundingRect(ref: RefObject<HTMLElement>): DOMRect | null {
+  const [rect, setRect] = useState<DOMRect | null>(null)
+  useLayoutEffect(() => {
+    const element = ref.current
+    if (element != null) {
+      setRect(element.getBoundingClientRect())
+      // TypeScript 3.9 does not know about resize observer
+      // @ts-ignore
+      const observer = new ResizeObserver((entries) => {
+        if (entries.length > 0) {
+          setRect(entries[0].contentRect as DOMRect)
+        }
+      })
+      observer.observe(element)
+      return () => observer.disconnect()
+    }
+  }, [])
+  return rect
+}


### PR DESCRIPTION
Recent change in `<ResponsiveFrame />` made use of a custom hook that uses `element.getBoundingClientRect()` and `ResizeObserver` to get actual target element size. The hook returns a tuple `[number | null, number | null]`. In this PR I'm trying to resolve two things:

1. `FacetController.test.js` has been skipped due to ResizeObserver being unavailable in JSDOM environment. Moving the hook to a separate module enables us to use `jest.mock()` to 1) simply avoid the test failure 2) being able to configure the result of the hook (i.e. the "size") in tests.
2. Getting an element's size is just one of the cases of `getBoundingClientRect()` usage. I think we can benefit from generalizing (and simplifying) the hook to just return the bounding rect of an element. The rect includes required size fields along with coordinates. See https://developer.mozilla.org/en-US/docs/Web/API/DOMRect. Thus, we don't need to come up with custom signatures, simply using the existing general structures.
