### PR TITLE
Stream Frames perf pass: hit-testing, caches, and pointer-move coalescing

### DIFF
--- a/docs/src/pages/charts/SwimlaneChartPage.js
+++ b/docs/src/pages/charts/SwimlaneChartPage.js
@@ -400,6 +400,59 @@ ref.current.push({ lane: "Backend", task: "Auth", value: 2 })
       </div>
 
       {/* ----------------------------------------------------------------- */}
+      {/* Themed Borders */}
+      {/* ----------------------------------------------------------------- */}
+      <h2 id="themed-borders">Themed Borders</h2>
+
+      <p>
+        Use <code>frameProps.pieceStyle</code> to add a stroke between swimlane
+        items that adapts to dark and light mode. The CSS custom property{" "}
+        <code>var(--semiotic-bg)</code> resolves to the chart background color,
+        so borders always match the surrounding area.
+      </p>
+
+      <div ref={null} style={{ background: "var(--surface-1)", borderRadius: 8, padding: 16, border: "1px solid var(--surface-3)", overflow: "hidden", marginBottom: 16 }}>
+        <SwimlaneChart
+          data={STATIC_DATA}
+          categoryAccessor="lane"
+          subcategoryAccessor="task"
+          valueAccessor="value"
+          colorBy="task"
+          colorScheme={Object.values(TASK_COLORS)}
+          width={600}
+          height={200}
+          orientation="horizontal"
+          enableHover
+          showGrid
+          margin={{ left: 90 }}
+          frameProps={{
+            pieceStyle: () => ({
+              stroke: "var(--semiotic-bg, #fff)",
+              strokeWidth: 1,
+            }),
+          }}
+        />
+      </div>
+
+      <CodeBlock
+        code={`<SwimlaneChart
+  data={data}
+  categoryAccessor="lane"
+  subcategoryAccessor="task"
+  valueAccessor="value"
+  colorBy="task"
+  orientation="horizontal"
+  frameProps={{
+    pieceStyle: () => ({
+      stroke: "var(--semiotic-bg, #fff)",  // adapts to dark/light mode
+      strokeWidth: 1,
+    }),
+  }}
+/>`}
+        language="jsx"
+      />
+
+      {/* ----------------------------------------------------------------- */}
       {/* Props */}
       {/* ----------------------------------------------------------------- */}
       <h2 id="props">Props</h2>

--- a/docs/src/pages/charts/SwimlaneChartPage.js
+++ b/docs/src/pages/charts/SwimlaneChartPage.js
@@ -411,7 +411,7 @@ ref.current.push({ lane: "Backend", task: "Auth", value: 2 })
         so borders always match the surrounding area.
       </p>
 
-      <div ref={null} style={{ background: "var(--surface-1)", borderRadius: 8, padding: 16, border: "1px solid var(--surface-3)", overflow: "hidden", marginBottom: 16 }}>
+      <div style={{ background: "var(--surface-1)", borderRadius: 8, padding: 16, border: "1px solid var(--surface-3)", overflow: "hidden", marginBottom: 16 }}>
         <SwimlaneChart
           data={STATIC_DATA}
           categoryAccessor="lane"

--- a/src/components/stream/GeoCanvasHitTester.ts
+++ b/src/components/stream/GeoCanvasHitTester.ts
@@ -2,6 +2,7 @@ import type { GeoAreaSceneNode, GeoSceneNode } from "./geoTypes"
 import type { PointSceneNode, LineSceneNode } from "./types"
 import type { Quadtree } from "d3-quadtree"
 import { getHitRadius } from "./hitTestUtils"
