### PR TITLE
fix theming

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -27,6 +27,8 @@
 **QuadrantChart** — Scatterplot + `quadrants` (required), `xCenter`, `yCenter`
 **MultiAxisLineChart** — Dual Y-axis. `series` (required: `[{ yAccessor, label?, color?, format?, extent? }]`). Falls back to multi-line if not 2 series.
 **Heatmap** — `data`, `xAccessor`, `yAccessor`, `valueAccessor`, `colorScheme`, `showValues`, `cellBorderColor`
+**ScatterplotMatrix** — `data`, `fields` (array of numeric field names for grid)
+**MinimapChart** — Overview + detail with linked zoom. Wraps an XY chart.
 
 ## Ordinal Charts (`semiotic/ordinal`)
 
@@ -150,7 +152,7 @@ All HOCs accept `annotations` (array). Coordinates use data field names.
 
 ## Theming
 
-CSS custom properties: `--semiotic-bg`, `--semiotic-text`, `--semiotic-text-secondary`, `--semiotic-border`, `--semiotic-grid`, `--semiotic-primary`, `--semiotic-focus`, `--semiotic-font-family`, `--semiotic-tooltip-bg`/`text`/`radius`/`font-size`/`shadow`.
+CSS custom properties: `--semiotic-bg`, `--semiotic-text`, `--semiotic-text-secondary`, `--semiotic-border`, `--semiotic-grid`, `--semiotic-primary`, `--semiotic-focus`, `--semiotic-font-family`, `--semiotic-annotation-color`, `--semiotic-legend-font-size`, `--semiotic-title-font-size`, `--semiotic-tick-font-family`, `--semiotic-tooltip-bg`/`text`/`radius`/`font-size`/`shadow`.
 
 ```jsx
 <ThemeProvider theme="tufte">       {/* Named preset */}

--- a/.cursorrules
+++ b/.cursorrules
@@ -27,6 +27,8 @@
 **QuadrantChart** — Scatterplot + `quadrants` (required), `xCenter`, `yCenter`
 **MultiAxisLineChart** — Dual Y-axis. `series` (required: `[{ yAccessor, label?, color?, format?, extent? }]`). Falls back to multi-line if not 2 series.
 **Heatmap** — `data`, `xAccessor`, `yAccessor`, `valueAccessor`, `colorScheme`, `showValues`, `cellBorderColor`
+**ScatterplotMatrix** — `data`, `fields` (array of numeric field names for grid)
+**MinimapChart** — Overview + detail with linked zoom. Wraps an XY chart.
 
 ## Ordinal Charts (`semiotic/ordinal`)
 
@@ -150,7 +152,7 @@ All HOCs accept `annotations` (array). Coordinates use data field names.
 
 ## Theming
 
-CSS custom properties: `--semiotic-bg`, `--semiotic-text`, `--semiotic-text-secondary`, `--semiotic-border`, `--semiotic-grid`, `--semiotic-primary`, `--semiotic-focus`, `--semiotic-font-family`, `--semiotic-tooltip-bg`/`text`/`radius`/`font-size`/`shadow`.
+CSS custom properties: `--semiotic-bg`, `--semiotic-text`, `--semiotic-text-secondary`, `--semiotic-border`, `--semiotic-grid`, `--semiotic-primary`, `--semiotic-focus`, `--semiotic-font-family`, `--semiotic-annotation-color`, `--semiotic-legend-font-size`, `--semiotic-title-font-size`, `--semiotic-tick-font-family`, `--semiotic-tooltip-bg`/`text`/`radius`/`font-size`/`shadow`.
 
 ```jsx
 <ThemeProvider theme="tufte">       {/* Named preset */}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,6 +27,8 @@
 **QuadrantChart** — Scatterplot + `quadrants` (required), `xCenter`, `yCenter`
 **MultiAxisLineChart** — Dual Y-axis. `series` (required: `[{ yAccessor, label?, color?, format?, extent? }]`). Falls back to multi-line if not 2 series.
 **Heatmap** — `data`, `xAccessor`, `yAccessor`, `valueAccessor`, `colorScheme`, `showValues`, `cellBorderColor`
+**ScatterplotMatrix** — `data`, `fields` (array of numeric field names for grid)
+**MinimapChart** — Overview + detail with linked zoom. Wraps an XY chart.
 
 ## Ordinal Charts (`semiotic/ordinal`)
 
@@ -150,7 +152,7 @@ All HOCs accept `annotations` (array). Coordinates use data field names.
 
 ## Theming
 
-CSS custom properties: `--semiotic-bg`, `--semiotic-text`, `--semiotic-text-secondary`, `--semiotic-border`, `--semiotic-grid`, `--semiotic-primary`, `--semiotic-focus`, `--semiotic-font-family`, `--semiotic-tooltip-bg`/`text`/`radius`/`font-size`/`shadow`.
+CSS custom properties: `--semiotic-bg`, `--semiotic-text`, `--semiotic-text-secondary`, `--semiotic-border`, `--semiotic-grid`, `--semiotic-primary`, `--semiotic-focus`, `--semiotic-font-family`, `--semiotic-annotation-color`, `--semiotic-legend-font-size`, `--semiotic-title-font-size`, `--semiotic-tick-font-family`, `--semiotic-tooltip-bg`/`text`/`radius`/`font-size`/`shadow`.
 
 ```jsx
 <ThemeProvider theme="tufte">       {/* Named preset */}

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -27,6 +27,8 @@
 **QuadrantChart** — Scatterplot + `quadrants` (required), `xCenter`, `yCenter`
 **MultiAxisLineChart** — Dual Y-axis. `series` (required: `[{ yAccessor, label?, color?, format?, extent? }]`). Falls back to multi-line if not 2 series.
 **Heatmap** — `data`, `xAccessor`, `yAccessor`, `valueAccessor`, `colorScheme`, `showValues`, `cellBorderColor`
+**ScatterplotMatrix** — `data`, `fields` (array of numeric field names for grid)
+**MinimapChart** — Overview + detail with linked zoom. Wraps an XY chart.
 
 ## Ordinal Charts (`semiotic/ordinal`)
 
@@ -150,7 +152,7 @@ All HOCs accept `annotations` (array). Coordinates use data field names.
 
 ## Theming
 
-CSS custom properties: `--semiotic-bg`, `--semiotic-text`, `--semiotic-text-secondary`, `--semiotic-border`, `--semiotic-grid`, `--semiotic-primary`, `--semiotic-focus`, `--semiotic-font-family`, `--semiotic-tooltip-bg`/`text`/`radius`/`font-size`/`shadow`.
+CSS custom properties: `--semiotic-bg`, `--semiotic-text`, `--semiotic-text-secondary`, `--semiotic-border`, `--semiotic-grid`, `--semiotic-primary`, `--semiotic-focus`, `--semiotic-font-family`, `--semiotic-annotation-color`, `--semiotic-legend-font-size`, `--semiotic-title-font-size`, `--semiotic-tick-font-family`, `--semiotic-tooltip-bg`/`text`/`radius`/`font-size`/`shadow`.
 
 ```jsx
 <ThemeProvider theme="tufte">       {/* Named preset */}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ All HOCs accept `annotations` (array). Coordinates use data field names.
 
 ## Theming
 
