### PR TITLE
Scope allowed files for publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "dist/semiotic.d.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist/semiotic.*"
   ],
   "scripts": {
     "start": "parcel serve --target docs",


### PR DESCRIPTION
To avoid accidental publish of other working files.