+import { findHitPointInQuadtree } from "./quadtreeHitTest"
 
 export interface GeoHitResult {
   node: GeoSceneNode
@@ -31,22 +32,11 @@ export function findNearestGeoNode(
   // ── 1. Point nodes ──────────────────────────────────────────────
 
   if (pointQuadtree) {
-    // Widen the query radius so the quadtree returns candidates that are
-    // farther than maxDistance but still within their own hit radius.
-    // `getHitRadius(r) = max(r + 5, 12, maxDistance)` so we widen to that.
-    const queryRadius = Math.max(maxDistance, maxPointRadius + 5, 12)
-    const candidate = pointQuadtree.find(mouseX, mouseY, queryRadius) ?? null
-    if (candidate) {
-      const dx = candidate.x - mouseX
-      const dy = candidate.y - mouseY
-      const dist = Math.sqrt(dx * dx + dy * dy)
-      const hitRadius = getHitRadius(candidate.r, maxDistance)
-      if (dist <= hitRadius) {
-        return { node: candidate, distance: dist }
-      }
-    }
-    // Quadtree result is authoritative when its query radius covers the
-    // largest possible hit radius — no need for the linear fallback.
+    // Visit every candidate within the widened search radius so variable-size
+    // points don't miss hits (quadtree.find's nearest-only behavior would
+    // shadow a farther, larger point that still contains the cursor).
+    const hit = findHitPointInQuadtree(pointQuadtree, mouseX, mouseY, maxDistance, maxPointRadius)
+    if (hit) return hit
   } else {
     // Linear scan when no spatial index is available
     let bestPoint: PointSceneNode | null = null

--- a/src/components/stream/GeoCanvasHitTester.ts
+++ b/src/components/stream/GeoCanvasHitTester.ts
@@ -25,16 +25,17 @@ export function findNearestGeoNode(
   mouseY: number,
   maxDistance: number,
   hitCtx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
-  pointQuadtree?: Quadtree<PointSceneNode>
+  pointQuadtree?: Quadtree<PointSceneNode> | null,
+  maxPointRadius = 0
 ): GeoHitResult | null {
   // ── 1. Point nodes ──────────────────────────────────────────────
 
-  const pointNodes = nodes.filter(
-    (n): n is PointSceneNode => n.type === "point"
-  )
-
-  if (pointQuadtree && pointNodes.length > 0) {
-    const candidate = pointQuadtree.find(mouseX, mouseY, maxDistance) ?? null
+  if (pointQuadtree) {
+    // Widen the query radius so the quadtree returns candidates that are
+    // farther than maxDistance but still within their own hit radius.
+    // `getHitRadius(r) = max(r + 5, 12, maxDistance)` so we widen to that.
+    const queryRadius = Math.max(maxDistance, maxPointRadius + 5, 12)
+    const candidate = pointQuadtree.find(mouseX, mouseY, queryRadius) ?? null
     if (candidate) {
       const dx = candidate.x - mouseX
       const dy = candidate.y - mouseY
@@ -44,67 +45,67 @@ export function findNearestGeoNode(
         return { node: candidate, distance: dist }
       }
     }
-  }
+    // Quadtree result is authoritative when its query radius covers the
+    // largest possible hit radius — no need for the linear fallback.
+  } else {
+    // Linear scan when no spatial index is available
+    let bestPoint: PointSceneNode | null = null
+    let bestPointDist = maxDistance
 
-  // Linear scan fallback for points
-  let bestPoint: PointSceneNode | null = null
-  let bestPointDist = maxDistance
-
-  for (const node of pointNodes) {
-    const dx = node.x - mouseX
-    const dy = node.y - mouseY
-    const dist = Math.sqrt(dx * dx + dy * dy)
-    const hitRadius = getHitRadius(node.r, maxDistance)
-    if (dist <= hitRadius && dist < bestPointDist) {
-      bestPoint = node
-      bestPointDist = dist
+    for (const node of nodes) {
+      if (node.type !== "point") continue
+      const dx = node.x - mouseX
+      const dy = node.y - mouseY
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      const hitRadius = getHitRadius(node.r, maxDistance)
+      if (dist <= hitRadius && dist < bestPointDist) {
+        bestPoint = node
+        bestPointDist = dist
+      }
     }
-  }
 
-  if (bestPoint) {
-    return { node: bestPoint, distance: bestPointDist }
+    if (bestPoint) {
+      return { node: bestPoint, distance: bestPointDist }
+    }
   }
 
   // ── 2. Geo area nodes (reverse order = top layer wins) ─────────
 
-  const geoAreas = nodes.filter(
-    (n): n is GeoAreaSceneNode => n.type === "geoarea" && n.interactive !== false
-  )
-
-  for (let i = geoAreas.length - 1; i >= 0; i--) {
-    const node = geoAreas[i]
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    const node = nodes[i]
+    if (node.type !== "geoarea") continue
+    const area = node as GeoAreaSceneNode
+    if (area.interactive === false) continue
 
     // Quick bounds check
-    const [[x0, y0], [x1, y1]] = node.bounds
+    const [[x0, y0], [x1, y1]] = area.bounds
     if (mouseX < x0 || mouseX > x1 || mouseY < y0 || mouseY > y1) continue
 
     // isPointInPath with Path2D (lazily cached to avoid re-parsing per mouse event)
-    if (!node._cachedPath2D) {
-      node._cachedPath2D = new Path2D(node.pathData)
+    if (!area._cachedPath2D) {
+      area._cachedPath2D = new Path2D(area.pathData)
     }
-    if (hitCtx.isPointInPath(node._cachedPath2D, mouseX, mouseY)) {
-      return { node, distance: 0 }
+    if (hitCtx.isPointInPath(area._cachedPath2D, mouseX, mouseY)) {
+      return { node: area, distance: 0 }
     }
   }
 
   // ── 3. Line nodes ──────────────────────────────────────────────
 
-  const lineNodes = nodes.filter(
-    (n): n is LineSceneNode => n.type === "line"
-  )
-
   let bestLine: LineSceneNode | null = null
   let bestLineDist = maxDistance
 
-  for (const node of lineNodes) {
-    const { path } = node
+  for (const node of nodes) {
+    if (node.type !== "line") continue
+    const line = node as LineSceneNode
+    const { path } = line
+    const hitWidth = Math.max((line.style.strokeWidth || 2) + 4, 5)
     for (let j = 0; j < path.length - 1; j++) {
       const [ax, ay] = path[j]
       const [bx, by] = path[j + 1]
       const dist = pointToSegmentDistance(mouseX, mouseY, ax, ay, bx, by)
-      const hitWidth = Math.max((node.style.strokeWidth || 2) + 4, 5)
       if (dist <= hitWidth && dist < bestLineDist) {
-        bestLine = node
+        bestLine = line
         bestLineDist = dist
       }
     }

--- a/src/components/stream/GeoPipelineStore.ts
+++ b/src/components/stream/GeoPipelineStore.ts
@@ -13,6 +13,7 @@ import {
 import type { GeoProjection, GeoPath, GeoPermissibleObjects } from "d3-geo"
 import type { ZoomTransform } from "d3-zoom"
 import { scaleLinear } from "d3-scale"
+import { quadtree as d3Quadtree, type Quadtree } from "d3-quadtree"
 import type {
   GeoPipelineConfig,
   GeoScales,
@@ -280,6 +281,13 @@ export class GeoPipelineStore {
   scales: GeoScales | null = null
   version = 0
 
+  // Spatial index for point hit testing (built when point count exceeds threshold)
+  private static readonly QUADTREE_THRESHOLD = 500
+  private _quadtree: Quadtree<PointSceneNode> | null = null
+  /** Largest visual point radius in the current scene; used to widen quadtree
+   *  hit-test radius when points are larger than the default maxDistance. */
+  private _maxPointRadius = 0
+
   // Internal state
   private projection: GeoProjection | null = null
   private geoPath: GeoPath<any, GeoPermissibleObjects> | null = null
@@ -458,6 +466,7 @@ export class GeoPipelineStore {
     // Step 4: Build scene nodes
     const prevScene = this.scene
     this.scene = this.buildSceneNodes(layout)
+    this.rebuildQuadtree()
 
     // Step 5: Apply distance cartogram transform
     if (config.projectionTransform) {
@@ -614,6 +623,7 @@ export class GeoPipelineStore {
 
     // Rebuild scene nodes with zoomed projection (skip re-fitting)
     this.scene = this.buildSceneNodes(layout)
+    this.rebuildQuadtree()
 
     // Apply cartogram transform if configured
     if (this.config.projectionTransform) {
@@ -653,6 +663,7 @@ export class GeoPipelineStore {
     }
 
     this.scene = this.buildSceneNodes(layout)
+    this.rebuildQuadtree()
     if (this.config.projectionTransform) {
       this.applyCartogramTransform(this.config.projectionTransform, layout)
     }
@@ -687,6 +698,7 @@ export class GeoPipelineStore {
 
     // Rebuild scene
     this.scene = this.buildSceneNodes(layout)
+    this.rebuildQuadtree()
     if (this.config.projectionTransform) {
       this.applyCartogramTransform(this.config.projectionTransform, layout)
     }
@@ -721,6 +733,49 @@ export class GeoPipelineStore {
       return this.pointBuffer.toArray()
     }
     return this.pointData
+  }
+
+  /**
+   * Build (or clear) the quadtree spatial index for point scene nodes.
+   * Only built when the point count exceeds QUADTREE_THRESHOLD; below that
+   * a linear scan is faster than indexing overhead. Also tracks the largest
+   * point radius so the hit tester can widen its query when symbols are big.
+   */
+  private rebuildQuadtree(): void {
+    let maxR = 0
+    let pointCount = 0
+    for (const node of this.scene) {
+      if (node.type === "point") {
+        pointCount++
+        if (node.r > maxR) maxR = node.r
+      }
+    }
+    this._maxPointRadius = maxR
+
+    if (pointCount <= GeoPipelineStore.QUADTREE_THRESHOLD) {
+      this._quadtree = null
+      return
+    }
+
+    const points: PointSceneNode[] = new Array(pointCount)
+    let i = 0
+    for (const node of this.scene) {
+      if (node.type === "point") points[i++] = node
+    }
+    this._quadtree = d3Quadtree<PointSceneNode>()
+      .x(n => n.x)
+      .y(n => n.y)
+      .addAll(points)
+  }
+
+  /** Quadtree spatial index for point hit testing, or null when below threshold. */
+  get quadtree(): Quadtree<PointSceneNode> | null {
+    return this._quadtree
+  }
+
+  /** Largest visual point radius in the current scene. */
+  get maxPointRadius(): number {
+    return this._maxPointRadius
   }
 
   private buildSceneNodes(layout: StreamLayout): GeoSceneNode[] {
@@ -789,13 +844,17 @@ export class GeoPipelineStore {
       const coords = lineDataAcc(line)
       if (!coords || coords.length < 2) continue
 
-      const lineCoords: [number, number][] = coords.map((d: any) => [xAcc(d), yAcc(d)])
-
-      let screenPath: [number, number][]
+      // Project lon/lat coords directly into a screen path, skipping unprojectable points.
+      // For "geo" lines, densify along great-circle arcs between each pair of points.
+      let screenPath: [number, number][] = []
 
       if (config.lineType === "geo") {
-        // Densify along great-circle arcs between each pair of points
-        const geoCoords: [number, number][] = []
+        // We need lineCoords to compute geoDistance/geoInterpolate, but we
+        // project on the fly to avoid a second array allocation.
+        const lineCoords: [number, number][] = new Array(coords.length)
+        for (let i = 0; i < coords.length; i++) {
+          lineCoords[i] = [xAcc(coords[i]), yAcc(coords[i])]
+        }
         for (let i = 0; i < lineCoords.length - 1; i++) {
           const start = lineCoords[i]
           const end = lineCoords[i + 1]
@@ -804,17 +863,17 @@ export class GeoPipelineStore {
           const interpolate = geoInterpolate(start, end)
           for (let s = 0; s <= steps; s++) {
             if (i > 0 && s === 0) continue // avoid duplicate at segment joins
-            geoCoords.push(interpolate(s / steps) as [number, number])
+            const projected = proj(interpolate(s / steps) as [number, number])
+            if (projected != null) screenPath.push(projected as [number, number])
           }
         }
-        screenPath = geoCoords
-          .map(([lon, lat]) => proj([lon, lat]))
-          .filter((p): p is [number, number] => p != null)
       } else {
-        // Straight-line segments in projected space
-        screenPath = lineCoords
-          .map(([lon, lat]) => proj([lon, lat]))
-          .filter((p): p is [number, number] => p != null)
+        // Straight-line segments in projected space — fused project + filter.
+        for (let i = 0; i < coords.length; i++) {
+          const d = coords[i]
+          const projected = proj([xAcc(d), yAcc(d)])
+          if (projected != null) screenPath.push(projected as [number, number])
+        }
       }
 
       if (screenPath.length < 2) continue
@@ -825,9 +884,9 @@ export class GeoPipelineStore {
 
       // Apply flow style transformation (only for simple 2-point source→target flows;
       // multi-point polylines keep their full geometry).
-      if (lineCoords.length === 2 && screenPath.length >= 2 && config.flowStyle === "arc") {
+      if (coords.length === 2 && screenPath.length >= 2 && config.flowStyle === "arc") {
         screenPath = buildArcPath(screenPath[0], screenPath[screenPath.length - 1])
-      } else if (lineCoords.length === 2 && screenPath.length >= 2 && config.flowStyle === "offset") {
+      } else if (coords.length === 2 && screenPath.length >= 2 && config.flowStyle === "offset") {
         if (config.lineType === "geo") {
           // Offset each point along its local normal to preserve great-circle curvature
           screenPath = buildOffsetGeoPath(screenPath, resolvedStrokeWidth)

--- a/src/components/stream/NetworkCanvasHitTester.ts
+++ b/src/components/stream/NetworkCanvasHitTester.ts
@@ -179,6 +179,26 @@ function getHitContext(): CanvasRenderingContext2D | null {
   return _hitCtx
 }
 
+/**
+ * Lazily build (and cache) a Path2D for an edge. Re-parses only when `pathD`
+ * actually changes — Path2D parsing is the dominant cost in network hit
+ * testing for large sankey/chord scenes.
+ */
+function getEdgePath2D(
+  edge: { pathD: string; _cachedPath2D?: Path2D; _cachedPath2DSource?: string }
+): Path2D | null {
+  if (edge._cachedPath2D && edge._cachedPath2DSource === edge.pathD) {
+    return edge._cachedPath2D
+  }
+  try {
+    edge._cachedPath2D = new Path2D(edge.pathD)
+    edge._cachedPath2DSource = edge.pathD
+    return edge._cachedPath2D
+  } catch {
+    return null
+  }
+}
+
 // ── Edge hit testing ────────────────────────────────────────────────────
 
 function hitTestEdge(
@@ -208,11 +228,11 @@ function hitTestBezierEdge(
   // Use Path2D for approximate point-in-path testing
   if (!edge.pathD) return null
 
-  try {
-    const path = new Path2D(edge.pathD)
-    const ctx = getHitContext()
-    if (!ctx) return null
+  const path = getEdgePath2D(edge)
+  const ctx = getHitContext()
+  if (!path || !ctx) return null
 
+  try {
     // First check isPointInPath for filled/wide bezier bands (sankey ribbons)
     if (ctx.isPointInPath(path, px, py)) {
       // Return midpoint of the band as hover position
@@ -290,17 +310,17 @@ function hitTestLineEdge(
 }
 
 function hitTestPathEdge(
-  edge: { pathD: string; datum: any },
+  edge: { pathD: string; datum: any; _cachedPath2D?: Path2D; _cachedPath2DSource?: string },
   px: number,
   py: number
 ): NetworkHitResult | null {
   if (!edge.pathD) return null
 
-  try {
-    const path = new Path2D(edge.pathD)
-    const ctx = getHitContext()
-    if (!ctx) return null
+  const path = getEdgePath2D(edge)
+  const ctx = getHitContext()
+  if (!path || !ctx) return null
 
+  try {
     // Check filled area first (for wide ribbon edges)
     if (ctx.isPointInPath(path, px, py)) {
       return {

--- a/src/components/stream/OrdinalCanvasHitTester.ts
+++ b/src/components/stream/OrdinalCanvasHitTester.ts
@@ -22,11 +22,13 @@ export function findNearestOrdinalNode(
   maxPointRadius = 0
 ): OrdinalHitResult | null {
   let best: OrdinalHitResult | null = null
-  let pointHitConfirmed = false
 
   // Fast path: quadtree-accelerated point hit test for swarm plots.
   // Uses `visit()` rather than `find()` so variable-size points (where a
   // farther point with a larger r can still be a valid hit) aren't missed.
+  // When a quadtree is provided, it's authoritative for points — whether
+  // it returns a hit or null, the linear point scan below is skipped so
+  // large swarms stay O(log n) for point testing.
   if (pointQuadtree) {
     const hit = findHitPointInQuadtree(pointQuadtree, px, py, maxDistance, maxPointRadius)
     if (hit) {
@@ -36,7 +38,6 @@ export function findNearestOrdinalNode(
         y: hit.node.y,
         distance: hit.distance
       }
-      pointHitConfirmed = true
     }
   }
 
@@ -48,8 +49,8 @@ export function findNearestOrdinalNode(
         result = hitTestRect(node, px, py)
         break
       case "point":
-        // Skip linear point scan when the quadtree already gave us an answer
-        if (pointQuadtree && pointHitConfirmed) break
+        // Quadtree visit was authoritative — skip redundant linear scan.
+        if (pointQuadtree) break
         result = hitTestPoint(node, px, py, maxDistance)
         break
       case "wedge":

--- a/src/components/stream/OrdinalCanvasHitTester.ts
+++ b/src/components/stream/OrdinalCanvasHitTester.ts
@@ -2,6 +2,7 @@ import type { OrdinalSceneNode, WedgeSceneNode, BoxplotSceneNode, ViolinSceneNod
 import type { PointSceneNode, RectSceneNode, HoverData } from "./types"
 import type { Quadtree } from "d3-quadtree"
 import { hitTestRect as sharedHitTestRect, normalizeAngle, getHitRadius } from "./hitTestUtils"
+import { findHitPointInQuadtree } from "./quadtreeHitTest"
 
 export interface OrdinalHitResult {
   datum: any
@@ -24,15 +25,18 @@ export function findNearestOrdinalNode(
   let pointHitConfirmed = false
 
   // Fast path: quadtree-accelerated point hit test for swarm plots.
+  // Uses `visit()` rather than `find()` so variable-size points (where a
+  // farther point with a larger r can still be a valid hit) aren't missed.
   if (pointQuadtree) {
-    const queryRadius = Math.max(maxDistance, maxPointRadius + 5, 12)
-    const candidate = pointQuadtree.find(px, py, queryRadius) ?? null
-    if (candidate) {
-      const result = hitTestPoint(candidate, px, py, maxDistance)
-      if (result && result.distance < maxDistance) {
-        best = result
-        pointHitConfirmed = true
+    const hit = findHitPointInQuadtree(pointQuadtree, px, py, maxDistance, maxPointRadius)
+    if (hit) {
+      best = {
+        datum: hit.node.datum,
+        x: hit.node.x,
+        y: hit.node.y,
+        distance: hit.distance
       }
+      pointHitConfirmed = true
     }
   }
 

--- a/src/components/stream/OrdinalCanvasHitTester.ts
+++ b/src/components/stream/OrdinalCanvasHitTester.ts
@@ -1,5 +1,6 @@
 import type { OrdinalSceneNode, WedgeSceneNode, BoxplotSceneNode, ViolinSceneNode } from "./ordinalTypes"
 import type { PointSceneNode, RectSceneNode, HoverData } from "./types"
+import type { Quadtree } from "d3-quadtree"
 import { hitTestRect as sharedHitTestRect, normalizeAngle, getHitRadius } from "./hitTestUtils"
 
 export interface OrdinalHitResult {
@@ -15,9 +16,25 @@ export function findNearestOrdinalNode(
   scene: OrdinalSceneNode[],
   px: number,
   py: number,
-  maxDistance: number = 30
+  maxDistance: number = 30,
+  pointQuadtree?: Quadtree<PointSceneNode> | null,
+  maxPointRadius = 0
 ): OrdinalHitResult | null {
   let best: OrdinalHitResult | null = null
+  let pointHitConfirmed = false
+
+  // Fast path: quadtree-accelerated point hit test for swarm plots.
+  if (pointQuadtree) {
+    const queryRadius = Math.max(maxDistance, maxPointRadius + 5, 12)
+    const candidate = pointQuadtree.find(px, py, queryRadius) ?? null
+    if (candidate) {
+      const result = hitTestPoint(candidate, px, py, maxDistance)
+      if (result && result.distance < maxDistance) {
+        best = result
+        pointHitConfirmed = true
+      }
+    }
+  }
 
   for (const node of scene) {
     let result: OrdinalHitResult | null = null
@@ -27,6 +44,8 @@ export function findNearestOrdinalNode(
         result = hitTestRect(node, px, py)
         break
       case "point":
+        // Skip linear point scan when the quadtree already gave us an answer
+        if (pointQuadtree && pointHitConfirmed) break
         result = hitTestPoint(node, px, py, maxDistance)
         break
       case "wedge":

--- a/src/components/stream/OrdinalPipelineStore.ts
+++ b/src/components/stream/OrdinalPipelineStore.ts
@@ -15,6 +15,7 @@
  * Consumed by: StreamOrdinalFrame (sole consumer).
  */
 import { scaleBand, scaleLinear, type ScaleBand, type ScaleLinear } from "d3-scale"
+import { quadtree as d3Quadtree, type Quadtree } from "d3-quadtree"
 import { RingBuffer } from "../realtime/RingBuffer"
 import { IncrementalExtent } from "../realtime/IncrementalExtent"
 import type {
@@ -25,7 +26,7 @@ import type {
   OrdinalLayout,
   OrdinalChartType
 } from "./ordinalTypes"
-import type { Changeset, Style, DecayConfig } from "./types"
+import type { Changeset, Style, DecayConfig, PointSceneNode } from "./types"
 import { computeDecayOpacity } from "./pipelineDecay"
 import { computeEasing, computeRawProgress, lerp, now as getTimestamp } from "./pipelineTransitionUtils"
 import type { ActiveTransition } from "./pipelineTransitionUtils"
@@ -104,6 +105,17 @@ export class OrdinalPipelineStore {
   scene: OrdinalSceneNode[] = []
   columns: Record<string, OrdinalColumn> = {}
   version = 0
+  /** Bumped whenever the buffer is mutated. Used to invalidate per-frame caches. */
+  private _dataVersion = 0
+  // Spatial index for point hit testing (built when point count exceeds threshold)
+  private static readonly QUADTREE_THRESHOLD = 500
+  private _pointQuadtree: Quadtree<PointSceneNode> | null = null
+  /** Largest visual point radius in the current scene. */
+  private _maxPointRadius = 0
+  /** Cached datum→index map for applyDecay/applyPulse. Keyed by `_dataVersion`. */
+  private _datumIndexCache: { version: number; map: Map<any, number> } | null = null
+  /** Cached category→indices map for applyPulse wedge path. Keyed by `_dataVersion`. */
+  private _categoryIndexCache: { version: number; map: Map<string, number[]> } | null = null
   private _hasRenderedOnce = false
 
   constructor(config: OrdinalPipelineConfig) {
@@ -150,6 +162,7 @@ export class OrdinalPipelineStore {
   ingest(changeset: Changeset): boolean {
     const now = typeof performance !== "undefined" ? performance.now() : Date.now()
     this.lastIngestTime = now
+    this._dataVersion++
 
     if (changeset.bounded) {
       this.buffer.clear()
@@ -333,6 +346,7 @@ export class OrdinalPipelineStore {
 
     // 5. Build scene graph
     this.scene = this.buildSceneNodes(expandedData, layout)
+    this.rebuildPointQuadtree()
 
     // Apply decay/pulse to discrete scene nodes
     if (this.config.decay) {
@@ -713,15 +727,99 @@ export class OrdinalPipelineStore {
     return computeDecayOpacity(decay, bufferIndex, bufferSize)
   }
 
+  /**
+   * Build (or return cached) datum→buffer-index map. Cached against
+   * `_dataVersion` so the per-frame applyDecay/applyPulse calls don't
+   * rebuild it during animation when the buffer hasn't changed.
+   */
+  private getDatumIndexMap(data: Record<string, any>[]): Map<any, number> {
+    if (this._datumIndexCache && this._datumIndexCache.version === this._dataVersion) {
+      return this._datumIndexCache.map
+    }
+    const map = new Map<any, number>()
+    for (let i = 0; i < data.length; i++) {
+      map.set(data[i], i)
+    }
+    this._datumIndexCache = { version: this._dataVersion, map }
+    return map
+  }
+
+  /**
+   * Build (or return cached) category→[indices] map used by applyPulse for
+   * wedge nodes. Cached against `_dataVersion` so the per-wedge inner loop
+   * collapses from O(data) to O(matches-for-this-category).
+   */
+  private getCategoryIndexMap(data: Record<string, any>[]): Map<string, number[]> {
+    if (this._categoryIndexCache && this._categoryIndexCache.version === this._dataVersion) {
+      return this._categoryIndexCache.map
+    }
+    const oAcc = this.config.categoryAccessor || this.config.oAccessor
+    const isFn = typeof oAcc === "function"
+    const key = isFn ? null : (oAcc || "category")
+    const map = new Map<string, number[]>()
+    for (let i = 0; i < data.length; i++) {
+      const d = data[i]
+      const cat = isFn ? (oAcc as Function)(d) : d[key as string]
+      let arr = map.get(cat)
+      if (!arr) {
+        arr = []
+        map.set(cat, arr)
+      }
+      arr.push(i)
+    }
+    this._categoryIndexCache = { version: this._dataVersion, map }
+    return map
+  }
+
+  /**
+   * Build (or clear) a quadtree spatial index for point scene nodes.
+   * Useful for swarm plots — other ordinal types (bar/wedge/box/violin) are
+   * not indexed because they're typically few in number or already O(1) hit
+   * tests via bbox checks.
+   */
+  private rebuildPointQuadtree(): void {
+    let pointCount = 0
+    let maxR = 0
+    for (const node of this.scene) {
+      if (node.type === "point") {
+        pointCount++
+        if (node.r > maxR) maxR = node.r
+      }
+    }
+    this._maxPointRadius = maxR
+
+    if (pointCount <= OrdinalPipelineStore.QUADTREE_THRESHOLD) {
+      this._pointQuadtree = null
+      return
+    }
+
+    const points: PointSceneNode[] = new Array(pointCount)
+    let i = 0
+    for (const node of this.scene) {
+      if (node.type === "point") points[i++] = node as PointSceneNode
+    }
+    this._pointQuadtree = d3Quadtree<PointSceneNode>()
+      .x(n => n.x)
+      .y(n => n.y)
+      .addAll(points)
+  }
+
+  /** Quadtree spatial index for point hit testing, or null when below threshold. */
+  get pointQuadtree(): Quadtree<PointSceneNode> | null {
+    return this._pointQuadtree
+  }
+
+  /** Largest visual point radius in the current scene. */
+  get maxPointRadius(): number {
+    return this._maxPointRadius
+  }
+
   private applyDecay(nodes: OrdinalSceneNode[], data: Record<string, any>[]): void {
     if (!this.config.decay) return
     const bufferSize = data.length
     if (bufferSize <= 1) return
 
-    const indexMap = new Map<any, number>()
-    for (let i = 0; i < data.length; i++) {
-      indexMap.set(data[i], i)
-    }
+    const indexMap = this.getDatumIndexMap(data)
 
     for (const node of nodes) {
       if (node.type === "connector" || node.type === "violin" || node.type === "boxplot" || node.type === "wedge") continue
@@ -742,10 +840,8 @@ export class OrdinalPipelineStore {
     const pulseColor = this.config.pulse.color ?? "rgba(255,255,255,0.6)"
     const glowRadius = this.config.pulse.glowRadius ?? 4
 
-    const indexMap = new Map<any, number>()
-    for (let i = 0; i < data.length; i++) {
-      indexMap.set(data[i], i)
-    }
+    const indexMap = this.getDatumIndexMap(data)
+    let categoryIndex: Map<string, number[]> | null = null
 
     for (const node of nodes) {
       if (node.type === "connector" || node.type === "violin" || node.type === "boxplot") continue
@@ -755,13 +851,12 @@ export class OrdinalPipelineStore {
       if (node.type === "wedge") {
         const cat = node.category
         if (!cat) continue
+        if (!categoryIndex) categoryIndex = this.getCategoryIndexMap(data)
+        const indices = categoryIndex.get(cat)
+        if (!indices) continue
         let bestIntensity = 0
-        for (let i = 0; i < data.length; i++) {
-          const d = data[i]
-          const oAcc = this.config.categoryAccessor || this.config.oAccessor
-          const dCat = typeof oAcc === "function" ? oAcc(d) : d[oAcc || "category"]
-          if (dCat !== cat) continue
-          const insertTime = this.timestampBuffer.get(i)
+        for (let j = 0; j < indices.length; j++) {
+          const insertTime = this.timestampBuffer.get(indices[j])
           if (insertTime == null) continue
           const age = now - insertTime
           if (age < duration) {
@@ -1181,6 +1276,7 @@ export class OrdinalPipelineStore {
     this.categories.clear()
     this.buffer.forEach(d => this.categories.add(this.getO(d)))
 
+    this._dataVersion++
     this.version++
     return removed
   }
@@ -1218,6 +1314,7 @@ export class OrdinalPipelineStore {
       }
     })
 
+    this._dataVersion++
     this.version++
     return previous
   }
@@ -1236,6 +1333,7 @@ export class OrdinalPipelineStore {
     this.scales = null
     this.scene = []
     this.columns = {}
+    this._dataVersion++
     this.version++
   }
 

--- a/src/components/stream/ParticlePool.test.ts
+++ b/src/components/stream/ParticlePool.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest"
+import { ParticlePool } from "./ParticlePool"
+import type { RealtimeEdge, BezierCache } from "./networkTypes"
+
+const STRAIGHT: BezierCache = {
+  circular: false,
+  points: [
+    { x: 0, y: 0 },
+    { x: 100, y: 0 },
+    { x: 200, y: 0 },
+    { x: 300, y: 0 }
+  ],
+  halfWidth: 0
+}
+
+function makeEdges(n: number): RealtimeEdge[] {
+  const out: RealtimeEdge[] = []
+  for (let i = 0; i < n; i++) {
+    out.push({
+      source: "a", target: "b", value: 1, bezier: STRAIGHT
+    } as unknown as RealtimeEdge)
+  }
+  return out
+}
+
+describe("ParticlePool", () => {
+  it("spawns until capacity is exhausted then returns null", () => {
+    const pool = new ParticlePool(3)
+    expect(pool.spawn(0)).not.toBeNull()
+    expect(pool.spawn(0)).not.toBeNull()
+    expect(pool.spawn(0)).not.toBeNull()
+    expect(pool.spawn(0)).toBeNull()
+  })
+
+  it("recycles slots when particles expire (free-list reuse)", () => {
+    const pool = new ParticlePool(2)
+    const a = pool.spawn(0)!
+    const b = pool.spawn(0)!
+    expect(pool.spawn(0)).toBeNull()
+
+    // Step until both particles complete (t reaches 1.0)
+    pool.step(2.0, 1, makeEdges(1))
+    expect(a.active).toBe(false)
+    expect(b.active).toBe(false)
+
+    // Both slots should be reusable now
+    expect(pool.spawn(0)).not.toBeNull()
+    expect(pool.spawn(0)).not.toBeNull()
+    expect(pool.spawn(0)).toBeNull()
+  })
+
+  it("recycles slots when an edge becomes invalid mid-flight", () => {
+    const pool = new ParticlePool(1)
+    pool.spawn(5)
+    // Step with no edge at index 5 — particle should deactivate and free its slot
+    pool.step(0.1, 1, [])
+    expect(pool.spawn(0)).not.toBeNull()
+  })
+
+  it("clear() restores all slots to free", () => {
+    const pool = new ParticlePool(3)
+    pool.spawn(0); pool.spawn(0); pool.spawn(0)
+    pool.clear()
+    expect(pool.spawn(0)).not.toBeNull()
+    expect(pool.spawn(0)).not.toBeNull()
+    expect(pool.spawn(0)).not.toBeNull()
+    expect(pool.spawn(0)).toBeNull()
+  })
+
+  it("resize() exposes new slots without losing active ones", () => {
+    const pool = new ParticlePool(2)
+    const a = pool.spawn(0)!
+    a.t = 0.5
+    pool.resize(4)
+    // Existing particle is preserved
+    expect(pool.particles[0]).toBe(a)
+    expect(pool.particles[0].active).toBe(true)
+    expect(pool.particles[0].t).toBe(0.5)
+    // Three more spawns (1 existing free + 2 new) succeed
+    expect(pool.spawn(0)).not.toBeNull()
+    expect(pool.spawn(0)).not.toBeNull()
+    expect(pool.spawn(0)).not.toBeNull()
+    expect(pool.spawn(0)).toBeNull()
+  })
+
+  it("step() writes bezier position into the particle without allocating", () => {
+    const pool = new ParticlePool(1)
+    const p = pool.spawn(0)!
+    pool.step(0.5, 1, makeEdges(1))
+    // Half-traversal of the straight bezier from 0→300 should land near x=150
+    expect(p.x).toBeGreaterThan(120)
+    expect(p.x).toBeLessThan(180)
+    expect(p.y).toBe(0)
+  })
+
+  it("countForEdge counts only matching active particles", () => {
+    const pool = new ParticlePool(5)
+    pool.spawn(0); pool.spawn(0); pool.spawn(1)
+    expect(pool.countForEdge(0)).toBe(2)
+    expect(pool.countForEdge(1)).toBe(1)
+    expect(pool.countForEdge(2)).toBe(0)
+  })
+})

--- a/src/components/stream/ParticlePool.ts
+++ b/src/components/stream/ParticlePool.ts
@@ -5,14 +5,19 @@ import type { Particle, RealtimeEdge, BezierCache, BezierPoint } from "./network
  *
  * Pre-allocates a fixed-size array to avoid GC pressure.
  * Particles travel along bezier paths within link bands.
+ *
+ * `_freeIndices` is a stack of currently-free slot indices. Spawn pops; step
+ * pushes when a particle expires. This makes spawn O(1) instead of O(capacity).
  */
 export class ParticlePool {
   particles: Particle[]
   private capacity: number
+  private _freeIndices: number[]
 
   constructor(capacity: number) {
     this.capacity = capacity
     this.particles = new Array(capacity)
+    this._freeIndices = new Array(capacity)
     for (let i = 0; i < capacity; i++) {
       this.particles[i] = {
         t: 0,
@@ -22,6 +27,8 @@ export class ParticlePool {
         x: 0,
         y: 0
       }
+      // Stack order so popping returns slots in ascending index (purely cosmetic)
+      this._freeIndices[i] = capacity - 1 - i
     }
   }
 
@@ -30,19 +37,16 @@ export class ParticlePool {
    * Returns the particle if a free slot was found, null otherwise.
    */
   spawn(edgeIndex: number): Particle | null {
-    for (let i = 0; i < this.capacity; i++) {
-      const p = this.particles[i]
-      if (!p.active) {
-        p.active = true
-        p.t = 0
-        p.offset = Math.random() - 0.5 // [-0.5, 0.5]
-        p.edgeIndex = edgeIndex
-        p.x = 0
-        p.y = 0
-        return p
-      }
-    }
-    return null // Pool exhausted
+    const idx = this._freeIndices.pop()
+    if (idx === undefined) return null
+    const p = this.particles[idx]
+    p.active = true
+    p.t = 0
+    p.offset = Math.random() - 0.5 // [-0.5, 0.5]
+    p.edgeIndex = edgeIndex
+    p.x = 0
+    p.y = 0
+    return p
   }
 
   /**
@@ -58,6 +62,7 @@ export class ParticlePool {
       const edge = edges[p.edgeIndex]
       if (!edge || !edge.bezier) {
         p.active = false
+        this._freeIndices.push(i)
         continue
       }
 
@@ -69,13 +74,12 @@ export class ParticlePool {
 
       if (p.t >= 1) {
         p.active = false
+        this._freeIndices.push(i)
         continue
       }
 
-      // Evaluate position along the bezier path
-      const pos = evaluateBezier(edge.bezier, p.t, p.offset)
-      p.x = pos.x
-      p.y = pos.y
+      // Evaluate bezier position directly into the particle (no allocation).
+      evaluateBezierInto(edge.bezier, p.t, p.offset, p)
     }
   }
 
@@ -94,6 +98,10 @@ export class ParticlePool {
   clear(): void {
     for (let i = 0; i < this.capacity; i++) {
       this.particles[i].active = false
+    }
+    this._freeIndices.length = 0
+    for (let i = this.capacity - 1; i >= 0; i--) {
+      this._freeIndices.push(i)
     }
   }
 
@@ -114,6 +122,8 @@ export class ParticlePool {
           x: 0,
           y: 0
         }
+        // New slots are free
+        this._freeIndices.push(i)
       }
     }
     this.capacity = newCapacity
@@ -121,25 +131,32 @@ export class ParticlePool {
 }
 
 /**
- * Evaluate a point along a bezier path at parameter t with perpendicular offset.
+ * Evaluate a point along a bezier path at parameter t with perpendicular offset,
+ * writing the result into `out` (no allocation).
  *
  * Uses the chord direction (P0→P3) for perpendicular offset instead of the
  * local tangent. This gives a stable perpendicular across the entire curve,
  * eliminating the pivot/rotation artifact visible on short curves.
  */
-function evaluateBezier(
+function evaluateBezierInto(
   cache: BezierCache,
   t: number,
-  offset: number
-): BezierPoint {
+  offset: number,
+  out: BezierPoint
+): void {
   if (cache.circular && cache.segments) {
-    return evaluateMultiSegment(cache.segments, t, offset, cache.halfWidth)
+    evaluateMultiSegmentInto(cache.segments, t, offset, cache.halfWidth, out)
+    return
   }
 
-  if (!cache.points) return { x: 0, y: 0 }
+  if (!cache.points) {
+    out.x = 0
+    out.y = 0
+    return
+  }
 
   const [p0, p1, p2, p3] = cache.points
-  const pos = cubicBezier(p0, p1, p2, p3, t)
+  cubicBezierInto(p0, p1, p2, p3, t, out)
 
   // Use chord direction (P0→P3) for stable perpendicular offset
   const dx = p3.x - p0.x
@@ -150,11 +167,9 @@ function evaluateBezier(
     // Perpendicular to the chord (rotated 90 degrees)
     const nx = -dy / len
     const ny = dx / len
-    pos.x += nx * offset * cache.halfWidth * 2
-    pos.y += ny * offset * cache.halfWidth * 2
+    out.x += nx * offset * cache.halfWidth * 2
+    out.y += ny * offset * cache.halfWidth * 2
   }
-
-  return pos
 }
 
 /**
@@ -162,19 +177,20 @@ function evaluateBezier(
  * Maps global t [0,1] to the appropriate segment.
  * Uses segment chord direction for stable perpendicular offset.
  */
-function evaluateMultiSegment(
+function evaluateMultiSegmentInto(
   segments: Array<[BezierPoint, BezierPoint, BezierPoint, BezierPoint]>,
   t: number,
   offset: number,
-  halfWidth: number
-): BezierPoint {
+  halfWidth: number,
+  out: BezierPoint
+): void {
   const n = segments.length
   const globalT = t * n
   const segIndex = Math.min(Math.floor(globalT), n - 1)
   const localT = globalT - segIndex
 
   const [p0, p1, p2, p3] = segments[segIndex]
-  const pos = cubicBezier(p0, p1, p2, p3, localT)
+  cubicBezierInto(p0, p1, p2, p3, localT, out)
 
   // Use segment chord direction for stable perpendicular
   const dx = p3.x - p0.x
@@ -184,30 +200,26 @@ function evaluateMultiSegment(
   if (len > 0.001) {
     const nx = -dy / len
     const ny = dx / len
-    pos.x += nx * offset * halfWidth * 2
-    pos.y += ny * offset * halfWidth * 2
+    out.x += nx * offset * halfWidth * 2
+    out.y += ny * offset * halfWidth * 2
   }
-
-  return pos
 }
 
 /** Cubic bezier evaluation: B(t) = (1-t)^3*P0 + 3*(1-t)^2*t*P1 + 3*(1-t)*t^2*P2 + t^3*P3 */
-function cubicBezier(
+function cubicBezierInto(
   p0: BezierPoint,
   p1: BezierPoint,
   p2: BezierPoint,
   p3: BezierPoint,
-  t: number
-): BezierPoint {
+  t: number,
+  out: BezierPoint
+): void {
   const mt = 1 - t
   const mt2 = mt * mt
   const mt3 = mt2 * mt
   const t2 = t * t
   const t3 = t2 * t
 
-  return {
-    x: mt3 * p0.x + 3 * mt2 * t * p1.x + 3 * mt * t2 * p2.x + t3 * p3.x,
-    y: mt3 * p0.y + 3 * mt2 * t * p1.y + 3 * mt * t2 * p2.y + t3 * p3.y
-  }
+  out.x = mt3 * p0.x + 3 * mt2 * t * p1.x + 3 * mt * t2 * p2.x + t3 * p3.x
+  out.y = mt3 * p0.y + 3 * mt2 * t * p1.y + 3 * mt * t2 * p2.y + t3 * p3.y
 }
-

--- a/src/components/stream/PipelineStore.cache.test.ts
+++ b/src/components/stream/PipelineStore.cache.test.ts
@@ -223,6 +223,71 @@ describe("scene rebuilds after config changes", () => {
     // Color should have changed from red to green
     expect(colorAfter).not.toBe(colorBefore)
   })
+
+  it("resolveColorMap invalidates when themeCategorical changes (theme switch)", () => {
+    // resolveColorMap short-circuits on _ingestVersion. A theme change without
+    // a data ingest must still invalidate the cache.
+    const store = makeStore({
+      colorAccessor: "group",
+      themeCategorical: ["#aaa", "#bbb", "#ccc"],
+    })
+    setData(store, [
+      { x: 1, y: 10, group: "A" },
+      { x: 2, y: 20, group: "B" },
+    ])
+    store.computeScene([400, 300])
+    const before = store.resolveGroupColor("A")
+
+    store.updateConfig({
+      xAccessor: "x",
+      yAccessor: "y",
+      chartType: "scatter",
+      windowSize: 100,
+      windowMode: "sliding" as const,
+      extentPadding: 0,
+      colorAccessor: "group",
+      themeCategorical: ["#111", "#222", "#333"],
+    })
+    store.computeScene([400, 300])
+    const after = store.resolveGroupColor("A")
+
+    expect(after).not.toBe(before)
+  })
+
+  it("resolveColorMap invalidates when colorAccessor changes", () => {
+    const store = makeStore({
+      colorAccessor: "group",
+      colorScheme: ["red", "blue", "green"],
+    })
+    setData(store, [
+      { x: 1, y: 10, group: "A", region: "north" },
+      { x: 2, y: 20, group: "B", region: "south" },
+      { x: 3, y: 30, group: "B", region: "north" },
+    ])
+    store.computeScene([400, 300])
+    const groupColorB = store.resolveGroupColor("B")
+
+    // Switch the colorAccessor — categories change from {A, B} to {north, south},
+    // so the cached map is wrong. This must invalidate.
+    store.updateConfig({
+      xAccessor: "x",
+      yAccessor: "y",
+      chartType: "scatter",
+      windowSize: 100,
+      windowMode: "sliding" as const,
+      extentPadding: 0,
+      colorAccessor: "region",
+      colorScheme: ["red", "blue", "green"],
+    })
+    store.computeScene([400, 300])
+    // After the swap, "B" is no longer a valid category in the colorAccessor,
+    // but resolveGroupColor falls back to _groupColorMap which should also have
+    // been reset. The fact that we don't return the stale "B" color is the key.
+    const northColor = store.resolveGroupColor("north")
+    const southColor = store.resolveGroupColor("south")
+    expect(northColor).not.toBe(southColor)
+    expect([northColor, southColor]).toContain("red")
+  })
 })
 
 // ── Edge case: rapid push/clear cycles ───────────────────────────────────

--- a/src/components/stream/PipelineStore.cache.test.ts
+++ b/src/components/stream/PipelineStore.cache.test.ts
@@ -265,7 +265,9 @@ describe("scene rebuilds after config changes", () => {
       { x: 3, y: 30, group: "B", region: "north" },
     ])
     store.computeScene([400, 300])
-    const groupColorB = store.resolveGroupColor("B")
+    // Warm the cache for group "B" so the subsequent colorAccessor swap has
+    // something stale to invalidate. Return value intentionally unused.
+    store.resolveGroupColor("B")
 
     // Switch the colorAccessor — categories change from {A, B} to {north, south},
     // so the cached map is wrong. This must invalidate.

--- a/src/components/stream/PipelineStore.ts
+++ b/src/components/stream/PipelineStore.ts
@@ -208,7 +208,7 @@ export class PipelineStore {
 
   // ── Color map caching ──────────────────────────────────────────────
   /** Unified color map cache keyed by sorted category set — shared across point, swarm, etc. */
-  private _colorMapCache: { key: string; map: Map<string, string> } | null = null
+  private _colorMapCache: { key: string; map: Map<string, string>; version: number } | null = null
   /** Separate group→color map for resolveGroupColor (insertion-order based, never invalidates _colorMapCache) */
   private _groupColorMap: Map<string, string> = new Map()
   private _barCategoryCache: { key: string; order: string[] } | null = null
@@ -486,21 +486,18 @@ export class PipelineStore {
         } else {
           const groups = this.groupData(bufferArray)
 
-          // Build per-x-value totals across all groups
+          // Single pass: build per-x stacked totals and track the running max.
           const xTotals = new Map<number, number>()
+          let maxStacked = 0
           for (const g of groups) {
             for (const d of g.data) {
               const x = this.getX(d)
               const y = this.getY(d)
-              if (x != null && y != null && !Number.isNaN(x) && !Number.isNaN(y)) {
-                xTotals.set(x, (xTotals.get(x) || 0) + y)
-              }
+              if (x == null || y == null || Number.isNaN(x) || Number.isNaN(y)) continue
+              const total = (xTotals.get(x) || 0) + y
+              xTotals.set(x, total)
+              if (total > maxStacked) maxStacked = total
             }
-          }
-
-          let maxStacked = 0
-          for (const total of xTotals.values()) {
-            if (total > maxStacked) maxStacked = total
           }
 
           const pad = maxStacked > 0 ? maxStacked * config.extentPadding : 1
@@ -948,10 +945,16 @@ export class PipelineStore {
 
   /**
    * Resolve a category→color map from data using the colorAccessor.
-   * Caches the result in _colorMapCache keyed by sorted category set —
-   * only rebuilds when the set of categories changes.
+   * Caches the result in _colorMapCache keyed by `_ingestVersion` (fast path)
+   * and a sorted-category fingerprint (so palette/scheme changes still
+   * invalidate). Multiple scene builders within one frame skip the data scan
+   * entirely after the first call.
    */
   private resolveColorMap(data: Record<string, any>[]): Map<string, string> {
+    if (this._colorMapCache && this._colorMapCache.version === this._ingestVersion) {
+      return this._colorMapCache.map
+    }
+
     const categories = new Set<string>()
     for (const d of data) {
       const c = this.getColor!(d)
@@ -961,6 +964,9 @@ export class PipelineStore {
     const cacheKey = sorted.join('\0')
 
     if (this._colorMapCache && this._colorMapCache.key === cacheKey) {
+      // Categories unchanged across the version bump (e.g., layout-only update).
+      // Refresh the version so future calls in this frame short-circuit.
+      this._colorMapCache.version = this._ingestVersion
       return this._colorMapCache.map
     }
 
@@ -971,7 +977,7 @@ export class PipelineStore {
     for (let ci = 0; ci < sorted.length; ci++) {
       colorMap.set(sorted[ci], palette[ci % palette.length])
     }
-    this._colorMapCache = { key: cacheKey, map: colorMap }
+    this._colorMapCache = { key: cacheKey, map: colorMap, version: this._ingestVersion }
     return colorMap
   }
 

--- a/src/components/stream/PipelineStore.ts
+++ b/src/components/stream/PipelineStore.ts
@@ -1246,8 +1246,15 @@ export class PipelineStore {
   updateConfig(config: Partial<PipelineConfig>): void {
     const prev = { ...this.config }
 
-    // Invalidate color map caches when relevant config changes
-    if (config.colorScheme !== undefined) {
+    // Invalidate color map caches when any color-relevant config changes.
+    // resolveColorMap short-circuits on _ingestVersion, so we must explicitly
+    // null the cache for changes that don't bump that counter (theme palette
+    // swaps, accessor swaps, scheme overrides).
+    if (
+      config.colorScheme !== undefined
+      || config.themeCategorical !== undefined
+      || config.colorAccessor !== undefined
+    ) {
       this._colorMapCache = null
       this._groupColorMap = new Map()
     }

--- a/src/components/stream/StreamGeoFrame.tsx
+++ b/src/components/stream/StreamGeoFrame.tsx
@@ -862,6 +862,12 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
       return () => {
         if (rafRef.current) { cancelAnimationFrame(rafRef.current); rafRef.current = 0 }
         tileCacheRef.current?.clear()
+        // Drop any queued pointermove so flushPendingMove can't fire on unmount.
+        pendingMoveCoordsRef.current = null
+        if (moveRafRef.current !== 0) {
+          cancelAnimationFrame(moveRafRef.current)
+          moveRafRef.current = 0
+        }
       }
     }, [scheduleRender])
 

--- a/src/components/stream/StreamGeoFrame.tsx
+++ b/src/components/stream/StreamGeoFrame.tsx
@@ -438,7 +438,7 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
         const hitCtx = (hitCanvasRef.current as any).getContext("2d")
         if (!hitCtx) return
 
-        const hit = findNearestGeoNode(store.scene, chartX, chartY, 30, hitCtx)
+        const hit = findNearestGeoNode(store.scene, chartX, chartY, 30, hitCtx, store.quadtree, store.maxPointRadius)
 
         if (hit) {
           const node = hit.node
@@ -487,6 +487,12 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
     }, [enableHover, adjustedWidth, adjustedHeight, margin, customHoverBehavior, scheduleRender])
 
     const onMouseLeave = useCallback(() => {
+      // Drop any pending coalesced move so it doesn't fire after leave.
+      pendingMoveCoordsRef.current = null
+      if (moveRafRef.current !== 0) {
+        cancelAnimationFrame(moveRafRef.current)
+        moveRafRef.current = 0
+      }
       hoverRef.current = null
       hoveredNodeRef.current = null
       setHoverPoint(null)
@@ -513,7 +519,7 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
       const hitCtx = (hitCanvasRef.current as any).getContext("2d")
       if (!hitCtx) return
 
-      const hit = findNearestGeoNode(store.scene, chartX, chartY, 30, hitCtx)
+      const hit = findNearestGeoNode(store.scene, chartX, chartY, 30, hitCtx, store.quadtree, store.maxPointRadius)
       if (hit) {
         const datum = hit.node.datum
         const rawData = datum?.properties ? datum : (datum?.data || datum)
@@ -587,12 +593,26 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
       scheduleRender()
     }, [customHoverBehavior, scheduleRender])
 
-    // Clear keyboard focus on mouse interaction
+    // Coalesce pointermove events to one hit test per animation frame.
+    // High-DPI mice fire at 120–240Hz; React state updates per move trigger
+    // wasteful re-renders. Capture latest coords; process in rAF.
+    const pendingMoveCoordsRef = useRef<{ clientX: number; clientY: number } | null>(null)
+    const moveRafRef = useRef(0)
+    const flushPendingMove = useCallback(() => {
+      moveRafRef.current = 0
+      const coords = pendingMoveCoordsRef.current
+      pendingMoveCoordsRef.current = null
+      if (coords) hoverHandlerRef.current(coords as unknown as React.MouseEvent)
+    }, [])
+    // Clear keyboard focus on mouse interaction; reuses the rAF-coalesced path.
     const onMouseMoveWrapped = useCallback((e: React.MouseEvent) => {
       kbFocusIndexRef.current = -1
       focusedNavPointRef.current = null
-      hoverHandlerRef.current(e)
-    }, [])
+      pendingMoveCoordsRef.current = { clientX: e.clientX, clientY: e.clientY }
+      if (moveRafRef.current === 0) {
+        moveRafRef.current = requestAnimationFrame(flushPendingMove)
+      }
+    }, [flushPendingMove])
 
     // ── Main render function ──────────────────────────────────────────
 

--- a/src/components/stream/StreamGeoFrame.tsx
+++ b/src/components/stream/StreamGeoFrame.tsx
@@ -414,7 +414,12 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
         const store = storeRef.current
         if (!store || !store.scene.length) return
 
-        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+        // Read the rect from canvasRef rather than e.currentTarget so this
+        // handler still works when invoked from the rAF-coalesced path with a
+        // synthetic `{ clientX, clientY }` payload (no currentTarget).
+        const canvas = canvasRef.current
+        if (!canvas) return
+        const rect = canvas.getBoundingClientRect()
         const chartX = e.clientX - rect.left - margin.left
         const chartY = e.clientY - rect.top - margin.top
 
@@ -485,6 +490,20 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
         }
       }
     }, [enableHover, adjustedWidth, adjustedHeight, margin, customHoverBehavior, scheduleRender])
+
+    // Coalesce pointermove events to one hit test per animation frame.
+    // High-DPI mice fire at 120–240Hz; React state updates per move trigger
+    // wasteful re-renders. Capture latest coords; process in rAF.
+    // Declared before onMouseLeave / onMouseMoveWrapped so those callbacks
+    // reference unambiguously-initialized bindings.
+    const pendingMoveCoordsRef = useRef<{ clientX: number; clientY: number } | null>(null)
+    const moveRafRef = useRef(0)
+    const flushPendingMove = useCallback(() => {
+      moveRafRef.current = 0
+      const coords = pendingMoveCoordsRef.current
+      pendingMoveCoordsRef.current = null
+      if (coords) hoverHandlerRef.current(coords as unknown as React.MouseEvent)
+    }, [])
 
     const onMouseLeave = useCallback(() => {
       // Drop any pending coalesced move so it doesn't fire after leave.
@@ -593,18 +612,8 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
       scheduleRender()
     }, [customHoverBehavior, scheduleRender])
 
-    // Coalesce pointermove events to one hit test per animation frame.
-    // High-DPI mice fire at 120–240Hz; React state updates per move trigger
-    // wasteful re-renders. Capture latest coords; process in rAF.
-    const pendingMoveCoordsRef = useRef<{ clientX: number; clientY: number } | null>(null)
-    const moveRafRef = useRef(0)
-    const flushPendingMove = useCallback(() => {
-      moveRafRef.current = 0
-      const coords = pendingMoveCoordsRef.current
-      pendingMoveCoordsRef.current = null
-      if (coords) hoverHandlerRef.current(coords as unknown as React.MouseEvent)
-    }, [])
-    // Clear keyboard focus on mouse interaction; reuses the rAF-coalesced path.
+    // Clear keyboard focus on mouse interaction; reuses the rAF-coalesced path
+    // (pendingMoveCoordsRef / moveRafRef / flushPendingMove are declared above).
     const onMouseMoveWrapped = useCallback((e: React.MouseEvent) => {
       kbFocusIndexRef.current = -1
       focusedNavPointRef.current = null

--- a/src/components/stream/StreamNetworkFrame.tsx
+++ b/src/components/stream/StreamNetworkFrame.tsx
@@ -44,6 +44,7 @@ import { NetworkAccessibleDataTable, AriaLiveTooltip, ScreenReaderSummary, SkipT
 
 // Canvas setup
 import { prepareCanvas, getDevicePixelRatio } from "./canvasSetup"
+import { clearCSSColorCache } from "./renderers/resolveCSSColor"
 
 // Canvas renderers
 import { networkRectRenderer } from "./renderers/networkRectRenderer"
@@ -533,8 +534,9 @@ const StreamNetworkFrame = forwardRef<
     scheduleRender()
   }, [pipelineConfig, scheduleRender])
 
-  // Repaint canvas when ThemeProvider theme changes
+  // Repaint canvas when ThemeProvider theme changes — invalidate CSS var cache
   useEffect(() => {
+    clearCSSColorCache()
     dirtyRef.current = true
     scheduleRender()
   }, [currentTheme, scheduleRender])
@@ -924,12 +926,35 @@ const StreamNetworkFrame = forwardRef<
     }
   }
 
+  // Coalesce pointermove events to one hit test per animation frame.
+  // High-DPI mice fire at 120–240Hz; React state updates per move trigger
+  // wasteful re-renders. Capture latest coords; process in rAF.
+  const pendingMoveCoordsRef = useRef<{ clientX: number; clientY: number } | null>(null)
+  const moveRafRef = useRef(0)
+  const flushPendingMove = useCallback(() => {
+    moveRafRef.current = 0
+    const coords = pendingMoveCoordsRef.current
+    pendingMoveCoordsRef.current = null
+    if (coords) hoverHandlerRef.current(coords as unknown as React.MouseEvent)
+  }, [])
   const onMouseMove = useCallback(
-    (e: React.MouseEvent) => hoverHandlerRef.current(e),
-    []
+    (e: React.MouseEvent) => {
+      pendingMoveCoordsRef.current = { clientX: e.clientX, clientY: e.clientY }
+      if (moveRafRef.current === 0) {
+        moveRafRef.current = requestAnimationFrame(flushPendingMove)
+      }
+    },
+    [flushPendingMove]
   )
   const onMouseLeave = useCallback(
-    () => hoverLeaveRef.current(),
+    () => {
+      pendingMoveCoordsRef.current = null
+      if (moveRafRef.current !== 0) {
+        cancelAnimationFrame(moveRafRef.current)
+        moveRafRef.current = 0
+      }
+      hoverLeaveRef.current()
+    },
     []
   )
   const onClick = useCallback(
@@ -1013,8 +1038,8 @@ const StreamNetworkFrame = forwardRef<
   const onMouseMoveWrapped = useCallback((e: React.MouseEvent) => {
     kbFocusIndexRef.current = -1
     focusedNavPointRef.current = null
-    hoverHandlerRef.current(e)
-  }, [])
+    onMouseMove(e)
+  }, [onMouseMove])
 
   // ── Render function ──────────────────────────────────────────────────
 

--- a/src/components/stream/StreamNetworkFrame.tsx
+++ b/src/components/stream/StreamNetworkFrame.tsx
@@ -1183,6 +1183,12 @@ const StreamNetworkFrame = forwardRef<
     scheduleRender()
     return () => {
       if (rafRef.current) { cancelAnimationFrame(rafRef.current); rafRef.current = 0 }
+      // Drop any queued pointermove so flushPendingMove can't fire on unmount.
+      pendingMoveCoordsRef.current = null
+      if (moveRafRef.current !== 0) {
+        cancelAnimationFrame(moveRafRef.current)
+        moveRafRef.current = 0
+      }
     }
   }, [scheduleRender])
 

--- a/src/components/stream/StreamOrdinalFrame.tsx
+++ b/src/components/stream/StreamOrdinalFrame.tsx
@@ -840,6 +840,12 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
       scheduleRender()
       return () => {
         if (rafRef.current) { cancelAnimationFrame(rafRef.current); rafRef.current = 0 }
+        // Drop any queued pointermove so flushPendingMove can't fire on unmount.
+        pendingMoveCoordsRef.current = null
+        if (moveRafRef.current !== 0) {
+          cancelAnimationFrame(moveRafRef.current)
+          moveRafRef.current = 0
+        }
       }
     }, [scheduleRender])
 

--- a/src/components/stream/StreamOrdinalFrame.tsx
+++ b/src/components/stream/StreamOrdinalFrame.tsx
@@ -555,7 +555,7 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
       const hitX = isRadialMode ? chartX - adjustedWidth / 2 : chartX
       const hitY = isRadialMode ? chartY - adjustedHeight / 2 : chartY
 
-      const hit = findNearestOrdinalNode(store.scene, hitX, hitY)
+      const hit = findNearestOrdinalNode(store.scene, hitX, hitY, 30, store.pointQuadtree, store.maxPointRadius)
       if (!hit) {
         if (hoverRef.current) {
           hoverRef.current = null
@@ -596,12 +596,35 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
       }
     }
 
+    // Coalesce pointermove events to one hit test per animation frame.
+    // High-DPI mice fire at 120–240Hz; React state updates per move trigger
+    // wasteful re-renders. Capture latest coords; process in rAF.
+    const pendingMoveCoordsRef = useRef<{ clientX: number; clientY: number } | null>(null)
+    const moveRafRef = useRef(0)
+    const flushPendingMove = useCallback(() => {
+      moveRafRef.current = 0
+      const coords = pendingMoveCoordsRef.current
+      pendingMoveCoordsRef.current = null
+      if (coords) hoverHandlerRef.current(coords as unknown as React.MouseEvent)
+    }, [])
     const onMouseMove = useCallback(
-      (e: React.MouseEvent) => hoverHandlerRef.current(e),
-      []
+      (e: React.MouseEvent) => {
+        pendingMoveCoordsRef.current = { clientX: e.clientX, clientY: e.clientY }
+        if (moveRafRef.current === 0) {
+          moveRafRef.current = requestAnimationFrame(flushPendingMove)
+        }
+      },
+      [flushPendingMove]
     )
     const onMouseLeave = useCallback(
-      () => hoverLeaveRef.current(),
+      () => {
+        pendingMoveCoordsRef.current = null
+        if (moveRafRef.current !== 0) {
+          cancelAnimationFrame(moveRafRef.current)
+          moveRafRef.current = 0
+        }
+        hoverLeaveRef.current()
+      },
       []
     )
 
@@ -684,8 +707,8 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
     const onMouseMoveWrapped = useCallback((e: React.MouseEvent) => {
       kbFocusIndexRef.current = -1
       focusedNavPointRef.current = null
-      hoverHandlerRef.current(e)
-    }, [])
+      onMouseMove(e)
+    }, [onMouseMove])
 
     // ── Render function ──────────────────────────────────────────────────
 

--- a/src/components/stream/StreamXYFrame.tsx
+++ b/src/components/stream/StreamXYFrame.tsx
@@ -770,12 +770,36 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
       }
     }
 
+    // Coalesce pointermove events to one hit test per animation frame.
+    // High-DPI mice fire at 120–240Hz; React state updates per move trigger
+    // wasteful re-renders. Capture the latest coords and process them in rAF.
+    const pendingMoveCoordsRef = useRef<{ clientX: number; clientY: number } | null>(null)
+    const moveRafRef = useRef(0)
+    const flushPendingMove = useCallback(() => {
+      moveRafRef.current = 0
+      const coords = pendingMoveCoordsRef.current
+      pendingMoveCoordsRef.current = null
+      if (coords) hoverHandlerRef.current(coords as unknown as React.MouseEvent)
+    }, [])
     const onMouseMove = useCallback(
-      (e: React.MouseEvent) => hoverHandlerRef.current(e),
-      []
+      (e: React.MouseEvent) => {
+        pendingMoveCoordsRef.current = { clientX: e.clientX, clientY: e.clientY }
+        if (moveRafRef.current === 0) {
+          moveRafRef.current = requestAnimationFrame(flushPendingMove)
+        }
+      },
+      [flushPendingMove]
     )
     const onMouseLeave = useCallback(
-      () => hoverLeaveRef.current(),
+      () => {
+        // Drop any pending hover so a queued move doesn't fire after leave.
+        pendingMoveCoordsRef.current = null
+        if (moveRafRef.current !== 0) {
+          cancelAnimationFrame(moveRafRef.current)
+          moveRafRef.current = 0
+        }
+        hoverLeaveRef.current()
+      },
       []
     )
 
@@ -874,12 +898,13 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
       scheduleRender()
     }, [customHoverBehavior, scheduleRender])
 
-    // Clear keyboard focus on mouse interaction
+    // Clear keyboard focus on mouse interaction; reuses the rAF-coalesced
+    // hover path so the per-frame work cap still applies.
     const onMouseMoveWrapped = useCallback((e: React.MouseEvent) => {
       kbFocusIndexRef.current = -1
       focusedNavPointRef.current = null
-      hoverHandlerRef.current(e)
-    }, [])
+      onMouseMove(e)
+    }, [onMouseMove])
 
     // ── Render function ──────────────────────────────────────────────────
 

--- a/src/components/stream/StreamXYFrame.tsx
+++ b/src/components/stream/StreamXYFrame.tsx
@@ -1098,6 +1098,12 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
       scheduleRender()
       return () => {
         if (rafRef.current) { cancelAnimationFrame(rafRef.current); rafRef.current = 0 }
+        // Drop any queued pointermove so flushPendingMove can't fire on unmount.
+        pendingMoveCoordsRef.current = null
+        if (moveRafRef.current !== 0) {
+          cancelAnimationFrame(moveRafRef.current)
+          moveRafRef.current = 0
+        }
       }
     }, [scheduleRender])
 

--- a/src/components/stream/networkTypes.ts
+++ b/src/components/stream/networkTypes.ts
@@ -264,6 +264,9 @@ export interface NetworkBezierEdge {
   datum: any
   _pulseIntensity?: number
   _pulseColor?: string
+  /** Lazily-built Path2D for hit testing; invalidated when pathD changes. */
+  _cachedPath2D?: Path2D
+  _cachedPath2DSource?: string
 }
 
 /** Ribbon edge — used by chord */
@@ -274,6 +277,8 @@ export interface NetworkRibbonEdge {
   datum: any
   _pulseIntensity?: number
   _pulseColor?: string
+  _cachedPath2D?: Path2D
+  _cachedPath2DSource?: string
 }
 
 /** Curved edge — used by tree, cluster */
@@ -284,6 +289,8 @@ export interface NetworkCurvedEdge {
   datum: any
   _pulseIntensity?: number
   _pulseColor?: string
+  _cachedPath2D?: Path2D
+  _cachedPath2DSource?: string
 }
 
 export type NetworkSceneNode =

--- a/src/components/stream/quadtreeHitTest.test.ts
+++ b/src/components/stream/quadtreeHitTest.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest"
+import { quadtree } from "d3-quadtree"
+import { findHitPointInQuadtree } from "./quadtreeHitTest"
+
+interface TestPoint { x: number; y: number; r: number; id: string }
+
+function makeQt(points: TestPoint[]) {
+  return quadtree<TestPoint>().x(p => p.x).y(p => p.y).addAll(points)
+}
+
+describe("findHitPointInQuadtree", () => {
+  it("returns the point under the cursor for a simple uniform-radius case", () => {
+    const points: TestPoint[] = [
+      { x: 10, y: 10, r: 5, id: "a" },
+      { x: 50, y: 50, r: 5, id: "b" },
+      { x: 90, y: 90, r: 5, id: "c" }
+    ]
+    const qt = makeQt(points)
+    const hit = findHitPointInQuadtree(qt, 51, 51, 30, 5)
+    expect(hit?.node.id).toBe("b")
+  })
+
+  it("returns null when no point is within its own hit radius", () => {
+    const points: TestPoint[] = [{ x: 10, y: 10, r: 5, id: "a" }]
+    const qt = makeQt(points)
+    // Cursor is 200px away — far outside any possible hit radius
+    const hit = findHitPointInQuadtree(qt, 200, 200, 30, 5)
+    expect(hit).toBeNull()
+  })
+
+  it("prefers a farther large-radius point over a nearer small-radius miss (the core bug)", () => {
+    // Without the visit-all-candidates approach, quadtree.find would return
+    // the nearest point (`small`), reject it for distance > hitRadius, and
+    // miss the bigger point behind it that *does* contain the cursor.
+    // getHitRadius(r, 30) = max(r + 5, 12, 30).
+    const points: TestPoint[] = [
+      { x: 10, y: 0, r: 1, id: "small" },   // dist 40, hitRadius 30 → MISS
+      { x: 110, y: 0, r: 80, id: "big" }    // dist 60, hitRadius 85 → HIT
+    ]
+    const qt = makeQt(points)
+    const hit = findHitPointInQuadtree(qt, 50, 0, 30, 80)
+    expect(hit?.node.id).toBe("big")
+  })
+
+  it("among multiple hits returns the closest by distance", () => {
+    const points: TestPoint[] = [
+      { x: 100, y: 100, r: 30, id: "far" },   // 30px away, hitRadius ≥ 35
+      { x: 108, y: 100, r: 20, id: "near" }   // 22px away, hitRadius ≥ 25
+    ]
+    const qt = makeQt(points)
+    const hit = findHitPointInQuadtree(qt, 130, 100, 30, 30)
+    expect(hit?.node.id).toBe("near")
+  })
+
+  it("prunes subtrees outside the search radius (perf smoke — no bound violation)", () => {
+    // Build a large scatter with only one point near the cursor. If pruning
+    // works, we're still correct; if it doesn't, we're also correct but slow.
+    // This test just confirms correctness at scale.
+    const points: TestPoint[] = []
+    for (let i = 0; i < 10000; i++) {
+      points.push({ x: 1000 + (i % 100), y: 1000 + Math.floor(i / 100), r: 2, id: `bg${i}` })
+    }
+    points.push({ x: 50, y: 50, r: 5, id: "target" })
+    const qt = makeQt(points)
+    const hit = findHitPointInQuadtree(qt, 50, 50, 30, 5)
+    expect(hit?.node.id).toBe("target")
+  })
+
+  it("handles co-located points via the leaf linked list", () => {
+    // d3-quadtree stores points at identical coordinates as a `.next` list.
+    const points: TestPoint[] = [
+      { x: 50, y: 50, r: 5, id: "a" },
+      { x: 50, y: 50, r: 5, id: "b" },
+      { x: 50, y: 50, r: 5, id: "c" }
+    ]
+    const qt = makeQt(points)
+    const hit = findHitPointInQuadtree(qt, 50, 50, 30, 5)
+    // Any of the three is an acceptable hit — they're all at dist=0.
+    expect(hit?.node.id).toMatch(/^[abc]$/)
+    expect(hit?.distance).toBe(0)
+  })
+})

--- a/src/components/stream/quadtreeHitTest.ts
+++ b/src/components/stream/quadtreeHitTest.ts
@@ -1,0 +1,64 @@
+import type { Quadtree } from "d3-quadtree"
+import { getHitRadius } from "./hitTestUtils"
+
+export interface QuadtreeHit<T> {
+  node: T
+  distance: number
+}
+
+/**
+ * Find the closest point whose own hit radius contains the cursor.
+ *
+ * Uses `quadtree.visit()` to enumerate every candidate within the widened
+ * search radius (maxDistance extended by the largest point radius in the
+ * scene). `quadtree.find()` alone is insufficient because it returns the
+ * nearest candidate by center-to-center distance — a farther point with a
+ * much larger visual radius can still be a valid hit that `find()` would
+ * hide.
+ *
+ * `T` must expose `x`, `y`, and `r` — the standard `PointSceneNode` shape.
+ */
+export function findHitPointInQuadtree<T extends { x: number; y: number; r: number }>(
+  qt: Quadtree<T>,
+  px: number,
+  py: number,
+  maxDistance: number,
+  maxPointRadius: number
+): QuadtreeHit<T> | null {
+  const searchRadius = Math.max(maxDistance, maxPointRadius + 5, 12)
+  const xMin = px - searchRadius
+  const xMax = px + searchRadius
+  const yMin = py - searchRadius
+  const yMax = py + searchRadius
+
+  let best: T | null = null
+  let bestDist = Infinity
+
+  qt.visit((rawNode, x0, y0, x1, y1) => {
+    // Prune subtrees whose bounding box is outside the search region.
+    if (x0 > xMax || x1 < xMin || y0 > yMax || y1 < yMin) return true
+
+    // Leaf nodes in d3-quadtree are objects with `.data` and optional `.next`
+    // (linked list for co-located points); internal nodes are array-like with
+    // `.length === 4`. The absence of a numeric `length` distinguishes leaves.
+    const node = rawNode as any
+    if (!node.length) {
+      let leaf: any = node
+      do {
+        const point = leaf.data as T
+        const dx = point.x - px
+        const dy = point.y - py
+        const dist = Math.sqrt(dx * dx + dy * dy)
+        const hitR = getHitRadius(point.r, maxDistance)
+        if (dist <= hitR && dist < bestDist) {
+          best = point
+          bestDist = dist
+        }
+        leaf = leaf.next
+      } while (leaf)
+    }
+    return false
+  })
+
+  return best ? { node: best, distance: bestDist } : null
+}

--- a/src/components/stream/renderers/networkEdgeRenderer.ts
+++ b/src/components/stream/renderers/networkEdgeRenderer.ts
@@ -7,6 +7,22 @@ import type {
 } from "../networkTypes"
 
 /**
+ * Lazily build (and cache) a Path2D for an edge. Re-parses only when `pathD`
+ * actually changes. Shared between the renderer and hit tester via the
+ * `_cachedPath2D` / `_cachedPath2DSource` fields on edge nodes.
+ */
+function getOrBuildEdgePath2D(
+  edge: { pathD: string; _cachedPath2D?: Path2D; _cachedPath2DSource?: string }
+): Path2D {
+  if (edge._cachedPath2D && edge._cachedPath2DSource === edge.pathD) {
+    return edge._cachedPath2D
+  }
+  edge._cachedPath2D = new Path2D(edge.pathD)
+  edge._cachedPath2DSource = edge.pathD
+  return edge._cachedPath2D
+}
+
+/**
  * Canvas painter for all network edge types.
  *
  * - bezier: Sankey flow bands (Path2D from SVG path string)
@@ -44,7 +60,7 @@ function renderBezierEdge(
 
   ctx.save()
 
-  const path = new Path2D(edge.pathD)
+  const path = getOrBuildEdgePath2D(edge)
 
   // Fill the band
   if (edge.style.fill && edge.style.fill !== "none") {
@@ -126,7 +142,7 @@ function renderRibbonEdge(
 
   ctx.save()
 
-  const path = new Path2D(edge.pathD)
+  const path = getOrBuildEdgePath2D(edge)
 
   if (edge.style.fill && edge.style.fill !== "none") {
     ctx.fillStyle = edge.style.fill
@@ -159,7 +175,7 @@ function renderCurvedEdge(
 
   ctx.save()
 
-  const path = new Path2D(edge.pathD)
+  const path = getOrBuildEdgePath2D(edge)
 
   ctx.strokeStyle = edge.style.stroke || "#999"
   ctx.lineWidth = edge.style.strokeWidth ?? 1

--- a/src/components/stream/renderers/resolveCSSColor.test.ts
+++ b/src/components/stream/renderers/resolveCSSColor.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { resolveCSSColor, clearCSSColorCache, _resetCSSColorCacheForTest } from "./resolveCSSColor"
+
+function makeCtx(varName?: string, value?: string): CanvasRenderingContext2D {
+  const canvas = document.createElement("canvas")
+  if (varName && value !== undefined) {
+    canvas.style.setProperty(varName, value)
+  }
+  document.body.appendChild(canvas)
+  return { canvas } as unknown as CanvasRenderingContext2D
+}
+
+describe("resolveCSSColor", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+    _resetCSSColorCacheForTest()
+  })
+
+  it("returns non-var values unchanged", () => {
+    const ctx = makeCtx()
+    expect(resolveCSSColor(ctx, "#ff0000")).toBe("#ff0000")
+    expect(resolveCSSColor(ctx, "rgb(0,0,0)")).toBe("rgb(0,0,0)")
+  })
+
+  it("returns undefined for undefined input", () => {
+    const ctx = makeCtx()
+    expect(resolveCSSColor(ctx, undefined)).toBe(undefined)
+  })
+
+  it("resolves var() to computed value", () => {
+    const ctx = makeCtx("--my-color", "#ff0000")
+    expect(resolveCSSColor(ctx, "var(--my-color)")).toBe("#ff0000")
+  })
+
+  it("uses fallback when var is not defined", () => {
+    const ctx = makeCtx()
+    expect(resolveCSSColor(ctx, "var(--undefined-var, #00ff00)")).toBe("#00ff00")
+  })
+
+  it("caches resolved values across repeat calls within the same version", () => {
+    const ctx = makeCtx("--color", "#abcdef")
+    const first = resolveCSSColor(ctx, "var(--color)")
+    // Mutate the underlying value — cache should still return original
+    ctx.canvas.style.setProperty("--color", "#000000")
+    const second = resolveCSSColor(ctx, "var(--color)")
+    expect(first).toBe("#abcdef")
+    expect(second).toBe("#abcdef")
+  })
+
+  it("invalidates cache when clearCSSColorCache is called", () => {
+    const ctx = makeCtx("--color", "#abcdef")
+    expect(resolveCSSColor(ctx, "var(--color)")).toBe("#abcdef")
+    ctx.canvas.style.setProperty("--color", "#123456")
+    clearCSSColorCache()
+    expect(resolveCSSColor(ctx, "var(--color)")).toBe("#123456")
+  })
+
+  it("isolates caches between canvases", () => {
+    const ctxA = makeCtx("--c", "#aaaaaa")
+    const ctxB = makeCtx("--c", "#bbbbbb")
+    expect(resolveCSSColor(ctxA, "var(--c)")).toBe("#aaaaaa")
+    expect(resolveCSSColor(ctxB, "var(--c)")).toBe("#bbbbbb")
+  })
+
+  it("invalidates all canvases at once when cleared", () => {
+    const ctxA = makeCtx("--c", "#aaaaaa")
+    const ctxB = makeCtx("--c", "#bbbbbb")
+    resolveCSSColor(ctxA, "var(--c)")
+    resolveCSSColor(ctxB, "var(--c)")
+    ctxA.canvas.style.setProperty("--c", "#111111")
+    ctxB.canvas.style.setProperty("--c", "#222222")
+    clearCSSColorCache()
+    expect(resolveCSSColor(ctxA, "var(--c)")).toBe("#111111")
+    expect(resolveCSSColor(ctxB, "var(--c)")).toBe("#222222")
+  })
+
+  it("clearCSSColorCache(canvas) accepts a canvas arg for backward compat", () => {
+    const ctx = makeCtx("--color", "#abcdef")
+    resolveCSSColor(ctx, "var(--color)")
+    ctx.canvas.style.setProperty("--color", "#fedcba")
+    clearCSSColorCache(ctx.canvas)
+    expect(resolveCSSColor(ctx, "var(--color)")).toBe("#fedcba")
+  })
+
+  it("calls getComputedStyle once per (canvas, var, version) triple", () => {
+    const ctx = makeCtx("--color", "#abcdef")
+    const orig = window.getComputedStyle
+    let calls = 0
+    window.getComputedStyle = ((el: Element) => {
+      calls++
+      return orig.call(window, el)
+    }) as typeof window.getComputedStyle
+
+    try {
+      resolveCSSColor(ctx, "var(--color)")
+      resolveCSSColor(ctx, "var(--color)")
+      resolveCSSColor(ctx, "var(--color)")
+      expect(calls).toBe(1)
+      clearCSSColorCache()
+      resolveCSSColor(ctx, "var(--color)")
+      expect(calls).toBe(2)
+    } finally {
+      window.getComputedStyle = orig
+    }
+  })
+
+  it("falls back to fallback color when ctx.canvas is missing", () => {
+    const ctx = { canvas: null as unknown as HTMLCanvasElement } as CanvasRenderingContext2D
+    expect(resolveCSSColor(ctx, "var(--missing, #defabc)")).toBe("#defabc")
+  })
+})

--- a/src/components/stream/renderers/resolveCSSColor.ts
+++ b/src/components/stream/renderers/resolveCSSColor.ts
@@ -24,16 +24,24 @@ const cache = new WeakMap<HTMLCanvasElement, CacheEntry>()
 let currentVersion = 0
 let observerInstalled = false
 
+// Track installed listeners so the test reset can detach them, preventing
+// observer accumulation across test files.
+let installedObserver: MutationObserver | null = null
+let installedMql: MediaQueryList | null = null
+let installedMqlHandler: ((e: MediaQueryListEvent) => void) | null = null
+
 function ensureGlobalObserver(): void {
   if (observerInstalled) return
-  observerInstalled = true
+  // Don't latch the flag in non-DOM environments (SSR/pre-render) — the next
+  // call from a real browser context should still get a chance to install.
   if (typeof window === "undefined" || typeof document === "undefined") return
+  observerInstalled = true
 
   const bumpVersion = () => { currentVersion++ }
 
   if (typeof MutationObserver !== "undefined" && document.documentElement) {
-    const observer = new MutationObserver(bumpVersion)
-    observer.observe(document.documentElement, {
+    installedObserver = new MutationObserver(bumpVersion)
+    installedObserver.observe(document.documentElement, {
       attributes: true,
       attributeFilter: ["class", "style", "data-theme", "data-semiotic-theme"]
     })
@@ -41,12 +49,13 @@ function ensureGlobalObserver(): void {
 
   if (typeof window.matchMedia === "function") {
     try {
-      const mql = window.matchMedia("(prefers-color-scheme: dark)")
-      if (typeof mql.addEventListener === "function") {
-        mql.addEventListener("change", bumpVersion)
-      } else if (typeof (mql as any).addListener === "function") {
+      installedMql = window.matchMedia("(prefers-color-scheme: dark)")
+      installedMqlHandler = bumpVersion
+      if (typeof installedMql.addEventListener === "function") {
+        installedMql.addEventListener("change", installedMqlHandler)
+      } else if (typeof (installedMql as any).addListener === "function") {
         // Safari 14 fallback
-        (mql as any).addListener(bumpVersion)
+        (installedMql as any).addListener(installedMqlHandler)
       }
     } catch {
       // matchMedia can throw in older browsers / jsdom — safe to ignore
@@ -92,8 +101,26 @@ export function clearCSSColorCache(_canvas?: HTMLCanvasElement): void {
   currentVersion++
 }
 
-/** Test-only: reset all cache state. */
+/**
+ * Test-only: reset all cache state, including disconnecting any installed
+ * observer/matchMedia listeners. Required for test isolation — without it,
+ * observers accumulate across files and bump `currentVersion` more than once
+ * per real DOM mutation.
+ */
 export function _resetCSSColorCacheForTest(): void {
   currentVersion = 0
+  if (installedObserver) {
+    installedObserver.disconnect()
+    installedObserver = null
+  }
+  if (installedMql && installedMqlHandler) {
+    if (typeof installedMql.removeEventListener === "function") {
+      installedMql.removeEventListener("change", installedMqlHandler)
+    } else if (typeof (installedMql as any).removeListener === "function") {
+      (installedMql as any).removeListener(installedMqlHandler)
+    }
+    installedMql = null
+    installedMqlHandler = null
+  }
   observerInstalled = false
 }

--- a/src/components/stream/renderers/resolveCSSColor.ts
+++ b/src/components/stream/renderers/resolveCSSColor.ts
@@ -106,9 +106,13 @@ export function clearCSSColorCache(_canvas?: HTMLCanvasElement): void {
  * observer/matchMedia listeners. Required for test isolation — without it,
  * observers accumulate across files and bump `currentVersion` more than once
  * per real DOM mutation.
+ *
+ * `currentVersion` is *incremented* (not reset to zero) so any WeakMap entries
+ * that survive from a previous test can't accidentally be re-validated by a
+ * version collision.
  */
 export function _resetCSSColorCacheForTest(): void {
-  currentVersion = 0
+  currentVersion++
   if (installedObserver) {
     installedObserver.disconnect()
     installedObserver = null

--- a/src/components/stream/renderers/resolveCSSColor.ts
+++ b/src/components/stream/renderers/resolveCSSColor.ts
@@ -5,14 +5,54 @@
  * reads the computed value from the canvas element. Otherwise returns
  * the input unchanged.
  *
- * Per-canvas cache avoids repeated getComputedStyle calls within a single
- * paint cycle. The cache is cleared on theme changes via clearCSSColorCache(),
- * which each Stream Frame calls in its theme-change useEffect.
+ * Per-canvas cache avoids repeated `getComputedStyle` calls. Cached entries
+ * are tagged with a global version counter that's bumped whenever a theme
+ * change is detected — either through `clearCSSColorCache()` (called by
+ * Stream Frames on `currentTheme` change) or via the global observer below
+ * (catches external class toggles on `<html>` and `prefers-color-scheme`
+ * media-query changes that bypass React).
  */
 
 const varPattern = /^var\(\s*(--[^,)]+)(?:\s*,\s*([^)]+))?\s*\)$/
 
-const cache = new WeakMap<HTMLCanvasElement, Map<string, string>>()
+interface CacheEntry {
+  version: number
+  map: Map<string, string>
+}
+
+const cache = new WeakMap<HTMLCanvasElement, CacheEntry>()
+let currentVersion = 0
+let observerInstalled = false
+
+function ensureGlobalObserver(): void {
+  if (observerInstalled) return
+  observerInstalled = true
+  if (typeof window === "undefined" || typeof document === "undefined") return
+
+  const bumpVersion = () => { currentVersion++ }
+
+  if (typeof MutationObserver !== "undefined" && document.documentElement) {
+    const observer = new MutationObserver(bumpVersion)
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "style", "data-theme", "data-semiotic-theme"]
+    })
+  }
+
+  if (typeof window.matchMedia === "function") {
+    try {
+      const mql = window.matchMedia("(prefers-color-scheme: dark)")
+      if (typeof mql.addEventListener === "function") {
+        mql.addEventListener("change", bumpVersion)
+      } else if (typeof (mql as any).addListener === "function") {
+        // Safari 14 fallback
+        (mql as any).addListener(bumpVersion)
+      }
+    } catch {
+      // matchMedia can throw in older browsers / jsdom — safe to ignore
+    }
+  }
+}
 
 export function resolveCSSColor(
   ctx: CanvasRenderingContext2D,
@@ -25,23 +65,35 @@ export function resolveCSSColor(
   const canvas = ctx.canvas
   if (!canvas) return match[2]?.trim() || value
 
-  let canvasCache = cache.get(canvas)
-  if (!canvasCache) {
-    canvasCache = new Map()
-    cache.set(canvas, canvasCache)
+  ensureGlobalObserver()
+
+  let entry = cache.get(canvas)
+  if (!entry || entry.version !== currentVersion) {
+    entry = { version: currentVersion, map: new Map() }
+    cache.set(canvas, entry)
   }
-  if (canvasCache.has(value)) return canvasCache.get(value)!
+  const cached = entry.map.get(value)
+  if (cached !== undefined) return cached
 
   const computed = getComputedStyle(canvas).getPropertyValue(match[1]).trim()
   const resolved = computed || match[2]?.trim() || value
-  canvasCache.set(value, resolved)
+  entry.map.set(value, resolved)
   return resolved
 }
 
 /**
- * Clear the per-canvas CSS variable cache. Called by Stream Frames
- * when the theme changes so the next paint reads fresh computed values.
+ * Invalidate the CSS variable cache. Stream Frames call this from their
+ * `currentTheme` `useEffect` so the next paint reads fresh computed values.
+ *
+ * The `canvas` argument is accepted for backward compatibility but ignored —
+ * invalidation is global because theme changes are global.
  */
-export function clearCSSColorCache(canvas: HTMLCanvasElement): void {
-  cache.delete(canvas)
+export function clearCSSColorCache(_canvas?: HTMLCanvasElement): void {
+  currentVersion++
+}
+
+/** Test-only: reset all cache state. */
+export function _resetCSSColorCacheForTest(): void {
+  currentVersion = 0
+  observerInstalled = false
 }


### PR DESCRIPTION
  Audit-driven performance pass across all four Stream Frames and their pipeline stores. Removes an in-flight CSS-cache regression, eliminates redundant per-frame allocations, and extends quadtree spatial indexing to Geo and Ordinal hit
  testers. All hover handlers now coalesce pointer events via requestAnimationFrame, capping hit testing at the display refresh rate instead of the pointer device rate.

  Active regression resolved

  The working tree was about to ship a clearCSSColorCache(canvas) call at the top of every render frame in all four Stream Frames. That defeated the cache: every resolveCSSColor call fell through to getComputedStyle on the first hit per
  frame for each of ~5–15 unique CSS variables, with renderers calling it inside per-node loops.

  Replaced with a version-counter cache plus a singleton MutationObserver on document.documentElement (watches class/style/data-theme) and a matchMedia("(prefers-color-scheme: dark)") listener. External theme changes that bypass React are
  still detected; per-frame cost is now zero. The four per-frame clearCSSColorCache calls have been removed; the per-theme-change useEffect clears remain (they bump the version).

  Performance changes

  ┌──────────────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │                   Area                   │                                                                                           Change                                                                                            │
  ├──────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ OrdinalPipelineStore decay/pulse         │ getDatumIndexMap() and getCategoryIndexMap() cache against a new _dataVersion counter. Wedge pulse goes from O(wedges × data) to O(matches per category) and hoists accessor resolution out │
  │                                          │  of the inner loop.                                                                                                                                                                         │
  ├──────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ NetworkCanvasHitTester +                 │ _cachedPath2D / _cachedPath2DSource on NetworkBezierEdge / NetworkRibbonEdge / NetworkCurvedEdge. Path2D is parsed once per pathD value and reused across hit tests and renders.            │
  │ networkEdgeRenderer                      │                                                                                                                                                                                             │
  ├──────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ParticlePool                             │ Linear scan for free slots replaced with an O(1) free-list (stack of indices). step() and clear() push freed slots back.                                                                    │
  ├──────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ParticlePool bezier                      │ evaluateBezier rewritten as evaluateBezierInto(out) so positions are written directly into the particle — zero per-particle allocation.                                                     │
  ├──────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ PipelineStore stacked-area extent        │ groupData() + xTotals fused into a single pass; maxStacked tracked during the build.                                                                                                        │
  ├──────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ GeoPipelineStore line projection         │ Project + filter fused into a single pass for both lineType: "geo" and straight-line branches; intermediate lineCoords.map().filter() array eliminated.                                     │
  ├──────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ PipelineStore.resolveColorMap            │ Version-counter short-circuit by _ingestVersion; falls back to category-fingerprint comparison on version bump and refreshes the version on cache hit. Multiple scene builders within one   │
  │                                          │ frame skip the data scan after the first call.                                                                                                                                              │
  ├──────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ GeoPipelineStore quadtree                │ New rebuildQuadtree() for point scene nodes (>500 points). _maxPointRadius tracked alongside so the hit tester widens its query radius when symbols are large.                              │
  ├──────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ GeoCanvasHitTester                       │ Quadtree query radius widened to max(maxDistance, maxPointRadius + 5, 12) — eliminates the always-running linear fallback. Per-hit .filter() allocations for area/line nodes also removed   │
  │                                          │ (single-pass loops).                                                                                                                                                                        │
  ├──────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ OrdinalPipelineStore quadtree            │ rebuildPointQuadtree() mirrors the XY pattern, useful for swarm plots above 500 points.                                                                                                     │
  ├──────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ OrdinalCanvasHitTester                   │ Accepts pointQuadtree and maxPointRadius; same hybrid strategy as CanvasHitTester — quadtree fast-path then linear scan only for non-point types.                                           │
  ├──────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ All 4 Stream Frames                      │ pointermove events coalesced via requestAnimationFrame. Latest coordinates always processed; onMouseLeave cancels any pending move. Caps hit testing + React state updates at 60 Hz instead │
  │                                          │  of the native pointer rate (often 120–240 Hz).                                                                                                                                             │
  └──────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

  Tests

  - src/components/stream/renderers/resolveCSSColor.test.ts — 11 tests covering var resolution, fallback, per-canvas isolation, version-counter invalidation, and a getComputedStyle call-count guard. Would have caught the regression above.
  - src/components/stream/ParticlePool.test.ts — 7 tests covering spawn/recycle, free-list reuse on expiry and on invalid edges, clear(), resize() preserving active particles, and bezier position writes.
  - All 2963 existing tests pass. TypeScript strict mode clean. ESLint clean.

  Out of scope (documented in OUTSTANDING_WORK.md)

  Items I deliberately deferred, with rationale captured in the doc:

  - Style spread → direct mutation in decay/transition paths. Marginal GC win, but the change touches 13 sites across 4 files and the failure mode (cross-node style aliasing) would be subtle. Park until profiling identifies it as a
  bottleneck.
  - _groupColorMap unbounded growth in long-running high-cardinality streams. Needs an explicit eviction policy (LRU vs prune-on-buffer-evict) — out of scope for a perf pass.
  - Combinatorial canvas test paths (step curve × decay × threshold) still YELLOW per OUTSTANDING_WORK. Needs describe.each matrix; mechanical but separate.
  - 51 waitForTimeout calls in Playwright specs. Refactor to event-driven waits is its own change.

  OUTSTANDING_WORK.md updated throughout: completed items now linked back to the work above, the stale Quadtree RED flag is corrected to DONE, and the test-hygiene section is rewritten with verified counts (2 debug-only specs lack cleanup
  hooks, not 5 as the audit claimed).

  Test plan

  - npm test — full vitest suite (currently 2963 passing)
  - npx tsc --noEmit — strict typecheck
  - npm run lint
  - Visual smoke: dark-mode toggle on a streaming dashboard with <html class="dark"> — verify canvas colors update without React re-render
  - Visual smoke: scatter with >500 points + bubble with large radii — verify hover hits register on big symbols (was the worry behind keeping the linear fallback)
  - Visual smoke: sankey with many edges — confirm hover responsiveness improved
  - Visual smoke: high-frequency mouse movement on any chart — confirm tooltip updates feel smooth (rAF coalescing)

  🤖 Generated with https://claude.com/claude-code