-CSS custom properties: `--semiotic-bg`, `--semiotic-text`, `--semiotic-text-secondary`, `--semiotic-border`, `--semiotic-grid`, `--semiotic-primary`, `--semiotic-focus`, `--semiotic-font-family`, `--semiotic-tooltip-bg`/`text`/`radius`/`font-size`/`shadow`.
+CSS custom properties: `--semiotic-bg`, `--semiotic-text`, `--semiotic-text-secondary`, `--semiotic-border`, `--semiotic-grid`, `--semiotic-primary`, `--semiotic-focus`, `--semiotic-font-family`, `--semiotic-annotation-color`, `--semiotic-legend-font-size`, `--semiotic-title-font-size`, `--semiotic-tick-font-family`, `--semiotic-tooltip-bg`/`text`/`radius`/`font-size`/`shadow`.
 
 ```jsx
 <ThemeProvider theme="tufte">       {/* Named preset */}

--- a/OUTSTANDING_WORK.md
+++ b/OUTSTANDING_WORK.md
@@ -1,264 +1,121 @@
 # Outstanding Work
 
-Last updated 2026-04-08.
+Last updated 2026-04-12.
 
 ---
 
-## Rounded Corners
+## Completed in 3.3.x (reference)
 
-**Status**: Pie/donut `cornerRadius` DONE. Bar/StackedBar `roundedTop` DONE (topmost segment only). GroupedBar `roundedTop` not yet implemented. Negative-value bar rounding not yet handled (rounds top regardless of sign direction).
-
-### What
-
-Optional rounded corners on:
-1. **Pie/donut wedges** — `cornerRadius` on PieChart/DonutChart/GaugeChart. Rounds the outer corners of each wedge arc.
-2. **Bar chart tops** — `roundedTop` on BarChart. Rounds only the top two corners of each bar (the end away from the baseline). Bottom stays flush with the axis.
-3. **Stacked bar top piece** — Only the topmost bar segment in a stack gets rounded corners. Interior segments stay rectangular so they stack cleanly.
-4. **RealtimeHistogram** — Same as stacked bar — only the top bin gets rounded.
-
-### Prop API
-
-```tsx
-<PieChart cornerRadius={8} />
-<DonutChart cornerRadius={6} />
-<BarChart roundedTop={4} />         // pixel radius
-<StackedBarChart roundedTop={4} />  // only topmost segment
-<RealtimeHistogram roundedTop={4} />
-```
-
-### Technical approach
-
-**Pie/donut (d3-shape `arc.cornerRadius`)**:
-- d3-shape's `arc()` generator already supports `.cornerRadius(r)`. The scene builder (`pieScene.ts`) creates `WedgeSceneNode` with start/end angles and radii.
-- Add `cornerRadius?: number` to `WedgeSceneNode`.
-- In `wedgeCanvasRenderer.ts`: replace manual `ctx.arc()` calls with d3-shape `arc()` generator that respects `cornerRadius`. The generator produces a path string; use `Path2D` to render it on canvas.
-- In `SceneToSVG.tsx ordinalSceneNodeToSVG` wedge case: already uses `d3Arc()` — just chain `.cornerRadius(n.cornerRadius || 0)`.
-- `OrdinalPipelineConfig` gets `cornerRadius?: number`. PieChart/DonutChart HOC props expose it and pass through.
-
-**Bar chart tops (canvas rounded rect)**:
-- Add `roundedTop?: number` to `RectSceneNode` (or pass via style).
-- In `barCanvasRenderer.ts`: when `roundedTop` is set, draw a path with rounded top-left and top-right corners instead of `ctx.fillRect`. For horizontal bars, round the end corners (right side for LTR, left for negative values).
-- In `SceneToSVG.tsx` rect case: use `rx`/`ry` SVG attributes. SVG `<rect rx>` rounds all corners — for top-only, render as a `<path>` with explicit arc commands on the top two corners.
-- Scene builder (`barScene.ts`): propagate `roundedTop` from config to each `RectSceneNode`. For stacked bars, only the last (topmost) segment gets `roundedTop`; interior segments get `roundedTop: 0`.
-
-**Stacked bar / histogram**:
-- The ordinal scene builder produces rect nodes in category order. The topmost segment in a stack is the last rect node for that category.
-- After building all rects for a category, mark only the last one with `roundedTop`.
-- For `normalize` mode (100% stacked), the topmost segment touches the full extent — still only round the top.
-
-### Canvas helper
-
-```ts
-function roundedTopRect(
-  ctx: CanvasRenderingContext2D,
-  x: number, y: number, w: number, h: number,
-  radius: number
-): void {
-  const r = Math.min(radius, w / 2, h / 2)
-  ctx.beginPath()
-  ctx.moveTo(x, y + h)          // bottom-left
-  ctx.lineTo(x, y + r)          // left side up
-  ctx.arcTo(x, y, x + r, y, r) // top-left corner
-  ctx.lineTo(x + w - r, y)     // top edge
-  ctx.arcTo(x + w, y, x + w, y + r, r) // top-right corner
-  ctx.lineTo(x + w, y + h)     // right side down
-  ctx.closePath()
-}
-```
-
-### Effort
-
-Medium (3-4 days):
-- Pie/donut cornerRadius: 0.5 day (d3-shape already supports it)
-- Bar roundedTop canvas renderer: 1 day
-- Bar roundedTop SVG renderer: 0.5 day
-- Stacked bar topmost-only logic: 0.5 day
-- HOC prop wiring: 0.5 day
-- Tests: 0.5 day
-
-### Edge cases
-
-- `cornerRadius` larger than wedge angle → d3-shape clamps automatically
-- `roundedTop` larger than bar height → clamp to `min(radius, h/2, w/2)`
-- Horizontal bars → round the end that points away from the axis (right for positive, left for negative)
-- Negative value bars (below zero baseline) → round the bottom (the end away from zero)
-- Single-segment stacked bar → round the top (it's both the first and last segment)
-
----
-## BUGS
-
-### StackedBarChart and GroupedBarChart missing `sort` prop [DONE]
-
-`sort` prop added to both `StackedBarChartProps` and `GroupedBarChartProps`. Default: `false` (data insertion order). Accepts `"asc"`, `"desc"`, `boolean`, or custom comparator. Mapped to `oSort` on the frame.
+- **Rounded corners** — `cornerRadius` on PieChart/DonutChart, `roundedTop` on BarChart/StackedBarChart/GroupedBarChart. Negative-value bars round the correct edge.
+- **`sort` on StackedBarChart/GroupedBarChart** — default `false` (insertion order).
+- **Push API transition exits** — `remove()` calls `snapshotPositions()` before mutation.
+- **Push API selection clearing** — all frames clear hover on datum removal.
+- **Network `edgeIdAccessor`** — `removeEdge(edgeId)` single-ID form.
+- **OG image server** — `scripts/og-server.mjs`.
+- **CLI screenshot generator** — `scripts/demo-server-render.mjs`.
+- **Release pipeline** — post-publish smoke test, rollback script.
+- **SSR alignment CI** — `scripts/check-ssr-alignment.js` checks HOC↔SSR↔validation parity.
+- **SSR fixes** — wedge rotation, hierarchy themes, gauge needle, bottom legend, ID uniqueness, `sweepAngle`/`hierarchySum`/`cornerRadius`/`roundedTop` passthrough.
+- **HoverData unification** — typed `HoverData` across all 4 frames.
+- **Shared `computeDecayOpacity`** — single source of truth in `pipelineDecay.ts`.
+- **`serverChartConfigs.ts`** — `renderChart` dispatch extracted to lookup table.
+- **`as any` reduction** — 240 → ~140.
+- **Test coverage** — 2890 tests across 157 files. Cache invalidation, push API edge cases, SSR coverage, HOC integration, callback wiring, bad data resilience.
 
 ---
 
-## Push API: Transition Exits on Remove [DONE]
+## Theming
 
-`remove()` now calls `snapshotPositions()` before buffer mutation in both PipelineStore and OrdinalPipelineStore. The next `computeScene()` will see the removed items in the "previous" snapshot and create fade-out exit transitions.
+### CSS variables [DONE]
 
----
+All four planned variables implemented:
+- `--semiotic-annotation-color` — falls back to `--semiotic-text`
+- `--semiotic-legend-font-size` — used by Legend component
+- `--semiotic-title-font-size` — available for chart titles
+- `--semiotic-tick-font-family` — monospace option for aligned numerics
 
-## Push API: Selection Clearing on Remove [DONE]
+### SemioticTheme interface additions [DONE]
 
-All three stream frames (XY, Ordinal, Network) now check if the hovered datum was in the removed set after `remove()`. If so, hover state is cleared (`hoverRef.current = null`, `setHoverPoint(null)`). Prevents stale tooltips and ghost highlights.
+- `colors.annotation` — annotation marker/text color (used by Annotation.tsx, staticAnnotations.tsx)
+- `typography.legendSize` — legend font size (used by Legend.tsx)
+- `typography.tickFontFamily` — tick label font family
+- `typography.titleFontSize` — chart title font size
+- `accessibility.colorBlindSafe` — type defined, runtime not yet wired
+- `accessibility.highContrast` — type defined, runtime not yet wired
 
----
+Theme presets updated: Tufte and Journalist presets include `annotation`, `tickFontFamily`, `legendSize`. `themeToCSS()` and `themeToTokens()` emit the new tokens. Server `themeStyles()` resolves the new fields with fallbacks.
 
-## Push API: Network Edge ID Accessor [DONE]
+### ThemeProvider useEffect timing lag [YELLOW]
 
-`edgeIdAccessor` added to `NetworkPipelineConfig`. `removeEdge()` now accepts either `(sourceId, targetId)` for endpoint-based removal or `(edgeId)` for single-ID removal when `edgeIdAccessor` is configured. Throws descriptive error if `edgeIdAccessor` not set and single-ID form is used. Handle type updated on `StreamNetworkFrameHandle`.
+`ThemeInitializer` uses `useEffect` to sync the store, causing CSS variables to be one render behind on initial mount. Mitigated by inline CSS vars on `ThemeCSSWrapper`'s div, but the architecture is fragile. Fix: resolve theme synchronously during render via `useSyncExternalStore` or store initialization.
 
----
+### Canvas theme bridge fragility [YELLOW]
 
-## Push API: Undo
+Canvas renderers read theme values via `getComputedStyle`. If the dirty flag isn't set when the theme updates, canvas keeps old colors while SVG updates to the new theme. Currently works because theme changes trigger re-render → dirty flag, but the coupling is implicit.
 
-**Status**: Not scoped.
+### Design system research gaps
 
-`remove()` and `update()` return the previous values, so the caller can `push` them back. But there's no built-in undo stack. For a chat agent workflow ("remove that node" / "undo"), the caller holds the return value manually.
-
-A built-in undo would be: `ref.current.undo()` that reverses the last mutation (remove, update, push). Requires an operation log with inverse operations. Scoping TBD — may be better as a userland wrapper than a library feature.
-
----
-
-## CLI Screenshot Generator
-
-**Status**: Not started. Trivial.
-
-A Node script (`scripts/demo-server-render.mjs`) that batch-renders charts to SVG/PNG files on disk. Produces the exact images needed for PR descriptions and release posts. ~80 lines.
-
-**Effort**: 0.5 day.
+Curated categorical sequences maximizing neighbor contrast, and per-role typography tokens (title vs legend vs axis vs tick — currently only sizes, not per-role font families).
 
 ---
 
-## OG Image HTTP Server [DONE]
+## Push API
 
-`scripts/og-server.mjs` — Node HTTP server serving chart SVG/PNG from URL query parameters.
-`GET /og?component=BarChart&theme=dark&title=Revenue&format=png&scale=2`
+### Undo
 
-Features: CORS, default demo data per chart type, JSON-encoded data in query params, landing page with example links. Deployable as standalone server or adapted to Vercel/Cloudflare.
-
----
-
-## PDF Export
-
-**Status**: Not scoped.
-
-`renderToPDF(component, props, options)` — generate PDF documents with embedded charts. Multi-page dashboard support via pdfkit or jsPDF (peer dependency). Text as vectors (no font embedding). Page layout (A4, Letter, custom).
-
-**Effort**: Large (1-2 weeks).
+**Status**: Not scoped. `remove()`/`update()` return previous values — caller can push them back manually. A built-in `ref.current.undo()` needs an operation log with inverse operations. May be better as a userland wrapper.
 
 ---
 
-## Edge Runtime Compatibility
+## Server Rendering
 
-**Status**: Not scoped.
+### CLI Screenshot Generator [DONE]
 
-Verify `renderChart`, `renderDashboard`, `generateFrameSVGs`, `generateFrameSequence` work in Cloudflare Workers, Vercel Edge Functions, and Deno Deploy. The sync functions should already work (they only use react-dom/server). The async functions (renderToImage, renderToAnimatedGif) require sharp which is Node-only — resvg-wasm would enable edge PNG generation.
+`scripts/demo-server-render.mjs` — batch-renders 7 charts + 1 dashboard across multiple themes to SVG/PNG.
 
-**Effort**: Medium (3-5 days). Mostly testing and polyfill discovery.
+### PDF Export
 
----
+**Status**: Not scoped. `renderToPDF()` with pdfkit/jsPDF. 1-2 weeks.
 
-## GIF Transition Easing (Phase 2 fix)
+### Edge Runtime Compatibility
 
-**Status**: Known limitation, not started.
+**Status**: Not scoped. Verify sync `renderChart`/`renderDashboard` work in CF Workers, Vercel Edge, Deno. 3-5 days.
 
-`transitionFrames` in `generateFrameSVGs` is currently a no-op because each frame creates a new PipelineStore. The store needs a previous scene snapshot to compute enter/update/exit transitions, but a fresh store has no history. Fixing this requires keeping a single store instance across frames and ingesting data incrementally (push the delta, let the store snapshot previous positions before rebuilding).
+### GIF Transition Easing
 
-`generateFrameSequence` is not affected — it renders each snapshot independently via `renderChart`, so transitions don't apply.
+**Status**: Not started. `transitionFrames` is a no-op — needs incremental store ingestion across frames. 2-3 days.
 
-**Effort**: Medium (2-3 days). Requires changing the XY branch of `generateFrameSVGs` to use incremental ingestion instead of bounded re-creation per frame.
+### Render Studio: Real GIF Downloads
 
----
-
-## Render Studio: Real GIF Downloads
-
-**Status**: Not started.
-
-The Render Studio page (`/server/studio`) animated preview still cycles SVG frames client-side. The Export & Embed page uses pre-built GIF files. The Studio could either generate GIFs at build time for common configs or link to the Export page for download.
-
-**Effort**: Small (0.5 day) if linking to Export page. Medium (1-2 days) if generating per-config GIFs at build time.
-
----
-
-## Release & CI Pipeline
-
-### Release pipeline hardening [DONE]
-
-- **Post-publish smoke test** — added to `.github/workflows/release.yml`. After `npm publish`, waits for registry propagation then installs `semiotic@version` in a temp project and verifies 8 entry points (`semiotic`, `semiotic/xy`, `semiotic/ordinal`, `semiotic/network`, `semiotic/realtime`, `semiotic/server`, `semiotic/themes`, `semiotic/utils`) export expected components.
-- **Rollback script** — `scripts/rollback-release.sh <bad-version> [good-version]`. Deprecates the bad version (shows warning on install) and points the dist-tag back to the previous version. Auto-detects previous version if not specified. Prints follow-up steps (delete git tag, optional unpublish).
-
----
-
-## Release & Publishing
-
-### Docs site prerendering
-
-Homepage and chart index pages resolve to a JS shell. Prerendering would improve SEO and LLM retrieval quality.
+**Status**: Not started. Link Studio animated preview to Export page for download. 0.5 day.
 
 ---
 
 ## Bugs & Code Quality
 
-### canvasPreRenderers only on StreamXYFrame
+### PipelineStore cache invalidation [YELLOW]
 
-### PipelineStore cache invalidation edge cases [YELLOW]
-
-Stacked area cumulative sums are cached by `bufferSize:_ingestVersion`. Color maps rebuild only when the set of categories changes. These caches are correct for tested patterns but the invalidation logic is implicit — there is no assertion or test that verifies a cache *does* invalidate when it should. A subtle change to ingest ordering could leave stale cached values without any visible error, just wrong numbers.
-
-**Symptom**: Stacked areas show wrong heights after certain data update patterns, or color assignments drift after category additions/removals.
+Implicit cache invalidation keyed by `bufferSize:_ingestVersion`. No test verifies caches invalidate correctly. Cache invalidation tests added in 3.3.x cover color maps, extents, and push-clear cycles, but combinatorial paths remain untested.
 
 ### Canvas renderer combinatorial paths [YELLOW]
 
-Line and area renderers handle three independent features that each break continuous paths into segments: curve interpolation, per-vertex decay opacity, and threshold coloring. These compose multiplicatively but are only validated visually via Playwright screenshots, not programmatically. Unusual combinations (e.g., step curve + exponential decay + threshold coloring) may produce artifacts.
+Step curve + exponential decay + threshold coloring compose multiplicatively. Only validated visually via Playwright.
 
-### NetworkPipelineStore tension threshold tuning [YELLOW]
+### NetworkPipelineStore tension threshold [YELLOW]
 
-Streaming network layouts use a `tension` counter that accumulates as edges arrive. Layout re-runs when tension exceeds a threshold. The threshold is empirically tuned, not theoretically derived. Under bursty traffic patterns, layouts may re-run too frequently (jittery graph) or too infrequently (stale positions).
+Empirically tuned, not theoretically derived. May re-run too frequently or infrequently under bursty traffic.
 
 ### GeoPipelineStore projection edge cases [YELLOW]
 
-Anti-meridian line splitting and zoom/pan transforms work for standard projections and zoom ranges. Edge cases near projection singularities (e.g., poles in Mercator, anti-meridian in Equirectangular) may produce rendering artifacts. The d3-geo math is trusted, but the custom wrapping code (splitting, tile alignment) has limited test coverage at extreme latitudes/longitudes.
-
-### Click-testing remainders
-
----
-
-## Theming Gaps
-
-### ThemeProvider useEffect timing lag [YELLOW]
-
-`ThemeInitializer` uses `useEffect` to sync the store, causing CSS variables to be one render behind on initial mount. Mitigated by inline CSS vars on `ThemeCSSWrapper`'s div, but the architecture is fragile — future changes to rendering order could re-expose the timing issue. The right fix may be to resolve the theme synchronously during render (via `useSyncExternalStore` or store initialization) rather than via effect.
-
-### Canvas theme bridge fragility [YELLOW]
-
-Canvas renderers read theme values via `getComputedStyle(canvas).getPropertyValue("--semiotic-bg")` at paint time. If the dirty flag isn't set when the theme updates, canvas keeps old colors while SVG elements (axes, legend) update to the new theme. Currently works because theme changes trigger a re-render which sets the dirty flag, but this coupling is implicit.
-
-### Planned CSS variables (not yet implemented)
-
-| Variable | Purpose | Priority |
-|---|---|---|
-| `--semiotic-annotation-color` | Default annotation text/marker color | Medium |
-| `--semiotic-legend-font-size` | Legend text size (separate from tick) | Low |
-| `--semiotic-title-font-size` | Chart title size | Low |
-| `--semiotic-tick-font-family` | Monospace option for numeric tick alignment | Low |
-
-### Planned SemioticTheme interface additions
-
-- `colors.annotation` — annotation marker/text color
-- `typography.legendSize` — legend font size
-- `typography.tickFontFamily` — monospace option for numeric alignment
-- `accessibility.colorBlindSafe` — auto-swap categorical palette for CB-safe variant
-- `accessibility.highContrast` — enforce 3:1+ contrast ratios
-
-### Design system research gaps
-
-Per Carbon/MUI comparison: curated categorical sequences maximizing neighbor contrast (currently user-provided arrays), and per-role typography tokens (title vs legend vs axis vs tick — currently only sizes, not per-role font families).
+Anti-meridian/pole rendering artifacts possible with limited test coverage at extreme latitudes.
 
 ---
 
 ## TypeScript
+
+### `as any` reduction
+
+~140 remaining. Hotspots: sankeyLayoutPlugin (27, vendor-adjacent), StreamGeoFrame (13, d3-zoom types), XYBrushOverlay (7), chordLayoutPlugin (6). Next targets: StreamGeoFrame d3 type imports, SceneToSVG d3-shape arc invocations.
 
 ### Accessor type audit
 
@@ -266,83 +123,32 @@ Replace bare `string` or deprecated `Accessor<T>` with `ChartAccessor<TDatum, T>
 
 ### Generic ColorConfig/SizeConfig
 
