### PR TITLE
Show arrows on solid sankey edges

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "d3-hexbin": "^0.2.2",
     "d3-hierarchy": "^1.1.3",
     "d3-interpolate": "^1.1.5",
+    "d3-path-arrows": "^0.4.0",
     "d3-polygon": "^1.0.5",
     "d3-sankey-circular": "0.25.0",
     "d3-scale": "^1.0.3",

--- a/src/components/svg/networkDrawing.tsx
+++ b/src/components/svg/networkDrawing.tsx
@@ -201,6 +201,7 @@ export const arcEdgeGenerator = (size) => {
 const ArrowedPath = (props) => {
   const { d, width } = props
   const pathRef = useRef(null)
+
   useEffect(() => {
     if (pathRef?.current) {
       const arrowHeadSize = Math.max(width / 5, 2)
@@ -208,7 +209,9 @@ const ArrowedPath = (props) => {
         .arrowLength(arrowHeadSize * 2.5)
         .gapLength(100)
         .arrowHeadSize(arrowHeadSize)
-        .path(() => d)
+        .path(d)
+
+      select(pathRef.current).selectAll("*").remove()
 
       select(pathRef.current).call(arrows)
 
@@ -220,7 +223,7 @@ const ArrowedPath = (props) => {
 
       select(pathRef.current).selectAll(".arrow-head").style("fill", "white")
     }
-  }, [!!pathRef?.current])
+  }, [d])
 
   return <g ref={pathRef} />
 }

--- a/src/components/types/networkTypes.ts
+++ b/src/components/types/networkTypes.ts
@@ -37,15 +37,20 @@ export interface NodeType {
 }
 
 export interface EdgeType {
+  circular?: boolean
+  circularPathData?: any
   source?: NodeType
   target?: NodeType
   d?: string
   x?: number
   y?: number
+  y0?: number
+  y1?: number
   sankeyWidth?: number
   direction?: string
   width?: number
   points?: Array<{ x: number; y: number }>
+  showArrows?: boolean
 }
 
 export interface GraphSettingsType {
@@ -96,8 +101,12 @@ export interface NetworkSettingsType {
   sortGroups?: Function
   simulation?: Function
   sort?: (a: GenericObject, b: GenericObject) => number
-  zoom?: boolean | "stretch" | ((nodes: NodeType[], size: number[]) => void)
+  zoom?:
+    | boolean
+    | "stretch"
+    | ((nodes: NodeType[], edges: EdgeType[], size: number[]) => void)
   fixExistingNodes?: boolean | Function
+  showArrows?: boolean
 }
 
 export interface NetworkFrameState extends GeneralFrameState {

--- a/src/docs/components/Sankey.js
+++ b/src/docs/components/Sankey.js
@@ -2,8 +2,8 @@ import * as React from "react"
 import DocumentComponent from "../layout/DocumentComponent"
 import SankeyRaw from "./SankeyRaw"
 import Select from "@material-ui/core/Select"
-import MenuItem from '@material-ui/core/MenuItem'
-import InputLabel from '@material-ui/core/InputLabel'
+import MenuItem from "@material-ui/core/MenuItem"
+import InputLabel from "@material-ui/core/InputLabel"
 import FormControl from "@material-ui/core/FormControl"
 
 const components = []
@@ -25,19 +25,19 @@ export default class Sankey extends React.Component {
   }
 
   render() {
-    const typeOptions = ["sankey", "force", "chord"].map(d => (
+    const typeOptions = ["sankey", "force", "chord"].map((d) => (
       <MenuItem key={`type-option-${d}`} label={d} value={d}>
         {d}
       </MenuItem>
     ))
 
-    const directionOptions = ["horizontal", "vertical"].map(d => (
+    const directionOptions = ["horizontal", "vertical"].map((d) => (
       <MenuItem key={`direction-option-${d}`} label={d} value={d}>
         {d}
       </MenuItem>
     ))
 
-    const orientOptions = ["justify", "left", "right", "center"].map(d => (
+    const orientOptions = ["justify", "left", "right", "center"].map((d) => (
       <MenuItem key={`orient-option-${d}`} label={d} value={d}>
         {d}
       </MenuItem>
@@ -48,7 +48,7 @@ export default class Sankey extends React.Component {
         <InputLabel htmlFor="chart-type-input">Chart Type</InputLabel>
         <Select
           value={this.state.type}
-          onChange={e => this.setState({ type: e.target.value })}
+          onChange={(e) => this.setState({ type: e.target.value })}
         >
           {typeOptions}
         </Select>
@@ -57,7 +57,7 @@ export default class Sankey extends React.Component {
         <InputLabel htmlFor="orient-input">orient</InputLabel>
         <Select
           value={this.state.orient}
-          onChange={e => this.setState({ orient: e.target.value })}
+          onChange={(e) => this.setState({ orient: e.target.value })}
         >
           {orientOptions}
         </Select>
@@ -66,7 +66,7 @@ export default class Sankey extends React.Component {
         <InputLabel htmlFor="orient-input">direction</InputLabel>
         <Select
           value={this.state.direction}
-          onChange={e => this.setState({ direction: e.target.value })}
+          onChange={(e) => this.setState({ direction: e.target.value })}
         >
           {directionOptions}
         </Select>
@@ -100,87 +100,9 @@ export default class Sankey extends React.Component {
     examples.push({
       name: "With Cycles",
       demo: SankeyRaw({
-        annotations,
-        type: this.state.type,
-        orient: this.state.orient,
-        cyclical: true,
-        direction: this.state.direction
+        direction: "off"
       }),
-      source: `
-const or_data = [{"id":"Agricultural 'waste'","input":0,"output":262.6972158,"years":[9.282517755,14.61107771,30.99950457,31.97585802,32.98811297,34.0375862,35.12564273,36.2536977,37.42321811],"category":"Agriculture","color":"#4d430c"},
-  {"id":"Wave","input":0,"output":0.95365274,"years":[0,0.003002055,0.158441781,0.396104452,0.396104452,0,0,0,0],"category":"Alternative","color":"#b3331d"},
-  {"id":"Tidal","input":0,"output":0.325222603,"years":[0.005003425,0.020013699,0.050034247,0.125085616,0.125085616,0,0,0,0],"category":"Alternative","color":"#b3331d"}
-  ...]
-
-const network_data = [
-  {"2010":127.93,"2015":127.93,"2020":127.93,"2025":127.93,"2030":63.965,"2035":63.965,"2040":63.965,"2045":63.965,"2050":63.965,"source":"Coal reserves","target":"Coal","total":831.545,"value":831.545},
-  {"2010":349.7879708,"2015":296.3632186,"2020":211.2161187,"2025":77.82581145,"2030":35.20638477,"2035":19.10842823,"2040":22.86599313,"2045":26.79703903,"2050":31.37680448,"source":"Coal imports","target":"Coal","total":1070.547769,"value":1070.547769},
-  {"2010":802.5479528,"2015":646.8288435,"2020":501.7889501,"2025":388.2747242,"2030":300.4395801,"2035":232.47442,"2040":179.8842746,"2045":139.1910227,"2050":107.70336,"source":"Oil reserves","target":"Oil","total":3299.133128,"value":3299.133128},
-...]
-
-${
-        this.state.type === "chord"
-          ? `const mirroredNetworkData = [
-    ...network_data.map(d => ({ source: d.source.id, target: d.target.id, value: d["2010"] })),
-    ...network_data.map(d => ({ target: d.source.id, source: d.target.id, value: d["2050"] }))
-    ]`
-          : ""
-        }
-
-const colors = {
-  Oil: "#b3331d",
-  Gas: "rgb(182, 167, 86)",
-  Coal: "#00a2ce",
-  Other: "grey"
-}
-
-const areaLegendGroups = [
-  {
-    styleFn: d => ({ fill: colors[d.label], stroke: "black" }),
-    items: [
-      { label: "Oil" },
-      { label: "Gas" },
-      { label: "Coal" },
-      { label: "Other" }
-    ]
-  }
-]
-
-<NetworkFrame
-  size={[ 700,400 ]}
-  nodes={or_data}
-  edges={${
-        this.state.type === "chord" ? "mirroredNetworkData" : "network_data"
-        }}
-  nodeStyle={d => ({
-    fill: colors[d.category],
-    stroke: "black"
-  })}
-  edgeStyle={d => ({
-    stroke: "grey",
-    fill: colors[d.source.category],
-    strokeWidth: 0.5,
-    fillOpacity: 0.75,
-    strokeOpacity: 0.75
-  })}
-  nodeIDAccessor="id"
-  sourceAccessor="source"
-  targetAccessor="target"
-  ${this.state.type === "force" ? "nodeSizeAccessor={5}" : ""}
-  ${this.state.type === "force" ? 'edgeType={"arrowhead"}' : ""}
-  hoverAnnotation={true}
-  ${this.state.type === "chord" ? "edgeWidthAccessor={d => d.value}" : ""}
-  networkType={{ type: ${this.state.type}, orient: ${
-        this.state.orient
-        }, iterations: 500 }}
-  annotations={[ { type: 'node', dy: 0, dx: 100, id: 'International aviation', label: 'Energy spent on international aviation' }
-  ,{ type: 'node', dy: 0, dx: 50, id: 'Oil', label: 'Big Oil' }
-  ,{ type: 'enclose', dy: -100, dx: 50, ids: [ 'Wave', 'Geothermal', 'Hydro', 'Tidal' ], label: 'Energy made with wave, tidal, hydro and geothermal' }
-  ]}
-  legend={{ legendGroups: areaLegendGroups }}
-  margin={{ right: 130 }}
-/>
-`
+      source: ``
     })
     examples.push({
       name: "downward",

--- a/src/docs/components/SankeyRaw.js
+++ b/src/docs/components/SankeyRaw.js
@@ -4,12 +4,12 @@ import { network_data, or_data } from "../sampledata/energy_time"
 import { sankey } from "d3-sankey"
 
 const mirroredNetworkData = [
-  ...network_data.map(d => ({
+  ...network_data.map((d) => ({
     source: d.source.id ? d.source.id : d.source,
     target: d.target.id ? d.target.id : d.target,
     value: d["2010"]
   })),
-  ...network_data.map(d => ({
+  ...network_data.map((d) => ({
     target: d.source.id ? d.source.id : d.source,
     source: d.target.id ? d.target.id : d.target,
     value: d["2050"]
@@ -45,7 +45,7 @@ const colors = {
 
 const areaLegendGroups = [
   {
-    styleFn: d => ({ fill: colors[d.label], stroke: "black" }),
+    styleFn: (d) => ({ fill: colors[d.label], stroke: "black" }),
     items: [
       { label: "Oil" },
       { label: "Gas" },
@@ -63,20 +63,20 @@ export default ({
   direction,
   size = [700, 400]
 }) => {
-  const sankeyChart = {
+  let sankeyChart = {
     size: size,
-    nodes: or_data.map(d => Object.assign({}, d)),
+    nodes: or_data.map((d) => Object.assign({}, d)),
     edges:
       type === "chord"
         ? mirroredNetworkData
         : cyclical
-          ? cyclicalData
-          : network_data,
-    nodeStyle: d => ({
+        ? cyclicalData
+        : network_data,
+    nodeStyle: (d) => ({
       fill: colors[d.category],
       stroke: "black"
     }),
-    edgeStyle: d => ({
+    edgeStyle: (d) => ({
       stroke: "black",
       fill: colors[d.source.category],
       strokeWidth: 0.5,
@@ -94,7 +94,11 @@ export default ({
       iterations: 500,
       direction,
       nodePaddingRatio: 0.05,
-      edgeSort: cyclical ? undefined : ((a, b) => { return a.value - b.value }),
+      edgeSort: cyclical
+        ? undefined
+        : (a, b) => {
+            return a.value - b.value
+          },
       customSankey: sankey
     },
     legend: { legendGroups: areaLegendGroups },
@@ -102,7 +106,215 @@ export default ({
   }
 
   if (type === "chord") {
-    sankeyChart.edgeWidthAccessor = d => d.value
+    sankeyChart.edgeWidthAccessor = (d) => d.value
+  }
+
+  sankeyChart = {
+    edges: [
+      {
+        id: "login-shop-California-California",
+        key: "login-shop-California-California",
+        _NWFEdgeKey: "login-shop-California-California",
+        source: "login",
+        target: "shop",
+        group: "California",
+        value: 82
+      },
+      {
+        id: "home-error-California-California",
+        key: "home-error-California-California",
+        _NWFEdgeKey: "home-error-California-California",
+        source: "home",
+        target: "error",
+        group: "California",
+        value: 2
+      },
+      {
+        id: "home-login-California-California",
+        key: "home-login-California-California",
+        _NWFEdgeKey: "home-login-California-California",
+        source: "home",
+        target: "login",
+        group: "California",
+        value: 221
+      },
+      {
+        id: "home-login-Colorado-Colorado",
+        key: "home-login-Colorado-Colorado",
+        _NWFEdgeKey: "home-login-Colorado-Colorado",
+        source: "home",
+        target: "login",
+        group: "Colorado",
+        value: 133
+      },
+      {
+        id: "home-shop-Colorado-Colorado",
+        key: "home-shop-Colorado-Colorado",
+        _NWFEdgeKey: "home-shop-Colorado-Colorado",
+        source: "home",
+        target: "shop",
+        group: "Colorado",
+        value: 50
+      },
+      {
+        id: "home-cart-Colorado-Colorado",
+        key: "home-cart-Colorado-Colorado",
+        _NWFEdgeKey: "home-cart-Colorado-Colorado",
+        source: "home",
+        target: "cart",
+        group: "Colorado",
+        value: 27
+      },
+      {
+        id: "cart-checkout-Colorado-Colorado",
+        key: "cart-checkout-Colorado-Colorado",
+        _NWFEdgeKey: "cart-checkout-Colorado-Colorado",
+        source: "cart",
+        target: "checkout",
+        group: "Colorado",
+        value: 107
+      },
+      {
+        id: "cart-login-Colorado-Colorado",
+        key: "cart-login-Colorado-Colorado",
+        _NWFEdgeKey: "cart-login-Colorado-Colorado",
+        source: "cart",
+        target: "login",
+        group: "Colorado",
+        value: 34
+      },
+      {
+        id: "checkout-login-California-California",
+        key: "checkout-login-California-California",
+        _NWFEdgeKey: "checkout-login-California-California",
+        source: "checkout",
+        target: "login",
+        group: "California",
+        value: 138
+      },
+      {
+        id: "home-login-Colombia-Colombia",
+        key: "home-login-Colombia-Colombia",
+        _NWFEdgeKey: "home-login-Colombia-Colombia",
+        source: "home",
+        target: "login",
+        group: "Colombia",
+        value: 3
+      },
+      {
+        id: "home-checkout-Colombia-Colombia",
+        key: "home-checkout-Colombia-Colombia",
+        _NWFEdgeKey: "home-checkout-Colombia-Colombia",
+        source: "home",
+        target: "checkout",
+        group: "Colombia",
+        value: 20
+      },
+      {
+        id: "home-cart-Colombia-Colombia",
+        key: "home-cart-Colombia-Colombia",
+        _NWFEdgeKey: "home-cart-Colombia-Colombia",
+        source: "home",
+        target: "cart",
+        group: "Colombia",
+        value: 21
+      },
+      {
+        id: "home-home-Colombia-Colombia",
+        key: "home-home-Colombia-Colombia",
+        _NWFEdgeKey: "home-home-Colombia-Colombia",
+        source: "home",
+        target: "home",
+        group: "Colombia",
+        value: 92
+      },
+      {
+        id: "home-error-Colombia-Colombia",
+        key: "home-error-Colombia-Colombia",
+        _NWFEdgeKey: "home-error-Colombia-Colombia",
+        source: "home",
+        target: "error",
+        group: "Colombia",
+        value: 35
+      },
+      {
+        id: "checkout-login-Colorado-Colorado",
+        key: "checkout-login-Colorado-Colorado",
+        _NWFEdgeKey: "checkout-login-Colorado-Colorado",
+        source: "checkout",
+        target: "login",
+        group: "Colorado",
+        value: 53
+      },
+      {
+        id: "shop-cart-Colorado-Colorado",
+        key: "shop-cart-Colorado-Colorado",
+        _NWFEdgeKey: "shop-cart-Colorado-Colorado",
+        source: "shop",
+        target: "cart",
+        group: "Colorado",
+        value: 99
+      },
+      {
+        id: "shop-login-Colorado-Colorado",
+        key: "shop-login-Colorado-Colorado",
+        _NWFEdgeKey: "shop-login-Colorado-Colorado",
+        source: "shop",
+        target: "login",
+        group: "Colorado",
+        value: 50
+      },
+      {
+        id: "shop-checkout-Colorado-Colorado",
+        key: "shop-checkout-Colorado-Colorado",
+        _NWFEdgeKey: "shop-checkout-Colorado-Colorado",
+        source: "shop",
+        target: "checkout",
+        group: "Colorado",
+        value: 21
+      },
+      {
+        id: "cart-checkout-Colombia-Colombia",
+        key: "cart-checkout-Colombia-Colombia",
+        _NWFEdgeKey: "cart-checkout-Colombia-Colombia",
+        source: "cart",
+        target: "checkout",
+        group: "Colombia",
+        value: 69
+      },
+      {
+        id: "cart-OLD_CHECKOUT-Colombia-Colombia",
+        key: "cart-OLD_CHECKOUT-Colombia-Colombia",
+        _NWFEdgeKey: "cart-OLD_CHECKOUT-Colombia-Colombia",
+        source: "cart",
+        target: "OLD_CHECKOUT",
+        group: "Colombia",
+        value: 9
+      }
+    ],
+    networkType: {
+      type: "sankey",
+      showArrows: true,
+      zoom: direction === "off" ? false : undefined
+    },
+    nodeStyle: {
+      fill: "#005066",
+      stroke: "none"
+    },
+    edgeStyle: {
+      fill: "blue",
+      opacity: 0.5
+    },
+    size: [700, 500],
+    margin: {
+      left: 10,
+      top: 10,
+      bottom: 10,
+      right: 10
+    },
+    baseMarkProps: {
+      forceUpdate: true
+    }
   }
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -4240,6 +4240,14 @@ d3-interpolate@1, d3-interpolate@^1.1.5:
   dependencies:
     d3-color "1 - 2"
 
+d3-path-arrows@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/d3-path-arrows/-/d3-path-arrows-0.4.0.tgz#b1dfd47425e339a687721ffc0b3131ccd8b3220e"
+  integrity sha512-L0N4QvV+TVR6suxVcGaSWtnoOmlwHAdK4cAZylc2t8lS+sQR3/LYkRhkNYdQa4eRsWw+4XKklIYEv+ljLQxH4Q==
+  dependencies:
+    d3-array "^1.2.1"
+    d3-selection "^1.1.0"
+
 d3-path@1:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
@@ -4295,6 +4303,11 @@ d3-selection@2:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-2.0.0.tgz#94a11638ea2141b7565f883780dabc7ef6a61066"
   integrity sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==
+
+d3-selection@^1.1.0:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.2.tgz#dcaa49522c0dbf32d6c1858afc26b6094555bc5c"
+  integrity sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==
 
 d3-shape@^1.2.0, d3-shape@^1.3.5:
   version "1.3.7"


### PR DESCRIPTION
The circular sankey layout isn't great at sizing to fit the existing space and this corrects it by adjusting the sankey edges and nodes in the zoom phase in network frame. But it adjusts the datapoints themselves and d3-circular-sankey has already calculated the edge `d` values for SVG `path` elements.

The edges drawn by `d3-sankey-circular` are meant to be paths where stroke-width encodes the flow, which has its strengths and weaknesses. The edges in Semiotic are areas. The main problem is that you can't get arrows drawn over areas (because the arrow code is based on the line which for stroke-encoding is the middle of the path but for area encoding it's the perimeter) so this adds an option to `networkSettings` called `showArrows` and draws arrows on top of the paths if it's set to true.
<img width="654" alt="Screen Shot 2022-08-21 at 12 57 51 PM" src="https://user-images.githubusercontent.com/495634/185808999-ca577aa2-f702-4b74-a2fa-b4f510f1b965.png">

