### PR TITLE
Quick optimizations to avoid excessive GC cycles

### DIFF
--- a/src/components/processing/ordinal.tsx
+++ b/src/components/processing/ordinal.tsx
@@ -360,12 +360,12 @@ export const calculateOrdinalFrame = (
 
     const nestedPositiveData = nest()
       .key((d) => d.column)
-      .rollup((leaves) => sum(leaves.map((d) => d.value)))
+      .rollup((leaves) => sum(leaves, (d) => d.value))
       .entries(positiveData)
 
     const nestedNegativeData = nest()
       .key((d) => d.column)
-      .rollup((leaves) => sum(leaves.map((d) => d.value)))
+      .rollup((leaves) => sum(leaves, (d) => d.value))
       .entries(negativeData)
 
     const positiveAnnotations = annotationsForExtent.filter((d) => d > 0)
@@ -463,7 +463,7 @@ export const calculateOrdinalFrame = (
   if (dynamicColumnWidth) {
     let columnValueCreator
     if (typeof dynamicColumnWidth === "string") {
-      columnValueCreator = (d) => sum(d.map((p) => p.data[dynamicColumnWidth]))
+      columnValueCreator = (d) => sum(d, (p) => p.data[dynamicColumnWidth])
     } else {
       columnValueCreator = (d) => dynamicColumnWidth(d.map((p) => p.data))
     }

--- a/src/components/svg/lineDrawing.ts
+++ b/src/components/svg/lineDrawing.ts
@@ -206,10 +206,10 @@ export const stackedArea = ({
     }, [])
 
   let stackSort = (a, b) =>
-    sum(b.data.map(p => p[yProp])) - sum(a.data.map(p => p[yProp]))
+    sum(b.data, (p) => p[yProp]) - sum(a.data, (p) => p[yProp])
   if (type === "stackedpercent-invert" || type === "stackedarea-invert") {
     stackSort = (a, b) =>
-      sum(a.data.map(p => p[yProp])) - sum(b.data.map(p => p[yProp]))
+      sum(a.data, (p) => p[yProp]) - sum(b.data, (p) => p[yProp])
   }
   sort = sort === undefined ? stackSort : sort
 
@@ -224,11 +224,11 @@ export const stackedArea = ({
       .map(d => d.data.filter(p => datesForUnique(p[xProp]) === xValue))
       .reduce((a, b) => a.concat(b), [])
 
-    const positiveStepTotal = sum(
-      stepValues.map(d => (d[yProp] > 0 ? d[yProp] : 0))
+    const positiveStepTotal = sum(stepValues, (d) =>
+      d[yProp] > 0 ? d[yProp] : 0
     )
-    const negativeStepTotal = sum(
-      stepValues.map(d => (d[yProp] < 0 ? d[yProp] : 0))
+    const negativeStepTotal = sum(stepValues, (d) =>
+      d[yProp] < 0 ? d[yProp] : 0
     )
 
     stepValues.forEach(l => {

--- a/src/components/svg/pieceLayouts.tsx
+++ b/src/components/svg/pieceLayouts.tsx
@@ -430,7 +430,7 @@ export function barLayout({
     const ordset = data[key]
     const barColumnWidth = Math.max(ordset.width, 1)
 
-    const calculatedPieces = ordset.pieceData.map((piece, i) => {
+    ordset.pieceData.forEach((piece, i) => {
       const pieceSize = piece.scaledValue
       const renderValue = renderMode && renderMode(piece.data, i)
 
@@ -553,15 +553,13 @@ export function barLayout({
         }
       )
 
-      const calculatedPiece = {
+      allCalculatedPieces.push({
         o: key,
         xy,
         piece,
         renderElement: renderElementObject
-      }
-      return calculatedPiece
+      })
     })
-    allCalculatedPieces = [...allCalculatedPieces, ...calculatedPieces]
   })
 
   return allCalculatedPieces

--- a/src/components/svg/summaryLayouts.tsx
+++ b/src/components/svg/summaryLayouts.tsx
@@ -1454,7 +1454,7 @@ export function bucketizedRenderingFn({
         }
       }
 
-      multiBins = multiBins.filter((d) => sum(d.map((p) => p.value)) > 0)
+      multiBins = multiBins.filter((d) => sum(d, (p) => p.value) > 0)
 
       horizonBins.forEach((summaryPoint, i) => {
         if (i !== 0 && i !== horizonBins.length - 1) {


### PR DESCRIPTION
There are some charts I'm testing this stuff on, and I'm seeing some significant boost for OrdinalFrame simply by reducing the amount of GC cycles the browser need to get through:

https://github.com/nteract/semiotic/commit/bd1dae92b46b570f0d6805192553a8f4060032f1 Pretty basic, not really that significant, but may be good to have for some edge cases where the array to sum is quite long.

https://github.com/nteract/semiotic/commit/f6dd89d61b86cae64402f7b79262408494a9874b This one is quite huge, it boosts `barLayout()` at least x3 on what I've tested it for. Making small slices via map and then adding them to the rest of items (both via spread and concat) producing too many GC cycles to free up the memory allocated for the map. Instead, we can push all the values directly to the resulting array.