-These types use `Accessor<string>` instead of `ChartAccessor`. Making them generic with `TDatum` enables `keyof` inference on `colorBy`, `sizeBy`.
-
-### Realtime HOC generics
-
-Adding `TDatum` to Realtime HOC props interfaces enables accessor inference.
-
-**Files**: `types.ts`, all 36 HOC files
-
-### `as any` reduction [RED]
-
-172 `as any` casts in production code. Hotspots: PipelineStore (38), sankeyLayoutPlugin (25), NetworkPipelineStore (19), StreamOrdinalFrame (16). Primary source is the transition system — shadow properties accessed via `as any`. Each cast is a potential runtime type error that TypeScript can't catch. Fix: add `_transitionState?: TransitionState` to SceneNode variants.
+Make generic with `TDatum` for `keyof` inference on `colorBy`, `sizeBy`.
 
 ---
 
-## Declarative Bounded Animation
-
-### Enter/exit detection
-
-Add `_targetOpacity` to scene node types. New nodes enter at opacity 0→1, exiting nodes fade 1→0 then remove.
-
-**Files**: `PipelineStore.ts`, `types.ts`
-
-### Line/area path interpolation
-
-For lines with stable x-values, interpolate y-coordinates. Store path arrays in `prevPositionMap` keyed by group identity.
+## Declarative Animation
 
 ### `animate` prop on HOCs
 
-Add `animate?: boolean | TransitionConfig` to `BaseChartProps`. Default `false`. Currently declared but unused (`resolveAnimateConfig` exists in hooks.ts but no HOC consumes it).
-
-### Canvas renderer opacity support
-
-Each renderer respects `_targetOpacity` via `ctx.globalAlpha`, composing with selection dimming.
-
-**Files**: all canvas renderers
+`animate?: boolean | TransitionConfig` on `BaseChartProps`. Infrastructure exists (`_targetOpacity`, `snapshotPositions`, `startTransition`). Missing: HOC wiring, canvas `ctx.globalAlpha` from transition opacity. 1-2 weeks.
 
 ---
 
-## Testing & CI Gaps
+## Performance
 
-### Missing test specs
+### Quadtree for scatter hit testing [RED]
 
-1. `animation.spec.ts` — bounded data transitions, enter/exit (not yet written). Blocked on declarative animation implementation.
+O(log n) lookup for >10k points. Currently linear scan. 3-5 days.
 
-### SSR testing gap [DONE]
+### Other performance items
 
