### PR TITLE
Convert interaction canvas to function component

### DIFF
--- a/src/components/Frame.tsx
+++ b/src/components/Frame.tsx
@@ -164,12 +164,10 @@ export default function Frame(props) {
 
   const canvasContext = useRef(null)
 
-  const [voronoiHover, changeVoronoiHover] = useState(undefined)
+  const [voronoiHover, setVoronoi] = useState(undefined)
   const [finalDefs, changeFinalDefs] = useState(null)
   const [matte, changeMatte] = useState(null)
   const [SpanOrDiv] = useState(() => HOCSpanOrDiv(props.useSpans))
-
-  const [setVoronoi] = useState(() => (d) => changeVoronoiHover(d))
 
   useEffect(() => {
     const generatedDefs = generateFinalDefs({

--- a/src/components/NetworkFrame.tsx
+++ b/src/components/NetworkFrame.tsx
@@ -58,7 +58,9 @@ const defaultProps = {
   filterRenderedNodes: (d: NodeType) => d.id !== "root-generated"
 }
 
-export default React.memo(function NetworkFrame(allProps: NetworkFrameProps) {
+const NetworkFrame = React.memo(function NetworkFrame(
+  allProps: NetworkFrameProps
+) {
   const props: NetworkFrameProps = { ...defaultProps, ...allProps }
   const baseState = {
     dataVersion: undefined,
@@ -442,3 +444,6 @@ function defaultNetworkHTMLRule(
   }
   return null
 }
+
+NetworkFrame.displayName = "NetworkFrame"
+export default NetworkFrame

--- a/src/components/OrdinalFrame.tsx
+++ b/src/components/OrdinalFrame.tsx
@@ -59,7 +59,9 @@ const defaultProps: Partial<OrdinalFrameProps> = {
   optimizeCustomTooltipPosition: false
 }
 
-export default React.memo(function OrdinalFrame(allProps: OrdinalFrameProps) {
+const OrdinalFrame = React.memo(function OrdinalFrame(
+  allProps: OrdinalFrameProps
+) {
   const props: OrdinalFrameProps = { ...defaultProps, ...allProps }
   const baseState = {
     adjustedPosition: [],
@@ -584,3 +586,6 @@ function defaultORHTMLRule(
   }
   return null
 }
+
+OrdinalFrame.displayName = "OrdinalFrame"
+export default OrdinalFrame

--- a/src/components/XYFrame.tsx
+++ b/src/components/XYFrame.tsx
@@ -94,7 +94,7 @@ const defaultProps = {
   dataVersion: undefined
 }
 
-export default React.memo(function XYFrame(allProps: XYFrameProps) {
+const XYFrame = React.memo(function XYFrame(allProps: XYFrameProps) {
   const props = { ...defaultProps, ...allProps }
   const baseState = {
     SpanOrDiv: HOCSpanOrDiv(props.useSpans),
@@ -745,3 +745,6 @@ function defaultXYHTMLRule(
   }
   return null
 }
+
+XYFrame.displayName = "XYFrame"
+export default XYFrame

--- a/src/components/interactionLayerBehavior/InteractionCanvas.tsx
+++ b/src/components/interactionLayerBehavior/InteractionCanvas.tsx
@@ -1,4 +1,6 @@
 import * as React from "react"
+import { useRef, useLayoutEffect } from "react"
+
 import { canvasEvent } from "../svg/frameFunctions"
 
 import { MarginType } from "../types/generalTypes"
@@ -13,138 +15,123 @@ type InteractionCanvasProps = {
   voronoiHover: Function
 }
 
-type InteractionCanvasState = {
-  ref: any
-  interactionContext: null | HTMLCanvasElement
-}
+export default React.memo(function InteractionCanvas({
+  width,
+  height,
+  overlayRegions,
+  margin,
+  voronoiHover
+}: InteractionCanvasProps) {
+  let canvasRef = useRef<HTMLCanvasElement>()
 
-class InteractionCanvas extends React.Component<
-  InteractionCanvasProps,
-  InteractionCanvasState
-> {
-  constructor(props: InteractionCanvasProps) {
-    super(props)
-
-    this.state = {
-      ref: null,
-      interactionContext: null
-    }
-  }
-
-  canvasMap: Map<string, number> = new Map()
-
-  componentDidMount() {
-    this.canvasRendering()
-  }
-
-  componentDidUpdate(
-    prevProps: InteractionCanvasProps,
-    prevState: InteractionCanvasState
-  ) {
-    if (
-      prevProps.width !== this.props.width ||
-      prevProps.height !== this.props.height ||
-      this.props.overlayRegions !== prevProps.overlayRegions ||
-      (!prevState.interactionContext && this.state.interactionContext)
-    ) {
-      this.canvasRendering()
-    }
-  }
-
-  canvasRendering = () => {
-    const canvasMap = this.canvasMap
-    const { interactionContext } = this.state
-    const { voronoiHover, height, width, overlayRegions, margin } = this.props
-
-    if (interactionContext === null || !overlayRegions) return
-
-    const boundCanvasEvent = canvasEvent.bind(
-      null,
-      interactionContext,
+  useLayoutEffect(() => {
+    renderInteractionCanvas(
+      canvasRef.current,
+      voronoiHover,
+      height,
+      width,
       overlayRegions,
-      this.canvasMap
+      margin
     )
-    interactionContext.onmousemove = (e) => {
-      const overlay = boundCanvasEvent(e)
-      if (overlay && overlay.props && overlay.props.children[0]) {
-        overlay.props.children[0].props.onMouseEnter()
-      } else {
-        voronoiHover(null)
-      }
-    }
-    interactionContext.onmouseout = () => {
+  }, [width, height, overlayRegions])
+
+  return (
+    <canvas
+      className="frame-canvas-interaction"
+      ref={(canvas: HTMLCanvasElement) => {
+        if (canvas != null && canvasRef.current !== canvas) {
+          canvasRef.current = canvas
+          renderInteractionCanvas(
+            canvas,
+            voronoiHover,
+            height,
+            width,
+            overlayRegions,
+            margin
+          )
+        }
+      }}
+      style={{
+        position: "absolute",
+        left: `0px`,
+        top: `0px`,
+        imageRendering: "pixelated",
+        pointerEvents: "all",
+        opacity: 0
+      }}
+      width={width}
+      height={height}
+    />
+  )
+})
+
+function renderInteractionCanvas(
+  interactionContext: HTMLCanvasElement,
+  voronoiHover: Function,
+  height: number,
+  width: number,
+  overlayRegions: Array<{
+    props: { d?: string; children: Array<{ props: { d?: string } }> }
+  }>,
+  margin: MarginType
+) {
+  const canvasMap: Map<string, number> = new Map()
+  if (interactionContext === null || !overlayRegions) return
+
+  const boundCanvasEvent = canvasEvent.bind(
+    null,
+    interactionContext,
+    overlayRegions,
+    canvasMap
+  )
+  interactionContext.onmousemove = (e) => {
+    const overlay = boundCanvasEvent(e)
+    if (overlay && overlay.props && overlay.props.children[0]) {
+      overlay.props.children[0].props.onMouseEnter()
+    } else {
       voronoiHover(null)
     }
-
-    interactionContext.onclick = (e) => {
-      const overlay = boundCanvasEvent(e)
-      if (overlay && overlay.props) {
-        overlay.props.children[0].props.onClick(e)
-      }
-    }
-    interactionContext.ondblclick = (e) => {
-      const overlay = boundCanvasEvent(e)
-      if (overlay && overlay.props) {
-        overlay.props.children[0].props.onDoubleClick(e)
-      }
-    }
-
-    canvasMap.clear()
-
-    const interactionContext2D = interactionContext.getContext("2d")
-
-    interactionContext2D.imageSmoothingEnabled = false
-    interactionContext2D.setTransform(1, 0, 0, 1, margin.left, margin.top)
-    interactionContext2D.clearRect(-margin.left, -margin.top, width, height)
-
-    interactionContext2D.lineWidth = 1
-
-    overlayRegions.forEach((overlay, oi) => {
-      const overlayD = overlay.props.d || overlay.props.children[0].props.d
-      const interactionRGBA = `rgba(${Math.floor(
-        Math.random() * 255
-      )},${Math.floor(Math.random() * 255)},${Math.floor(
-        Math.random() * 255
-      )},255)`
-
-      canvasMap.set(interactionRGBA, oi)
-
-      interactionContext2D.fillStyle = interactionRGBA
-      interactionContext2D.strokeStyle = interactionRGBA
-
-      const p = new Path2D(overlayD)
-      interactionContext2D.stroke(p)
-      interactionContext2D.fill(p)
-    })
+  }
+  interactionContext.onmouseout = () => {
+    voronoiHover(null)
   }
 
-  render() {
-    const { width, height } = this.props
-
-    return (
-      <canvas
-        className="frame-canvas-interaction"
-        ref={(canvasContext: HTMLCanvasElement) => {
-          if (
-            canvasContext &&
-            this.state.interactionContext !== canvasContext
-          ) {
-            this.setState({ interactionContext: canvasContext })
-          }
-        }}
-        style={{
-          position: "absolute",
-          left: `0px`,
-          top: `0px`,
-          imageRendering: "pixelated",
-          pointerEvents: "all",
-          opacity: 0
-        }}
-        width={width}
-        height={height}
-      />
-    )
+  interactionContext.onclick = (e) => {
+    const overlay = boundCanvasEvent(e)
+    if (overlay && overlay.props) {
+      overlay.props.children[0].props.onClick(e)
+    }
   }
+  interactionContext.ondblclick = (e) => {
+    const overlay = boundCanvasEvent(e)
+    if (overlay && overlay.props) {
+      overlay.props.children[0].props.onDoubleClick(e)
+    }
+  }
+
+  const interactionContext2D = interactionContext.getContext("2d")
+
+  interactionContext2D.imageSmoothingEnabled = false
+  interactionContext2D.setTransform(1, 0, 0, 1, margin.left, margin.top)
+  interactionContext2D.clearRect(-margin.left, -margin.top, width, height)
+
+  interactionContext2D.lineWidth = 1
+
+  overlayRegions.forEach((overlay, oi) => {
+    const overlayD = overlay.props.d || overlay.props.children[0].props.d
+    const interactionRGBA = `rgba(${Math.floor(
+      Math.random() * 255
+    )},${Math.floor(Math.random() * 255)},${Math.floor(
+      Math.random() * 255
+    )},255)`
+
+    canvasMap.set(interactionRGBA, oi)
+
+    interactionContext2D.fillStyle = interactionRGBA
+    interactionContext2D.strokeStyle = interactionRGBA
+
+    const p = new Path2D(overlayD)
+    interactionContext2D.stroke(p)
+    interactionContext2D.fill(p)
+  })
 }
-
-export default InteractionCanvas


### PR DESCRIPTION
Once this PR is merged only VisualizationLayer is left to be converted.

InteractionCanvas is converted, didn't seem to be an issue. I also added a quick fix for missing display names on the website: React.memo() can't seem to copy the original name of the component, so I just put explicit `displayName` property.