### PR TITLE
Use redux for direct communication for tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,8 @@
     "object-assign": "4.1.1",
     "polygon-offset": "0.3.1",
     "react-annotation": "3.0.0-beta.4",
+    "react-redux": "^8.0.2",
+    "redux": "^4.2.0",
     "regression": "^2.0.1",
     "semiotic-mark": "0.5.0",
     "svg-path-bounding-box": "1.0.4"

--- a/src/components/InteractionLayer.tsx
+++ b/src/components/InteractionLayer.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import { useState, useEffect } from "react"
 import { brushX, brushY, brush } from "d3-brush"
 import { select } from "d3-selection"
+import { useDispatch } from "react-redux"
 
 // components
 import Brush from "./Brush"
@@ -391,10 +392,18 @@ export default function InteractionLayer(props: InteractionLayerProps) {
     customDoubleClickBehavior,
     customHoverBehavior,
     disableCanvasInteraction,
-    canvasRendering,
-    voronoiHover
+    canvasRendering
+    //    voronoiHover
   } = props
   let { enabled } = props
+
+  const dispatch = useDispatch()
+  const voronoiHover = (d) => {
+    dispatch({
+      type: "CHANGE_TOOLTIP",
+      tooltip: d
+    })
+  }
 
   const [overlayRegions, changeOverlayRegions] = useState([])
   const [interactionCanvas, changeInteractionCanvas] = useState(null)
@@ -407,7 +416,7 @@ export default function InteractionLayer(props: InteractionLayerProps) {
       nextOverlay = null
       interactionCanvas = null
     } else {
-      nextOverlay = calculateOverlay(props)
+      nextOverlay = calculateOverlay(props, voronoiHover)
       if (canvasRendering) {
         interactionCanvas = (
           <InteractionCanvas

--- a/src/components/VisualizationLayer.tsx
+++ b/src/components/VisualizationLayer.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { RefObject, useEffect, useState } from "react"
+import { useDispatch } from "react-redux"
 
 import {
   MarginType,
@@ -26,7 +27,6 @@ type Props = {
   ariaTitle?: string
   matte?: React.ReactNode
   matteClip?: boolean
-  voronoiHover: Function
   renderPipeline: RenderPipelineType
   baseMarkProps?: object
   projectedCoordinateNames: object
@@ -69,7 +69,11 @@ type State = {
   handleKeyDown: Function
 }
 
-const updateVisualizationLayer = (props: Props, handleKeyDown: Function) => {
+const updateVisualizationLayer = (
+  props: Props,
+  handleKeyDown: Function,
+  voronoiHover: Function
+) => {
   const {
     xScale,
     yScale,
@@ -134,7 +138,7 @@ const updateVisualizationLayer = (props: Props, handleKeyDown: Function) => {
             }
             onKeyDown={(e) => handleKeyDown({ e, k, props, piecesGroup })}
             onBlur={() => {
-              props.voronoiHover(undefined)
+              voronoiHover(undefined)
             }}
             ref={(thisNode) =>
               thisNode && (piecesGroup[k] = thisNode.childNodes)
@@ -213,6 +217,14 @@ export default function VisualizationLayer(props: Props) {
     additionalVizElements
   } = props
 
+  const dispatch = useDispatch()
+  const voronoiHover = (d) => {
+    dispatch({
+      type: "CHANGE_TOOLTIP",
+      tooltip: d
+    })
+  }
+
   const [focusedPieceIndex, changeFocusedPieceIndex] = useState(null)
   const [focusedVisualizationGroup, changeFocusedVisualizationGroup] =
     useState(null)
@@ -222,7 +234,11 @@ export default function VisualizationLayer(props: Props) {
     changeFocusedVisualizationGroup
   })
 
-  const vizState = updateVisualizationLayer(props, decoratedKeydown)
+  const vizState = updateVisualizationLayer(
+    props,
+    decoratedKeydown,
+    voronoiHover
+  )
 
   const { renderedElements } = vizState
 

--- a/src/components/processing/InteractionItems.tsx
+++ b/src/components/processing/InteractionItems.tsx
@@ -115,7 +115,10 @@ export const brushEnd = (
     interaction.end(e, columnName, data, columnData)
 }
 
-export const calculateOverlay = (props: InteractionLayerProps) => {
+export const calculateOverlay = (
+  props: InteractionLayerProps,
+  voronoiHover: Function
+) => {
   let voronoiPaths = []
   const {
     xScale,
@@ -130,7 +133,6 @@ export const calculateOverlay = (props: InteractionLayerProps) => {
     customDoubleClickBehavior,
     customHoverBehavior,
     hoverAnnotation,
-    voronoiHover,
     margin,
     advancedSettings = {}
   } = props

--- a/src/components/reducers/annotation.ts
+++ b/src/components/reducers/annotation.ts
@@ -1,0 +1,13 @@
+const baseState = {
+  tooltip: null
+}
+
+export default (state = baseState, action) => {
+  const { type, tooltip } = action
+
+  if (type === "CHANGE_TOOLTIP") {
+    return { ...state, tooltip }
+  }
+
+  return state
+}

--- a/src/components/reducers/index.ts
+++ b/src/components/reducers/index.ts
@@ -1,0 +1,17 @@
+import annotation from "./annotation"
+
+export interface DEXState {
+  annotation?: any
+}
+
+type FlagsState = {
+  enableScopedFilters: boolean
+  enableNewGridImplementation: boolean
+  enableNewChartExportMethod: boolean
+}
+
+export default function reducers(state: DEXState = {}, action) {
+  return {
+    annotation: annotation(state.annotation, action)
+  }
+}

--- a/src/components/types/interactionTypes.ts
+++ b/src/components/types/interactionTypes.ts
@@ -48,7 +48,6 @@ export type InteractionLayerProps = {
   customDoubleClickBehavior?: Function
   customClickBehavior?: Function
   customHoverBehavior?: Function
-  voronoiHover: Function
   canvasRendering?: boolean
   disableCanvasInteraction: boolean
   showLinePoints?: string


### PR DESCRIPTION
I've resisted adding Redux to the project but passing down the tooltip function causes so much trouble and direct communication between `InteractionLayer`, `VisualizationLayer` and `AnnotationLayer` for tooltips is so much more sensible and performant.