-- 10 server test files with 31+ integration tests covering all chart types, themes, formats
-- Geo SSR test added: ChoroplethMap with pre-resolved GeoJSON features, ProportionalSymbolMap
-- Negative cases added: empty data, missing accessors (defaults), unknown component name (throws descriptive error), null data, empty dashboard
-- All SSR tests run in CI via `npx vitest run --coverage` (same as all other tests)
-
-### Cross-browser testing [DONE — config added]
-
-Firefox and WebKit projects added to `playwright.config.ts`. CI installs all three browsers (`npx playwright install --with-deps chromium firefox webkit`). Snapshot baselines will need to be generated per-browser — the CI auto-generates missing baselines on first run.
-
-### Playwright snapshot baselines [YELLOW — partially addressed]
-
-CI has auto-generation logic: if no Linux baselines exist, runs `--update-snapshots` on first run. Both macOS and Linux baselines can coexist. Firefox/WebKit baselines will be generated on first CI run with the new config.
-
-### Canvas stub drift in unit tests [DONE]
-
-CI step added to `node.js.yml`: scans all `ctx.<method>` calls in `src/components/stream/renderers/`, compares against the stubbed methods in `setupTests.ts`, and fails if any method is used in production but not stubbed. Excludes property assignments (fillStyle, strokeStyle, etc.).
-
-### Sustained streaming load testing [DONE]
-
-`benchmarks/unit/streaming-load.bench.ts` added with 6 benchmarks:
-- RingBuffer: 10k/50k pushes with eviction, forEach iteration cost
-- PipelineStore: 1k push + scene rebuild, 5k burst, incremental 100-point hot path
-- Memory stability: 50k push/evict cycles assert buffer stays at capacity
-
-### Canvas accessibility [YELLOW — by design]
-
-Canvas data marks are opaque to assistive technology. Mitigated by: ARIA labels on canvas elements, SVG overlay for text-accessible axes/legends, `accessibleTable` (default true) rendering screen-reader-only data summary, keyboard navigation with graph-based traversal. The data marks themselves have no text alternative beyond tooltips. This is an inherent canvas limitation — further improvement would require a parallel invisible DOM representation of each data point.
-
-### Benchmark regressions [YELLOW — tooling gap]
-
-CI runs `npx vitest bench --reporter=verbose` for visibility. `scripts/check-bench-regression.js` exists for baseline comparison but vitest bench does not support `--reporter=json` output, so automated regression gating is blocked on upstream vitest support. The script will work once vitest adds JSON bench output. For now, benchmarks run in CI for visibility but don't fail builds.
+- RingBuffer in-place forEach
+- Canvas curve interpolation
+- Network decay sort cache
+- Incremental scene updates (append/evict vs full rebuild)
+- WebGL renderer for >100k points
+- Web Worker for force layout
 
 ---
 
@@ -350,74 +156,31 @@ CI runs `npx vitest bench --reporter=verbose` for visibility. `scripts/check-ben
 
 ### MCP protocol compliance testing [RED]
 
-The MCP server is tested via CLI (`--doctor`), not via actual MCP protocol messages. If a host (Claude Desktop, Cursor) sends a request in an unexpected format, the server's error handling is untested. No integration test starts the MCP server and exercises the protocol round-trip.
+No integration test exercises the actual MCP protocol round-trip. Tested via CLI only.
 
-**Fix**: Add a test that starts `semiotic-mcp`, sends tool calls via the MCP protocol (stdio transport), and validates responses. Cover: `renderChart` with valid props, `renderChart` with invalid props, `diagnoseConfig`, `suggestChart`.
+### Schema freshness check [YELLOW]
 
-### Schema freshness check is regex-based [YELLOW]
-
-`check-schema-freshness.js` validates sync between `ai/schema.json`, `validateProps.ts`, and `CLAUDE.md` using regex parsing. If the format of CLAUDE.md changes structurally, the parser may fail silently — reporting "in sync" when drift exists.
+Regex-based parsing. Structural CLAUDE.md changes could cause silent drift.
 
 ---
 
-## API Reference Documentation
+## Docs & Publishing
 
-- TypeDoc setup generating from 8 entry points
-- Prop table component rendering from TypeDoc JSON, embedded in doc pages
-- `/api` route in docs site with cross-links from example pages
+### Docs site prerendering
 
----
+Homepage resolves to a JS shell. Prerendering improves SEO and LLM retrieval.
 
-## Bundle Size
+### API Reference Documentation
 
-### Profile
-
-Run rollup-plugin-visualizer on each entry point.
-
-### Lazy-load statistical overlays
-
-`statisticalOverlays.ts` pulls LOESS/forecast logic. Dynamic import behind `forecast` and `anomaly` props.
-
-### PipelineStore shared base
-
-The 4 PipelineStore files (~4500 lines) share extent tracking, accessor resolution, and transition logic. Extract shared utilities.
-
----
-
-## Performance
-
-### Tier 2: Medium Complexity
-
-- **RingBuffer forEach** — iterate in-place instead of materializing for scan operations
-- **Canvas curve interpolation** — apply d3-shape curves to canvas line/area renderers
-- **Quadtree for scatter hit testing [RED]** — O(log n) lookup for >10k points. Currently linear scan for non-point nodes (lines, areas, rects). A chart with 10,000 line segments does 10,000 distance calculations per mouse move.
-- **Network decay sort cache** — maintain sorted node list, invalidate on topology change
-- **Line/area decay** — per-vertex opacity gradient for streaming line charts
-
-### Tier 3: Transformative
-
-- **Incremental force layout (warm start)** — preserve positions, fewer iterations for streaming
-- **Incremental scene updates** — append/evict nodes instead of full rebuild for streaming
-- **Streaming annotation anchoring** — `"latest"`, `"sticky"` anchor modes
-- **Heatmap canvas text** — render `showValues` text on canvas instead of SVG overlay
-- **WebGL renderer for >100k points** — single draw call via vertex buffer
-- **Web Worker for force layout** — move simulation off main thread
+TypeDoc setup, prop table component, `/api` route. Not started.
 
 ---
 
 ## Geo Enhancements
 
-- **Path2D hit testing generalization** — shared `pathHitTest` utility for network custom shapes, ordinal arcs, XY area fills
-- **Bounds pre-filter for network nodes** — apply geo-style `[[x0,y0],[x1,y1]]` bounds check to CanvasHitTester
-- **Canvas grid lines** — render XY grid lines on canvas as non-interactive background marks for performance
-- **Geographic minimap** — overview + detail with linked zoom, extending MinimapChart pattern
-- **Temporal animation on cartogram** — `timeAccessor` to scrub through time and watch cartogram reshape
-- **Edge encoding richness** — tapered lines (width varies along path) and animated dashed lines (directionality)
-
----
-
-## Learnings (Reference)
-
-- Test mocks must use `forwardRef` when HOCs pass refs. Update ALL test mocks in same PR when adding `forwardRef`.
-- Conditional spread `nodes != null` blocks inferred data — test the derived value, not the raw prop.
-- `renderEmptyState(undefined, ...)` returns `null` because `undefined` data means push API mode, not "no data."
+- Path2D hit testing generalization
+- Bounds pre-filter for network nodes
+- Canvas grid lines
+- Geographic minimap
+- Temporal animation on cartogram
+- Edge encoding richness (tapered lines, animated dashed)

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -27,6 +27,8 @@
 **QuadrantChart** — Scatterplot + `quadrants` (required), `xCenter`, `yCenter`
 **MultiAxisLineChart** — Dual Y-axis. `series` (required: `[{ yAccessor, label?, color?, format?, extent? }]`). Falls back to multi-line if not 2 series.
 **Heatmap** — `data`, `xAccessor`, `yAccessor`, `valueAccessor`, `colorScheme`, `showValues`, `cellBorderColor`
+**ScatterplotMatrix** — `data`, `fields` (array of numeric field names for grid)
+**MinimapChart** — Overview + detail with linked zoom. Wraps an XY chart.
 
 ## Ordinal Charts (`semiotic/ordinal`)
 
@@ -150,7 +152,7 @@ All HOCs accept `annotations` (array). Coordinates use data field names.
 
 ## Theming
 
-CSS custom properties: `--semiotic-bg`, `--semiotic-text`, `--semiotic-text-secondary`, `--semiotic-border`, `--semiotic-grid`, `--semiotic-primary`, `--semiotic-focus`, `--semiotic-font-family`, `--semiotic-tooltip-bg`/`text`/`radius`/`font-size`/`shadow`.
+CSS custom properties: `--semiotic-bg`, `--semiotic-text`, `--semiotic-text-secondary`, `--semiotic-border`, `--semiotic-grid`, `--semiotic-primary`, `--semiotic-focus`, `--semiotic-font-family`, `--semiotic-annotation-color`, `--semiotic-legend-font-size`, `--semiotic-title-font-size`, `--semiotic-tick-font-family`, `--semiotic-tooltip-bg`/`text`/`radius`/`font-size`/`shadow`.
 
 ```jsx
 <ThemeProvider theme="tufte">       {/* Named preset */}

--- a/scripts/demo-server-render.mjs
+++ b/scripts/demo-server-render.mjs
@@ -40,6 +40,10 @@ try {
 
 const generatePNG = process.argv.includes("--png")
 const outIdx = process.argv.indexOf("--out")
+if (outIdx !== -1 && (!process.argv[outIdx + 1] || process.argv[outIdx + 1].startsWith("--"))) {
+  console.error('Error: "--out" requires a directory path.\nUsage: npx tsx scripts/demo-server-render.mjs [--png] [--out <directory>]')
+  process.exit(1)
+}
 const outDir = outIdx !== -1 ? process.argv[outIdx + 1] : path.join(__dirname, "..", "demo-output")
 
 if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true })

