### PR TITLE
SVG notes on annotations can cause rerender issues

### DIFF
--- a/src/components/AnnotationLayer.tsx
+++ b/src/components/AnnotationLayer.tsx
@@ -57,6 +57,9 @@ function safeStringify(value) {
         return "..."
       }
       seen.add(v)
+      if (k === "note") {
+        return v.label
+      }
     }
     return v
   })


### PR DESCRIPTION
Due to the way we track dependencies on the `useEffect` in `AnnotationLayer` we can experience unnecessary rerenders if a user declares an SVG node as a note.