### PR TITLE
remove legacy docs build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
     "dist"
   ],
   "scripts": {
-    "start": "parcel serve --target docs",
-    "build": "parcel build --target docs",
     "test": "jest --config jest.config.js",
     "pretest:dist": "npm run dist",
     "test:dist": "playwright test",


### PR DESCRIPTION
Are these still necessary?