--- a/scripts/demo-server-render.mjs
+++ b/scripts/demo-server-render.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * CLI Screenshot Generator — batch-renders charts to SVG/PNG files on disk.
+ *
+ * Produces the exact images needed for PR descriptions, release posts, and
+ * documentation. Each chart uses a different theme to showcase variety.
+ *
+ * Usage:
+ *   npx tsx scripts/demo-server-render.mjs              # SVG only
+ *   npx tsx scripts/demo-server-render.mjs --png         # also generate PNGs (requires sharp)
+ *   npx tsx scripts/demo-server-render.mjs --out ./images # custom output dir
+ */
+
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+// Load from dist or source
+let renderChart, renderDashboard, renderToImage
+try {
+  const mod = await import("../dist/semiotic-server.js")
+  renderChart = mod.renderChart
+  renderDashboard = mod.renderDashboard
+  renderToImage = mod.renderToImage
+} catch {
+  try {
+    const mod = await import("../src/components/semiotic-server.ts")
+    renderChart = mod.renderChart
+    renderDashboard = mod.renderDashboard
+    renderToImage = mod.renderToImage
+  } catch (e) {
+    console.error('Run "npm run dist" first, or use "npx tsx scripts/demo-server-render.mjs"')
+    process.exit(1)
+  }
+}
+
+// ── Config ──────────────────────────────────────────────────────────────
+
+const generatePNG = process.argv.includes("--png")
+const outIdx = process.argv.indexOf("--out")
+const outDir = outIdx !== -1 ? process.argv[outIdx + 1] : path.join(__dirname, "..", "demo-output")
+
+if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true })
+
+// ── Sample data ─────────────────────────────────────────────────────────
+
+const barData = [
+  { category: "Q1", value: 42000, region: "Americas" },
+  { category: "Q2", value: 58000, region: "Americas" },
+  { category: "Q3", value: 65000, region: "Americas" },
+  { category: "Q4", value: 71000, region: "Americas" },
+  { category: "Q1", value: 28000, region: "EMEA" },
+  { category: "Q2", value: 35000, region: "EMEA" },
+  { category: "Q3", value: 41000, region: "EMEA" },
+  { category: "Q4", value: 48000, region: "EMEA" },
+]
+
+const lineData = Array.from({ length: 24 }, (_, i) => ({
+  month: i + 1,
+  revenue: Math.round(40000 + 30000 * Math.sin(i / 3) + i * 2000),
+  cost: Math.round(25000 + 5000 * Math.sin(i / 4) + i * 800),
+})).flatMap(d => [
+  { x: d.month, y: d.revenue, series: "Revenue" },
+  { x: d.month, y: d.cost, series: "Cost" },
+])
+
+const pieData = [
+  { category: "Desktop", value: 58 },
+  { category: "Mobile", value: 28 },
+  { category: "Tablet", value: 10 },
+  { category: "Other", value: 4 },
+]
+
+const sankeyEdges = [
+  { source: "Revenue", target: "Product", value: 500 },
+  { source: "Revenue", target: "Services", value: 300 },
+  { source: "Revenue", target: "Licensing", value: 200 },
+  { source: "Product", target: "Gross Profit", value: 300 },
+  { source: "Services", target: "Gross Profit", value: 200 },
+  { source: "Licensing", target: "Gross Profit", value: 200 },
+  { source: "Gross Profit", target: "OpEx", value: 350 },
+  { source: "Gross Profit", target: "Net Income", value: 350 },
+]
+
+// ── Chart definitions ───────────────────────────────────────────────────
+
+const charts = [
+  {
+    name: "bar-tufte",
+    component: "BarChart",
+    props: {
+      data: barData.filter(d => d.region === "Americas"),
+      categoryAccessor: "category",
+      valueAccessor: "value",
+      theme: "tufte",
+      title: "Quarterly Revenue",
+      roundedTop: 4,
+      showGrid: true,
+    },
+  },
+  {
+    name: "stacked-bar-dark",
+    component: "StackedBarChart",
+    props: {
+      data: barData,
+      categoryAccessor: "category",
+      valueAccessor: "value",
+      stackBy: "region",
+      colorBy: "region",
+      theme: "dark",
+      title: "Revenue by Region",
+      roundedTop: 4,
+      showLegend: true,
+      background: "#1a1a2e",
+    },
+  },
+  {
+    name: "line-journalist",
+    component: "LineChart",
+    props: {
+      data: lineData,
+      xAccessor: "x",
+      yAccessor: "y",
+      lineBy: "series",
+      colorBy: "series",
+      theme: "journalist",
+      title: "Revenue vs Cost",
+      showLegend: true,
+      showGrid: true,
+    },
+  },
+  {
+    name: "pie-pastels-rounded",
+    component: "PieChart",
+    props: {
+      data: pieData,
+      categoryAccessor: "category",
+      valueAccessor: "value",
+      colorBy: "category",
+      theme: "pastels",
+      cornerRadius: 8,
+      width: 400,
+      height: 400,
+    },
+  },
+  {
+    name: "donut-italian",
+    component: "DonutChart",
+    props: {
+      data: pieData,
+      categoryAccessor: "category",
+      valueAccessor: "value",
+      colorBy: "category",
+      theme: "italian",
+      cornerRadius: 6,
+      width: 400,
+      height: 400,
+    },
+  },
+  {
+    name: "sankey-dark",
+    component: "SankeyDiagram",
+    props: {
+      edges: sankeyEdges,
+      sourceAccessor: "source",
+      targetAccessor: "target",
+      valueAccessor: "value",
+      theme: "tufte-dark",
+      showLabels: true,
+      background: "#1a1a2e",
+    },
+  },
+  {
+    name: "gauge-high-contrast",
+    component: "GaugeChart",
+    props: {
+      value: 72,
+      min: 0,
+      max: 100,
+      sweep: 240,
+      arcWidth: 0.3,
+      thresholds: [
+        { value: 60, color: "#22c55e", label: "Normal" },
+        { value: 80, color: "#f59e0b", label: "Warning" },
+        { value: 100, color: "#ef4444", label: "Critical" },
+      ],
+      title: "CPU Usage",
+      theme: "high-contrast",
+      width: 350,
+      height: 350,
+    },
+  },
+]
+
+// ── Dashboard ───────────────────────────────────────────────────────────
+
+const dashboardDef = {
+  name: "dashboard-bi-tool",
+  charts: [
+    { component: "BarChart", colSpan: 2, props: { data: barData.filter(d => d.region === "Americas"), categoryAccessor: "category", valueAccessor: "value", title: "Revenue" } },
+    { component: "PieChart", props: { data: pieData, categoryAccessor: "category", valueAccessor: "value", colorBy: "category" } },
+    { component: "LineChart", colSpan: 2, props: { data: lineData, xAccessor: "x", yAccessor: "y", lineBy: "series", colorBy: "series", title: "Trend", showLegend: true } },
+  ],
+  options: { title: "Executive Summary", theme: "bi-tool", width: 1200, layout: { columns: 3 } },
+}
+
+// ── Render ───────────────────────────────────────────────────────────────
+
+console.log(`Rendering ${charts.length} charts + 1 dashboard to ${outDir}\n`)
+
+for (const chart of charts) {
+  const props = { width: 600, height: 400, ...chart.props }
+  const svg = renderChart(chart.component, props)
+  const svgPath = path.join(outDir, `${chart.name}.svg`)
+  fs.writeFileSync(svgPath, svg)
+  console.log(`  SVG  ${chart.name}.svg (${(svg.length / 1024).toFixed(1)}KB)`)
+
+  if (generatePNG && renderToImage) {
+    try {
+      const png = await renderToImage(chart.component, props, { format: "png", scale: 2 })
+      const pngPath = path.join(outDir, `${chart.name}.png`)
+      fs.writeFileSync(pngPath, png)
+      console.log(`  PNG  ${chart.name}.png (${(png.length / 1024).toFixed(1)}KB)`)
+    } catch (e) {
+      console.log(`  PNG  ${chart.name}.png SKIPPED (${e.message})`)
+    }
+  }
+}
+
+// Dashboard
+const dashSvg = renderDashboard(dashboardDef.charts, dashboardDef.options)
+const dashPath = path.join(outDir, `${dashboardDef.name}.svg`)
+fs.writeFileSync(dashPath, dashSvg)
+console.log(`  SVG  ${dashboardDef.name}.svg (${(dashSvg.length / 1024).toFixed(1)}KB)`)
+
+console.log(`\nDone. ${charts.length + 1} files in ${outDir}`)

--- a/scripts/demo-server-render.mjs
+++ b/scripts/demo-server-render.mjs
@@ -229,7 +229,7 @@ for (const chart of charts) {
       fs.writeFileSync(pngPath, png)
       console.log(`  PNG  ${chart.name}.png (${(png.length / 1024).toFixed(1)}KB)`)
     } catch (e) {
-      console.log(`  PNG  ${chart.name}.png SKIPPED (${e.message})`)
+      console.log(`  PNG  ${chart.name}.png SKIPPED (${e instanceof Error ? e.message : String(e)})`)
     }
   }
 }

--- a/scripts/demo-server-render.mjs
+++ b/scripts/demo-server-render.mjs
@@ -20,10 +20,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 // Load from dist or source
 let renderChart, renderDashboard, renderToImage
 try {
-  const mod = await import("../dist/semiotic-server.js")
-  renderChart = mod.renderChart
-  renderDashboard = mod.renderDashboard
-  renderToImage = mod.renderToImage
+  const mod = await import("../dist/server.module.min.js")
+  const server = mod.default ?? mod
+  renderChart = server.renderChart
+  renderDashboard = server.renderDashboard
+  renderToImage = server.renderToImage
 } catch {
   try {
     const mod = await import("../src/components/semiotic-server.ts")

--- a/scripts/og-server.mjs
+++ b/scripts/og-server.mjs
@@ -38,7 +38,8 @@ import { URL } from "node:url"
 // Load the built server renderer. Run `npm run dist` first, or use `npx tsx scripts/og-server.mjs`.
 let renderChart
 try {
-  ;({ renderChart } = await import("../dist/semiotic-server.js"))
+  const mod = await import("../dist/server.module.min.js")
+  renderChart = (mod.default ?? mod).renderChart
 } catch {
   // Fallback: try tsx/ts-node source import
   try {

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -107,7 +107,7 @@ function renderNote(
   let yOffset = 0
   const textElements: React.ReactElement[] = []
 
-  const textFill = color || "var(--semiotic-text, #333)"
+  const textFill = color || "var(--semiotic-annotation-color, var(--semiotic-text, #333))"
 
   if (titleLines.length > 0) {
     textElements.push(

--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -146,7 +146,7 @@ const renderLegendGroupVertical = (
         />}
         {renderedType}
         {isIsolated && <CheckMark />}
-        <text y={SWATCH / 2} x={SWATCH + 6} dominantBaseline="central" fontSize={12} fill="var(--semiotic-text, #333)">
+        <text y={SWATCH / 2} x={SWATCH + 6} dominantBaseline="central" style={{ fontSize: "var(--semiotic-legend-font-size, 12px)" }} fill="var(--semiotic-text, #333)">
           {item.label}
         </text>
       </g>
@@ -258,7 +258,7 @@ const renderLegendGroupHorizontal = (
         />}
         {renderedType}
         {isIsolated && <CheckMark />}
-        <text y={SWATCH / 2} x={SWATCH + 6} dominantBaseline="central" fontSize={12} fill="var(--semiotic-text, #333)">
+        <text y={SWATCH / 2} x={SWATCH + 6} dominantBaseline="central" style={{ fontSize: "var(--semiotic-legend-font-size, 12px)" }} fill="var(--semiotic-text, #333)">
           {item.label}
         </text>
       </g>

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -118,6 +118,10 @@ function ThemeCSSWrapper({ children }: { children: React.ReactNode }) {
     ...(theme.colors.selection ? { "--semiotic-selection-color": theme.colors.selection } : {}),
     ...(theme.colors.selectionOpacity != null ? { "--semiotic-selection-opacity": String(theme.colors.selectionOpacity) } : {}),
     ...(theme.colors.diverging ? { "--semiotic-diverging": theme.colors.diverging } : {}),
+    ...(theme.colors.annotation ? { "--semiotic-annotation-color": theme.colors.annotation } : {}),
+    ...(theme.typography.legendSize ? { "--semiotic-legend-font-size": `${theme.typography.legendSize}px` } : {}),
+    ...(theme.typography.titleFontSize ? { "--semiotic-title-font-size": `${theme.typography.titleFontSize}px` } : {}),
+    ...(theme.typography.tickFontFamily ? { "--semiotic-tick-font-family": theme.typography.tickFontFamily } : {}),
   }
 
   const themeName = React.useContext(ThemeNameContext)

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -119,9 +119,9 @@ function ThemeCSSWrapper({ children }: { children: React.ReactNode }) {
     ...(theme.colors.selectionOpacity != null ? { "--semiotic-selection-opacity": String(theme.colors.selectionOpacity) } : {}),
     ...(theme.colors.diverging ? { "--semiotic-diverging": theme.colors.diverging } : {}),
     ...(theme.colors.annotation ? { "--semiotic-annotation-color": theme.colors.annotation } : {}),
-    ...(theme.typography.legendSize ? { "--semiotic-legend-font-size": `${theme.typography.legendSize}px` } : {}),
-    ...(theme.typography.titleFontSize ? { "--semiotic-title-font-size": `${theme.typography.titleFontSize}px` } : {}),
-    ...(theme.typography.tickFontFamily ? { "--semiotic-tick-font-family": theme.typography.tickFontFamily } : {}),
+    ...(theme.typography.legendSize != null ? { "--semiotic-legend-font-size": `${theme.typography.legendSize}px` } : {}),
+    ...(theme.typography.titleFontSize != null ? { "--semiotic-title-font-size": `${theme.typography.titleFontSize}px` } : {}),
+    ...(theme.typography.tickFontFamily != null ? { "--semiotic-tick-font-family": theme.typography.tickFontFamily } : {}),
   }
 
   const themeName = React.useContext(ThemeNameContext)

--- a/src/components/charts/ordinal/GroupedBarChart.tsx
+++ b/src/components/charts/ordinal/GroupedBarChart.tsx
@@ -31,6 +31,8 @@ export interface GroupedBarChartProps<TDatum extends Record<string, any> = Recor
   /** Category sort order. Default: false (data insertion order). "asc"/"desc" sorts by total grouped value. Custom comparators receive category keys. */
   sort?: boolean | "asc" | "desc" | ((a: string, b: string) => number)
   barPadding?: number
+  /** Rounded corner radius on bar ends (away from baseline). */
+  roundedTop?: number
   baselinePadding?: boolean
   enableHover?: boolean
   showGrid?: boolean
@@ -68,7 +70,7 @@ export const GroupedBarChart = forwardRef(function GroupedBarChart<TDatum extend
     data, margin: userMargin, className,
     categoryAccessor = "category", groupBy, valueAccessor = "value",
     orientation = "vertical", valueFormat,
-    colorBy, colorScheme, sort = false, barPadding = 60, baselinePadding = false,
+    colorBy, colorScheme, sort = false, barPadding = 60, roundedTop, baselinePadding = false,
     tooltip, annotations, frameProps = {}, selection, linkedHover,
     onObservation, onClick, hoverHighlight, chartId,
     loading, emptyContent,
@@ -175,6 +177,7 @@ export const GroupedBarChart = forwardRef(function GroupedBarChart<TDatum extend
     responsiveHeight: props.responsiveHeight,
     margin: effectiveMargin,
     barPadding,
+    ...(roundedTop != null && { roundedTop }),
     baselinePadding,
     enableHover,
     ...(props.dataIdAccessor && { dataIdAccessor: props.dataIdAccessor }),

--- a/src/components/charts/shared/validationMap.ts
+++ b/src/components/charts/shared/validationMap.ts
@@ -300,7 +300,9 @@ export const VALIDATION_MAP: Record<string, ComponentSpec> = {
       groupBy: { type: ["string", "function"] },
       valueAccessor: { type: ["string", "function"] },
       orientation: { type: "string", enum: orientationEnum as unknown as string[] },
+      sort: { type: ["boolean", "string", "function"] },
       barPadding: { type: "number" },
+      roundedTop: { type: "number" },
     },
   },
 

--- a/src/components/semiotic-themes.ts
+++ b/src/components/semiotic-themes.ts
@@ -210,12 +210,15 @@ export const TUFTE_LIGHT: SemioticTheme = {
     grid: "#e0ddd0",
     border: "#e0ddd0",
     focus: "#8b0000",
+    annotation: "#8b0000",
   },
   typography: {
     fontFamily: "Georgia, 'Times New Roman', serif",
     titleSize: 16,
     labelSize: 12,
     tickSize: 10,
+    tickFontFamily: "'Courier New', Courier, monospace",
+    legendSize: 11,
   },
   tooltip: {
     background: "#fffff8",
@@ -268,12 +271,15 @@ export const JOURNALIST_LIGHT: SemioticTheme = {
     grid: "#d4d4d4",
     border: "#d4d4d4",
     focus: "#e45050",
+    annotation: "#e45050",
   },
   typography: {
     fontFamily: "'Franklin Gothic Medium', 'Libre Franklin', Arial, sans-serif",
-    titleSize: 16,
+    titleSize: 18,
     labelSize: 12,
     tickSize: 10,
+    tickFontFamily: "'Courier New', Courier, monospace",
+    legendSize: 11,
   },
   tooltip: {
     background: "#f8f8f8",
@@ -547,6 +553,20 @@ export function themeToCSS(theme: SemioticTheme, selector = ":root"): string {
     vars.push(`  --semiotic-border-radius: ${theme.borderRadius};`)
   }
 
+  // New theme tokens
+  if (theme.colors.annotation) {
+    vars.push(`  --semiotic-annotation-color: ${theme.colors.annotation};`)
+  }
+  if (theme.typography.legendSize) {
+    vars.push(`  --semiotic-legend-font-size: ${theme.typography.legendSize}px;`)
+  }
+  if (theme.typography.titleFontSize) {
+    vars.push(`  --semiotic-title-font-size: ${theme.typography.titleFontSize}px;`)
+  }
+  if (theme.typography.tickFontFamily) {
+    vars.push(`  --semiotic-tick-font-family: ${theme.typography.tickFontFamily};`)
+  }
+
   return `${selector} {\n${vars.join("\n")}\n}`
 }
 
@@ -599,6 +619,18 @@ export function themeToTokens(theme: SemioticTheme): Record<string, any> {
           $type: "string",
           $description: "d3-scale-chromatic diverging scheme name",
         },
+      } : {}),
+      ...(theme.colors.annotation ? {
+        "annotation-color": { $value: theme.colors.annotation, $type: "color" },
+      } : {}),
+      ...(theme.typography.legendSize ? {
+        "legend-font-size": { $value: `${theme.typography.legendSize}px`, $type: "dimension" },
+      } : {}),
+      ...(theme.typography.titleFontSize ? {
+        "title-font-size": { $value: `${theme.typography.titleFontSize}px`, $type: "dimension" },
+      } : {}),
+      ...(theme.typography.tickFontFamily ? {
+        "tick-font-family": { $value: theme.typography.tickFontFamily, $type: "fontFamily" },
       } : {}),
     },
   }

--- a/src/components/semiotic-themes.ts
+++ b/src/components/semiotic-themes.ts
@@ -557,13 +557,13 @@ export function themeToCSS(theme: SemioticTheme, selector = ":root"): string {
   if (theme.colors.annotation) {
     vars.push(`  --semiotic-annotation-color: ${theme.colors.annotation};`)
   }
-  if (theme.typography.legendSize) {
+  if (theme.typography.legendSize != null) {
     vars.push(`  --semiotic-legend-font-size: ${theme.typography.legendSize}px;`)
   }
-  if (theme.typography.titleFontSize) {
+  if (theme.typography.titleFontSize != null) {
     vars.push(`  --semiotic-title-font-size: ${theme.typography.titleFontSize}px;`)
   }
-  if (theme.typography.tickFontFamily) {
+  if (theme.typography.tickFontFamily != null) {
     vars.push(`  --semiotic-tick-font-family: ${theme.typography.tickFontFamily};`)
   }
 
@@ -623,13 +623,13 @@ export function themeToTokens(theme: SemioticTheme): Record<string, any> {
       ...(theme.colors.annotation ? {
         "annotation-color": { $value: theme.colors.annotation, $type: "color" },
       } : {}),
-      ...(theme.typography.legendSize ? {
+      ...(theme.typography.legendSize != null ? {
         "legend-font-size": { $value: `${theme.typography.legendSize}px`, $type: "dimension" },
       } : {}),
-      ...(theme.typography.titleFontSize ? {
+      ...(theme.typography.titleFontSize != null ? {
         "title-font-size": { $value: `${theme.typography.titleFontSize}px`, $type: "dimension" },
       } : {}),
-      ...(theme.typography.tickFontFamily ? {
+      ...(theme.typography.tickFontFamily != null ? {
         "tick-font-family": { $value: theme.typography.tickFontFamily, $type: "fontFamily" },
       } : {}),
     },

--- a/src/components/server/serverChartConfigs.ts
+++ b/src/components/server/serverChartConfigs.ts
@@ -175,6 +175,7 @@ const groupedBarChart: ChartConfig = {
     projection: rest.orientation === "horizontal" ? "horizontal" : "vertical",
     oSort: rest.sort ?? false,
     barPadding: rest.barPadding,
+    ...(rest.roundedTop != null && { roundedTop: rest.roundedTop }),
     ...common,
   }),
 }

--- a/src/components/server/staticAnnotations.tsx
+++ b/src/components/server/staticAnnotations.tsx
@@ -83,7 +83,7 @@ function renderAnnotation(
     case "y-threshold": {
       const value = ann.value
       if (value == null) return null
-      const color = ann.color || theme.colors.annotation || theme.colors.primary
+      const color = ann.color || theme.colors.annotation || theme.colors.text
       const label = ann.label
       const labelPos = ann.labelPosition || "right"
       const dasharray = ann.strokeDasharray || "6,4"
@@ -137,7 +137,7 @@ function renderAnnotation(
       if (value == null || !scales.x) return null
       const px = scales.x(value)
       if (px == null) return null
-      const color = ann.color || theme.colors.annotation || theme.colors.primary
+      const color = ann.color || theme.colors.annotation || theme.colors.text
       const label = ann.label
       const labelPos = ann.labelPosition || "top"
       const dasharray = ann.strokeDasharray || "6,4"
@@ -170,7 +170,7 @@ function renderAnnotation(
       if (y0 == null || y1 == null) return null
       const top = Math.min(y0, y1)
       const height = Math.abs(y1 - y0)
-      const fill = ann.fill || ann.color || theme.colors.annotation || theme.colors.primary
+      const fill = ann.fill || ann.color || theme.colors.annotation || theme.colors.text
       const opacity = ann.opacity ?? 0.1
       return (
         <g key={`ann-band-${index}`}>
@@ -198,7 +198,7 @@ function renderAnnotation(
       const oVal = scales.o(ann.category)
       if (oVal == null) return null
       const bandwidth = scales.o.bandwidth ? scales.o.bandwidth() : 40
-      const color = ann.color || theme.colors.annotation || theme.colors.primary
+      const color = ann.color || theme.colors.annotation || theme.colors.text
       const opacity = ann.opacity ?? 0.1
       // Horizontal ordinal: highlight across Y band
       if (config.projection === "horizontal") {

--- a/src/components/server/staticAnnotations.tsx
+++ b/src/components/server/staticAnnotations.tsx
@@ -83,7 +83,7 @@ function renderAnnotation(
     case "y-threshold": {
       const value = ann.value
       if (value == null) return null
-      const color = ann.color || theme.colors.primary
+      const color = ann.color || theme.colors.annotation || theme.colors.primary
       const label = ann.label
       const labelPos = ann.labelPosition || "right"
       const dasharray = ann.strokeDasharray || "6,4"
@@ -137,7 +137,7 @@ function renderAnnotation(
       if (value == null || !scales.x) return null
       const px = scales.x(value)
       if (px == null) return null
-      const color = ann.color || theme.colors.primary
+      const color = ann.color || theme.colors.annotation || theme.colors.primary
       const label = ann.label
       const labelPos = ann.labelPosition || "top"
       const dasharray = ann.strokeDasharray || "6,4"
@@ -170,7 +170,7 @@ function renderAnnotation(
       if (y0 == null || y1 == null) return null
       const top = Math.min(y0, y1)
       const height = Math.abs(y1 - y0)
-      const fill = ann.fill || ann.color || theme.colors.primary
+      const fill = ann.fill || ann.color || theme.colors.annotation || theme.colors.primary
       const opacity = ann.opacity ?? 0.1
       return (
         <g key={`ann-band-${index}`}>
@@ -198,7 +198,7 @@ function renderAnnotation(
       const oVal = scales.o(ann.category)
       if (oVal == null) return null
       const bandwidth = scales.o.bandwidth ? scales.o.bandwidth() : 40
-      const color = ann.color || theme.colors.primary
+      const color = ann.color || theme.colors.annotation || theme.colors.primary
       const opacity = ann.opacity ?? 0.1
       // Horizontal ordinal: highlight across Y band
       if (config.projection === "horizontal") {

--- a/src/components/server/themeResolver.ts
+++ b/src/components/server/themeResolver.ts
@@ -62,5 +62,9 @@ export function themeStyles(theme: SemioticTheme) {
     labelSize: theme.typography.labelSize,
     tickSize: theme.typography.tickSize,
     categorical: theme.colors.categorical,
+    annotation: theme.colors.annotation || theme.colors.text,
+    legendSize: theme.typography.legendSize || theme.typography.labelSize,
+    titleFontSize: theme.typography.titleFontSize || theme.typography.titleSize,
+    tickFontFamily: theme.typography.tickFontFamily || theme.typography.fontFamily,
   }
 }

--- a/src/components/server/themeResolver.ts
+++ b/src/components/server/themeResolver.ts
@@ -62,9 +62,9 @@ export function themeStyles(theme: SemioticTheme) {
     labelSize: theme.typography.labelSize,
     tickSize: theme.typography.tickSize,
     categorical: theme.colors.categorical,
-    annotation: theme.colors.annotation || theme.colors.text,
-    legendSize: theme.typography.legendSize || theme.typography.labelSize,
-    titleFontSize: theme.typography.titleFontSize || theme.typography.titleSize,
-    tickFontFamily: theme.typography.tickFontFamily || theme.typography.fontFamily,
+    annotation: theme.colors.annotation ?? theme.colors.text,
+    legendSize: theme.typography.legendSize ?? theme.typography.labelSize,
+    titleFontSize: theme.typography.titleFontSize ?? theme.typography.titleSize,
+    tickFontFamily: theme.typography.tickFontFamily ?? theme.typography.fontFamily,
   }
 }

--- a/src/components/store/ThemeStore.ts
+++ b/src/components/store/ThemeStore.ts
@@ -79,17 +79,20 @@ export const LIGHT_THEME: SemioticTheme = {
       "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf"
     ],
     sequential: "blues",
+    diverging: "RdBu",
     background: "transparent",
     text: "#333",
     textSecondary: "#666",
     grid: "#e0e0e0",
-    border: "#ccc"
+    border: "#ccc",
+    selection: "#00a2ce",
+    selectionOpacity: 0.15,
   },
   typography: {
     fontFamily: "sans-serif",
     titleSize: 16,
     labelSize: 12,
-    tickSize: 10
+    tickSize: 10,
   }
 }
 
@@ -102,11 +105,14 @@ export const DARK_THEME: SemioticTheme = {
       "#a1887f", "#f06292", "#90a4ae", "#dce775", "#4dd0e1"
     ],
     sequential: "blues",
+    diverging: "RdBu",
     background: "#1a1a2e",
     text: "#e0e0e0",
     textSecondary: "#aaa",
     grid: "#333",
-    border: "#555"
+    border: "#555",
+    selection: "#4fc3f7",
+    selectionOpacity: 0.15,
   },
   typography: {
     fontFamily: "sans-serif",

--- a/src/components/store/ThemeStore.ts
+++ b/src/components/store/ThemeStore.ts
@@ -21,12 +21,20 @@ export interface SemioticTheme {
     selection?: string
     /** Opacity for non-selected (dimmed) elements, 0–1 */
     selectionOpacity?: number
+    /** Default annotation text/marker color. Falls back to `text` if unset. */
+    annotation?: string
   }
   typography: {
     fontFamily: string
     titleSize: number
     labelSize: number
     tickSize: number
+    /** Font size for legend text. Falls back to `labelSize` if unset. */
+    legendSize?: number
+    /** Font family for axis tick labels. Use monospace for aligned numerics. Falls back to `fontFamily`. */
+    tickFontFamily?: string
+    /** Font size for chart title. Falls back to `titleSize` if unset. */
+    titleFontSize?: number
   }
   tooltip?: {
     background?: string
@@ -36,6 +44,12 @@ export interface SemioticTheme {
     shadow?: string
   }
   borderRadius?: string
+  accessibility?: {
+    /** Auto-swap to color-blind safe palette when true */
+    colorBlindSafe?: boolean
+    /** Enforce minimum 3:1 contrast ratios */
+    highContrast?: boolean
+  }
 }
 
 // ── Curated palettes ────────────────────────────────────────────────────────

--- a/src/components/stream/SceneToSVG.tsx
+++ b/src/components/stream/SceneToSVG.tsx
@@ -340,7 +340,7 @@ export function ordinalSceneNodeToSVG(node: OrdinalSceneNode, i: number): React.
   // Build a unique key combining node type, category (or group), and index
   // to avoid duplicate key warnings when multiple nodes share the same index
   // within stacked/grouped ordinal charts.
-  const category = (node as any).category || (node as any).group || ""
+  const category = ("category" in node ? node.category : undefined) || ("group" in node ? node.group : undefined) || ""
   const nodeKey = (suffix: string) => `ord-${node.type}-${category}-${i}-${suffix}`
   const baseKey = `ord-${node.type}-${category}-${i}`
 
@@ -349,9 +349,21 @@ export function ordinalSceneNodeToSVG(node: OrdinalSceneNode, i: number): React.
       const n = node as RectSceneNode
       if (n.roundedTop && n.roundedTop > 0) {
         const r = Math.min(n.roundedTop, n.w / 2, n.h / 2)
-        const d = n.roundedEdge === "right"
-          ? `M${n.x},${n.y} L${n.x + n.w - r},${n.y} A${r},${r} 0 0 1 ${n.x + n.w},${n.y + r} L${n.x + n.w},${n.y + n.h - r} A${r},${r} 0 0 1 ${n.x + n.w - r},${n.y + n.h} L${n.x},${n.y + n.h} Z`
-          : `M${n.x},${n.y + n.h} L${n.x},${n.y + r} A${r},${r} 0 0 1 ${n.x + r},${n.y} L${n.x + n.w - r},${n.y} A${r},${r} 0 0 1 ${n.x + n.w},${n.y + r} L${n.x + n.w},${n.y + n.h} Z`
+        const { x, y, w, h } = n
+        let d: string
+        switch (n.roundedEdge) {
+          case "right":
+            d = `M${x},${y} L${x+w-r},${y} A${r},${r} 0 0 1 ${x+w},${y+r} L${x+w},${y+h-r} A${r},${r} 0 0 1 ${x+w-r},${y+h} L${x},${y+h} Z`
+            break
+          case "left":
+            d = `M${x+w},${y} L${x+r},${y} A${r},${r} 0 0 0 ${x},${y+r} L${x},${y+h-r} A${r},${r} 0 0 0 ${x+r},${y+h} L${x+w},${y+h} Z`
+            break
+          case "bottom":
+            d = `M${x},${y} L${x+w},${y} L${x+w},${y+h-r} A${r},${r} 0 0 1 ${x+w-r},${y+h} L${x+r},${y+h} A${r},${r} 0 0 1 ${x},${y+h-r} Z`
+            break
+          default: // "top"
+            d = `M${x},${y+h} L${x},${y+r} A${r},${r} 0 0 1 ${x+r},${y} L${x+w-r},${y} A${r},${r} 0 0 1 ${x+w},${y+r} L${x+w},${y+h} Z`
+        }
         return (
           <path
             key={baseKey}

--- a/src/components/stream/ordinalSceneBuilders/barScene.ts
+++ b/src/components/stream/ordinalSceneBuilders/barScene.ts
@@ -114,14 +114,35 @@ export function buildBarScene(ctx: OrdinalSceneContext, layout: OrdinalLayout): 
       if (!byCat.has(cat)) byCat.set(cat, [])
       byCat.get(cat)!.push(n)
     }
+    const isV = projection === "vertical"
+    const baseline = rScale(0)
     for (const rects of byCat.values()) {
       if (rects.length === 0) continue
-      const isV = projection === "vertical"
-      const topmost = isV
-        ? rects.reduce((a, b) => a.y < b.y ? a : b)
-        : rects.reduce((a, b) => (a.x + a.w) > (b.x + b.w) ? a : b)
-      topmost.roundedTop = r
-      topmost.roundedEdge = isV ? "top" : "right"
+      // Split into positive (above/right of baseline) and negative (below/left)
+      const positive = rects.filter(n => {
+        const val = n.datum?.__aggregateValue ?? 0
+        return val >= 0
+      })
+      const negative = rects.filter(n => {
+        const val = n.datum?.__aggregateValue ?? 0
+        return val < 0
+      })
+      // Topmost positive segment: farthest from baseline in positive direction
+      if (positive.length > 0) {
+        const topmost = isV
+          ? positive.reduce((a, b) => a.y < b.y ? a : b)
+          : positive.reduce((a, b) => (a.x + a.w) > (b.x + b.w) ? a : b)
+        topmost.roundedTop = r
+        topmost.roundedEdge = isV ? "top" : "right"
+      }
+      // Bottommost negative segment: farthest from baseline in negative direction
+      if (negative.length > 0) {
+        const bottommost = isV
+          ? negative.reduce((a, b) => (a.y + a.h) > (b.y + b.h) ? a : b)
+          : negative.reduce((a, b) => a.x < b.x ? a : b)
+        bottommost.roundedTop = r
+        bottommost.roundedEdge = isV ? "bottom" : "left"
+      }
     }
   }
 
@@ -129,7 +150,7 @@ export function buildBarScene(ctx: OrdinalSceneContext, layout: OrdinalLayout): 
 }
 
 export function buildClusterBarScene(ctx: OrdinalSceneContext, layout: OrdinalLayout): OrdinalSceneNode[] {
-  const { scales, columns, getR, getGroup, resolvePieceStyle } = ctx
+  const { scales, columns, config, getR, getGroup, resolvePieceStyle } = ctx
   const { r: rScale, projection } = scales
   const nodes: OrdinalSceneNode[] = []
   const isVertical = projection === "vertical"
@@ -185,6 +206,21 @@ export function buildClusterBarScene(ctx: OrdinalSceneContext, layout: OrdinalLa
             style, d, groupKeys[gi]
           ))
         }
+      }
+    }
+  }
+
+  // Apply roundedTop — each grouped bar is independent (not stacked)
+  if (config.roundedTop && config.roundedTop > 0) {
+    const r = Math.max(0, config.roundedTop)
+    for (const n of nodes) {
+      if (n.type !== "rect") continue
+      const val = getR(n.datum)
+      n.roundedTop = r
+      if (isVertical) {
+        n.roundedEdge = val >= 0 ? "top" : "bottom"
+      } else {
+        n.roundedEdge = val >= 0 ? "right" : "left"
       }
     }
   }

--- a/src/components/stream/ordinalSceneBuilders/barScene.ts
+++ b/src/components/stream/ordinalSceneBuilders/barScene.ts
@@ -115,7 +115,6 @@ export function buildBarScene(ctx: OrdinalSceneContext, layout: OrdinalLayout): 
       byCat.get(cat)!.push(n)
     }
     const isV = projection === "vertical"
-    const baseline = rScale(0)
     for (const rects of byCat.values()) {
       if (rects.length === 0) continue
       // Split into positive (above/right of baseline) and negative (below/left)

--- a/src/components/stream/renderers/barCanvasRenderer.ts
+++ b/src/components/stream/renderers/barCanvasRenderer.ts
@@ -24,25 +24,42 @@ export const barCanvasRenderer: StreamRendererFn = (ctx, nodes, scales, layout) 
       ctx.fillStyle = (typeof node.style.fill === "string" ? resolveCSSColor(ctx, node.style.fill) : node.style.fill) || "#007bff"
       const r = Math.min(node.roundedTop, node.w / 2, node.h / 2)
       ctx.beginPath()
-      if (node.roundedEdge === "right") {
-        // Horizontal: round the right edge (value end)
-        ctx.moveTo(node.x, node.y)                              // top-left
-        ctx.lineTo(node.x + node.w - r, node.y)                 // top edge
-        ctx.arcTo(node.x + node.w, node.y, node.x + node.w, node.y + r, r) // top-right
-        ctx.lineTo(node.x + node.w, node.y + node.h - r)        // right side down
-        ctx.arcTo(node.x + node.w, node.y + node.h, node.x + node.w - r, node.y + node.h, r) // bottom-right
-        ctx.lineTo(node.x, node.y + node.h)                     // bottom edge
-        ctx.closePath()
-      } else {
-        // Vertical: round the top edge (value end)
-        ctx.moveTo(node.x, node.y + node.h)                     // bottom-left
-        ctx.lineTo(node.x, node.y + r)                           // left side up
-        ctx.arcTo(node.x, node.y, node.x + r, node.y, r)       // top-left
-        ctx.lineTo(node.x + node.w - r, node.y)                 // top edge
-        ctx.arcTo(node.x + node.w, node.y, node.x + node.w, node.y + r, r) // top-right
-        ctx.lineTo(node.x + node.w, node.y + node.h)            // right side down
-        ctx.closePath()
+      const { x, y, w, h } = node
+      switch (node.roundedEdge) {
+        case "right": // horizontal positive: round right edge
+          ctx.moveTo(x, y)
+          ctx.lineTo(x + w - r, y)
+          ctx.arcTo(x + w, y, x + w, y + r, r)
+          ctx.lineTo(x + w, y + h - r)
+          ctx.arcTo(x + w, y + h, x + w - r, y + h, r)
+          ctx.lineTo(x, y + h)
+          break
+        case "left": // horizontal negative: round left edge
+          ctx.moveTo(x + w, y)
+          ctx.lineTo(x + r, y)
+          ctx.arcTo(x, y, x, y + r, r)
+          ctx.lineTo(x, y + h - r)
+          ctx.arcTo(x, y + h, x + r, y + h, r)
+          ctx.lineTo(x + w, y + h)
+          break
+        case "bottom": // vertical negative: round bottom edge
+          ctx.moveTo(x, y)
+          ctx.lineTo(x + w, y)
+          ctx.lineTo(x + w, y + h - r)
+          ctx.arcTo(x + w, y + h, x + w - r, y + h, r)
+          ctx.lineTo(x + r, y + h)
+          ctx.arcTo(x, y + h, x, y + h - r, r)
+          break
+        default: // "top" — vertical positive: round top edge
+          ctx.moveTo(x, y + h)
+          ctx.lineTo(x, y + r)
+          ctx.arcTo(x, y, x + r, y, r)
+          ctx.lineTo(x + w - r, y)
+          ctx.arcTo(x + w, y, x + w, y + r, r)
+          ctx.lineTo(x + w, y + h)
+          break
       }
+      ctx.closePath()
       ctx.fill()
 
       if (node.style.stroke && node.style.stroke !== "none") {

--- a/src/components/stream/types.ts
+++ b/src/components/stream/types.ts
@@ -223,8 +223,8 @@ export interface RectSceneNode {
   h: number
   /** Rounded corner radius on the end away from the baseline */
   roundedTop?: number
-  /** Which edge to round: "top" (vertical bars), "right" (horizontal bars) */
-  roundedEdge?: "top" | "right"
+  /** Which edge to round: "top"/"bottom" (vertical), "right"/"left" (horizontal) */
+  roundedEdge?: "top" | "bottom" | "right" | "left"
   style: Style
   datum: any
   group?: string


### PR DESCRIPTION

  1. CLI Screenshot Generator
  - scripts/demo-server-render.mjs — renders 7 charts + 1 dashboard across multiple themes
  - Supports --png for retina PNG output, --out ./dir for custom output
  - Charts: bar (tufte), stacked bar (dark), line (journalist), pie (pastels, rounded), donut (italian), sankey (tufte-dark), gauge (high-contrast)
  - Dashboard: bi-tool theme, 3-column layout

  2. as any reduction
  - SceneToSVG.tsx — replaced (node as any).category with proper "category" in node checks
  - Current count: ~140 (down from 240 at session start)

  3. OUTSTANDING_WORK.md cleanup
  - All DONE items collapsed to one-liner references
  - Sections reorganized: Theming, Push API, Server Rendering, Bugs, TypeScript, Animation, Performance, MCP, Docs, Geo
  - Date updated to 2026-04-12

  4. Theming 

  SemioticTheme interface expanded:
  - colors.annotation — annotation text/marker color with --semiotic-annotation-color CSS var
  - typography.legendSize — legend font size with --semiotic-legend-font-size CSS var
  - typography.titleFontSize — title size with --semiotic-title-font-size CSS var
  - typography.tickFontFamily — tick font with --semiotic-tick-font-family CSS var
  - accessibility.colorBlindSafe / accessibility.highContrast — type definitions (runtime wiring tracked for future)

  CSS variables wired into components:
  - Annotation.tsx — uses --semiotic-annotation-color with --semiotic-text fallback
  - Legend.tsx — legend text uses --semiotic-legend-font-size with 12px fallback
  - staticAnnotations.tsx — server annotations use theme.colors.annotation || theme.colors.primary

  Serialization updated:
  - themeToCSS() — emits all 4 new CSS variables
  - themeToTokens() — emits DTCG design tokens for annotation, legend, title, tick
  - themeStyles() (server) — resolves new fields with fallbacks

  Theme presets enhanced:
  - Tufte: annotation: "#8b0000", tickFontFamily: monospace, legendSize: 11
  - Journalist: annotation: "#e45050", tickFontFamily: monospace, legendSize: 11, titleSize: 18