### PR TITLE
Prerender the documentation

### DIFF
--- a/OUTSTANDING_WORK.md
+++ b/OUTSTANDING_WORK.md
@@ -335,13 +335,13 @@ Regex-based CLAUDE.md parsing can still miss narrative/semantic drift. `check:su
 
 ## Docs & Publishing
 
-### Docs site prerendering
+### Docs site prerendering [GREEN]
 
-Homepage resolves to a JS shell. Prerendering improves SEO and LLM retrieval.
+`scripts/prerender.mjs` now rewrites the root `docs/build/index.html` as well as nested routes, so the homepage no longer remains a plain SPA shell after `website:build`. Route extraction is indentation-aware and covers nested `/api/*` and `/theming/*` routes; canonical URLs, LLM alternate links, JSON-LD, and noscript fallbacks are generated idempotently.
 
-### API Reference Documentation
+### API Reference Documentation [YELLOW]
 
-TypeDoc setup, prop table component, `/api` route. Not started.
+Baseline is present: `typedoc.json`, `docs:api:json`, `docs/src/pages/api/ApiReferencePage.js`, `/api/charts`, and `/api/typedoc`. Remaining work: richer component summaries/examples, stronger TypeDoc prop extraction, and a docs-route smoke test in CI that runs after a clean `website:build`.
 
 ---
 

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -23,18 +23,62 @@ const APP_SRC = resolve(__dirname, "../docs/src/App.js")
 
 // ── Extract routes from App.js ──────────────────────────────────────────
 
+function collectRouteOpeningTags(source) {
+  const tags = []
+  const routePattern = /<Route\b/g
+  let match
+
+  while ((match = routePattern.exec(source)) !== null) {
+    const start = match.index
+    const lineStart = source.lastIndexOf("\n", start) + 1
+    const indent = source.slice(lineStart, start).match(/^\s*/)[0].length
+    let quote = null
+    let braceDepth = 0
+    let end = -1
+
+    for (let i = start; i < source.length; i++) {
+      const char = source[i]
+
+      if (quote) {
+        if (char === "\\") {
+          i++
+        } else if (char === quote) {
+          quote = null
+        }
+        continue
+      }
+
+      if (char === "\"" || char === "'" || char === "`") {
+        quote = char
+      } else if (char === "{") {
+        braceDepth++
+      } else if (char === "}" && braceDepth > 0) {
+        braceDepth--
+      } else if (char === ">" && braceDepth === 0) {
+        end = i + 1
+        break
+      }
+    }
+
+    if (end === -1) continue
+    tags.push({ tag: source.slice(start, end), indent })
+    routePattern.lastIndex = end
+  }
+
+  return tags
+}
+
 export function extractRoutesFromSource(source) {
   const paths = new Set([""])
   const parentStack = []
 
-  for (const line of source.split(/\r?\n/)) {
-    const match = line.match(/<Route\b[^>]*\bpath="([^"]+)"/)
+  for (const { tag, indent } of collectRouteOpeningTags(source)) {
+    const match = tag.match(/\bpath\s*=\s*["']([^"']+)["']/)
     if (!match) continue
 
     const rawPath = match[1]
     if (rawPath === "*") continue
 
-    const indent = line.match(/^\s*/)[0].length
     while (parentStack.length > 0 && parentStack[parentStack.length - 1].indent >= indent) {
       parentStack.pop()
     }
@@ -52,7 +96,7 @@ export function extractRoutesFromSource(source) {
 
     paths.add(routePath)
 
-    if (line.includes("<Outlet")) {
+    if (!/\/\s*>$/.test(tag.trim())) {
       parentStack.push({ indent, path: routePath })
     }
   }
@@ -86,10 +130,10 @@ export function generatePage(shellHtml, routePath) {
 
   // JSON-LD injected here (not in source HTML) to avoid Parcel's jsonld transformer
   const llmsAlternate = '<link rel="alternate" type="text/plain" href="/llms.txt" title="LLM-readable documentation index" />'
-  const jsonLd = '<script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Semiotic","applicationCategory":"DeveloperApplication","description":"React data visualization library for charts, networks, and streaming data.","url":"https://semiotic3.nteract.io","codeRepository":"https://github.com/nteract/semiotic","programmingLanguage":["TypeScript","React"],"license":"https://opensource.org/licenses/Apache-2.0","author":{"@type":"Person","name":"Elijah Meeks"},"offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}<\/script>'
+  const jsonLd = '<script type="application/ld+json" data-jsonld="semiotic">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Semiotic","applicationCategory":"DeveloperApplication","description":"React data visualization library for charts, networks, and streaming data.","url":"https://semiotic3.nteract.io","codeRepository":"https://github.com/nteract/semiotic","programmingLanguage":["TypeScript","React"],"license":"https://opensource.org/licenses/Apache-2.0","author":{"@type":"Person","name":"Elijah Meeks"},"offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}<\/script>'
   const normalizedShell = shellHtml
     .replace(/<link\s+rel=["']?alternate["']?[^>]*href=["']?\/llms\.txt[^>]*>/g, "")
-    .replace(/<script\s+type=["']application\/ld\+json["']>\{"@context":"https:\/\/schema\.org","@type":"SoftwareApplication".*?<\/script>/g, "")
+    .replace(/<script\b[^>]*type=["']application\/ld\+json["'][^>]*>\{"@context":"https:\/\/schema\.org","@type":"SoftwareApplication"[\s\S]*?<\/script>/g, "")
 
   return normalizedShell
     .replace(/<title>[^<]*<\/title>/, `${llmsAlternate}<title>${fullTitle}</title>${jsonLd}`)

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -15,7 +15,7 @@
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs"
 import { resolve, dirname } from "path"
-import { fileURLToPath } from "url"
+import { fileURLToPath, pathToFileURL } from "url"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const BUILD_DIR = resolve(__dirname, "../docs/build")
@@ -23,35 +23,50 @@ const APP_SRC = resolve(__dirname, "../docs/src/App.js")
 
 // ── Extract routes from App.js ──────────────────────────────────────────
 
-function extractRoutes() {
-  const source = readFileSync(APP_SRC, "utf-8")
-  const PARENTS = ["charts", "features", "cookbook", "frames", "playground", "recipes", "api"]
-  const routePattern = /path="([^"]+)"/g
-  const rawPaths = []
-  let match
-  while ((match = routePattern.exec(source)) !== null) {
-    rawPaths.push(match[1])
-  }
-
+export function extractRoutesFromSource(source) {
   const paths = new Set([""])
-  let currentParent = ""
-  for (const p of rawPaths) {
-    if (p === "*") continue
-    if (PARENTS.includes(p)) {
-      currentParent = p
-      paths.add(p)
-    } else if (!p.includes("/")) {
-      paths.add(currentParent ? `${currentParent}/${p}` : p)
-    } else {
-      paths.add(p)
+  const parentStack = []
+
+  for (const line of source.split(/\r?\n/)) {
+    const match = line.match(/<Route\b[^>]*\bpath="([^"]+)"/)
+    if (!match) continue
+
+    const rawPath = match[1]
+    if (rawPath === "*") continue
+
+    const indent = line.match(/^\s*/)[0].length
+    while (parentStack.length > 0 && parentStack[parentStack.length - 1].indent >= indent) {
+      parentStack.pop()
+    }
+
+    const parentPath = parentStack[parentStack.length - 1]?.path || ""
+    const routePath = rawPath === "/"
+      ? ""
+      : rawPath === ""
+        ? parentPath
+        : rawPath.includes("/")
+          ? rawPath.replace(/^\/+/, "")
+          : parentPath
+            ? `${parentPath}/${rawPath}`
+            : rawPath
+
+    paths.add(routePath)
+
+    if (line.includes("<Outlet")) {
+      parentStack.push({ indent, path: routePath })
     }
   }
+
   return Array.from(paths)
+}
+
+function extractRoutes() {
+  return extractRoutesFromSource(readFileSync(APP_SRC, "utf-8"))
 }
 
 // ── Generate pre-rendered HTML for a route ──────────────────────────────
 
-function generatePage(shellHtml, routePath) {
+export function generatePage(shellHtml, routePath) {
   const title = routePath
     .split("/")
     .filter(Boolean)
@@ -70,17 +85,21 @@ function generatePage(shellHtml, routePath) {
     </nav>`
 
   // JSON-LD injected here (not in source HTML) to avoid Parcel's jsonld transformer
+  const llmsAlternate = '<link rel="alternate" type="text/plain" href="/llms.txt" title="LLM-readable documentation index" />'
   const jsonLd = '<script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Semiotic","applicationCategory":"DeveloperApplication","description":"React data visualization library for charts, networks, and streaming data.","url":"https://semiotic3.nteract.io","codeRepository":"https://github.com/nteract/semiotic","programmingLanguage":["TypeScript","React"],"license":"https://opensource.org/licenses/Apache-2.0","author":{"@type":"Person","name":"Elijah Meeks"},"offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}<\/script>'
+  const normalizedShell = shellHtml
+    .replace(/<link\s+rel=["']?alternate["']?[^>]*href=["']?\/llms\.txt[^>]*>/g, "")
+    .replace(/<script\s+type=["']application\/ld\+json["']>\{"@context":"https:\/\/schema\.org","@type":"SoftwareApplication".*?<\/script>/g, "")
 
-  return shellHtml
-    .replace(/<title>[^<]*<\/title>/, `<link rel="alternate" type="text/plain" href="/llms.txt" title="LLM-readable documentation index" /><title>${fullTitle}</title>${jsonLd}`)
-    .replace(/<noscript>.*?<\/noscript>/, `<noscript>${navHtml}</noscript>`)
-    .replace(/<link rel="canonical"[^>]*>/, `<link rel="canonical" href="https://semiotic3.nteract.io/${routePath}" />`)
+  return normalizedShell
+    .replace(/<title>[^<]*<\/title>/, `${llmsAlternate}<title>${fullTitle}</title>${jsonLd}`)
+    .replace(/<noscript>[\s\S]*?<\/noscript>/, `<noscript>${navHtml}</noscript>`)
+    .replace(/<link\s+rel=["']?canonical["']?[^>]*>/, `<link rel="canonical" href="https://semiotic3.nteract.io/${routePath}" />`)
 }
 
 // ── Main ────────────────────────────────────────────────────────────────
 
-function main() {
+export function prerender() {
   const shellPath = resolve(BUILD_DIR, "index.html")
   if (!existsSync(shellPath)) {
     console.error("docs/build/index.html not found. Run 'npm run website:build' first.")
@@ -92,7 +111,8 @@ function main() {
 
   console.log(`Pre-rendering ${routes.length} routes...`)
 
-  let created = 0
+  writeFileSync(shellPath, generatePage(shellHtml, ""))
+  let created = 1
   for (const route of routes) {
     if (route === "/" || route === "" || route === "*" || route.includes(":")) continue
     const dir = resolve(BUILD_DIR, route)
@@ -111,4 +131,6 @@ function main() {
   console.log(`\u2705 sitemap.txt written`)
 }
 
-main()
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  prerender()
+}

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -20,6 +20,7 @@ import { fileURLToPath, pathToFileURL } from "url"
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const BUILD_DIR = resolve(__dirname, "../docs/build")
 const APP_SRC = resolve(__dirname, "../docs/src/App.js")
+const SITE_URL = "https://semiotic3.nteract.io"
 
 // ── Extract routes from App.js ──────────────────────────────────────────
 
@@ -131,14 +132,21 @@ export function generatePage(shellHtml, routePath) {
   // JSON-LD injected here (not in source HTML) to avoid Parcel's jsonld transformer
   const llmsAlternate = '<link rel="alternate" type="text/plain" href="/llms.txt" title="LLM-readable documentation index" />'
   const jsonLd = '<script type="application/ld+json" data-jsonld="semiotic">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Semiotic","applicationCategory":"DeveloperApplication","description":"React data visualization library for charts, networks, and streaming data.","url":"https://semiotic3.nteract.io","codeRepository":"https://github.com/nteract/semiotic","programmingLanguage":["TypeScript","React"],"license":"https://opensource.org/licenses/Apache-2.0","author":{"@type":"Person","name":"Elijah Meeks"},"offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}<\/script>'
-  const normalizedShell = shellHtml
-    .replace(/<link\s+rel=["']?alternate["']?[^>]*href=["']?\/llms\.txt[^>]*>/g, "")
-    .replace(/<script\b[^>]*type=["']application\/ld\+json["'][^>]*>\{"@context":"https:\/\/schema\.org","@type":"SoftwareApplication"[\s\S]*?<\/script>/g, "")
+  const canonicalUrl = routePath ? `${SITE_URL}/${routePath}` : SITE_URL
+  let normalizedShell = shellHtml
+  let previousShell
+  do {
+    previousShell = normalizedShell
+    normalizedShell = normalizedShell
+      .replace(/<link\s+rel=["']?alternate["']?[^>]*href=["']?\/llms\.txt[^>]*>/g, "")
+      .replace(/<script\b[^>]*type=["']application\/ld\+json["'][^>]*>\{"@context":"https:\/\/schema\.org","@type":"SoftwareApplication"[\s\S]*?<\/script>/g, "")
+  } while (normalizedShell !== previousShell)
 
   return normalizedShell
     .replace(/<title>[^<]*<\/title>/, `${llmsAlternate}<title>${fullTitle}</title>${jsonLd}`)
     .replace(/<noscript>[\s\S]*?<\/noscript>/, `<noscript>${navHtml}</noscript>`)
-    .replace(/<link\s+rel=["']?canonical["']?[^>]*>/, `<link rel="canonical" href="https://semiotic3.nteract.io/${routePath}" />`)
+    .replace(/<meta\b(?=[^>]*\bproperty=["']?og:url["']?)[^>]*>/, `<meta property="og:url" content="${canonicalUrl}" />`)
+    .replace(/<link\s+rel=["']?canonical["']?[^>]*>/, `<link rel="canonical" href="${canonicalUrl}" />`)
 }
 
 // ── Main ────────────────────────────────────────────────────────────────

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -139,7 +139,7 @@ export function generatePage(shellHtml, routePath) {
     previousShell = normalizedShell
     normalizedShell = normalizedShell
       .replace(/<link\s+rel=["']?alternate["']?[^>]*href=["']?\/llms\.txt[^>]*>/g, "")
-      .replace(/<script\b[^>]*type=["']application\/ld\+json["'][^>]*>\{"@context":"https:\/\/schema\.org","@type":"SoftwareApplication"[\s\S]*?<\/script>/g, "")
+      .replace(/<script\b(?=[^>]*\btype=["']application\/ld\+json["'])(?=[^>]*\bdata-jsonld=["']semiotic["'])[^>]*>[\s\S]*?<\/script>/g, "")
   } while (normalizedShell !== previousShell)
 
   return normalizedShell

--- a/src/__tests__/scenarios/docs-prerender.test.ts
+++ b/src/__tests__/scenarios/docs-prerender.test.ts
@@ -62,6 +62,7 @@ describe("docs prerender helpers", () => {
       <html>
         <head>
           <title>Semiotic</title>
+          <meta property=og:url content=https://example.com/>
           <link rel=canonical href=https://example.com/>
         </head>
         <body><noscript>
@@ -73,7 +74,8 @@ describe("docs prerender helpers", () => {
     const html = generatePage(shell, "")
 
     expect(html).toContain("<title>Semiotic \u2014 Data Visualization for React</title>")
-    expect(html).toContain('rel="canonical" href="https://semiotic3.nteract.io/"')
+    expect(html).toContain('property="og:url" content="https://semiotic3.nteract.io"')
+    expect(html).toContain('rel="canonical" href="https://semiotic3.nteract.io"')
     expect(html).toContain('data-jsonld="semiotic"')
     expect(html).toContain("AI / Machine-readable docs")
     expect(html).not.toContain("old fallback")
@@ -81,22 +83,25 @@ describe("docs prerender helpers", () => {
 
   it("replaces minified canonical tags for nested routes", () => {
     const html = generatePage(
-      '<html><head><title>Shell</title><link rel=canonical href=https://example.com></head><body><noscript>old</noscript></body></html>',
+      '<html><head><title>Shell</title><meta property=og:url content=https://example.com><link rel=canonical href=https://example.com></head><body><noscript>old</noscript></body></html>',
       "theming/styling"
     )
 
+    expect(html).toContain('property="og:url" content="https://semiotic3.nteract.io/theming/styling"')
     expect(html).toContain('rel="canonical" href="https://semiotic3.nteract.io/theming/styling"')
     expect(html).not.toContain("https://example.com")
   })
 
   it("does not duplicate injected metadata when rerun", () => {
-    const shell = '<html><head><title>Shell</title><link rel=canonical href=https://example.com></head><body><noscript>old</noscript></body></html>'
+    const shell = '<html><head><title>Shell</title><meta property=og:url content=https://example.com><link rel=canonical href=https://example.com></head><body><noscript>old</noscript></body></html>'
     const once = generatePage(shell, "")
     const twice = generatePage(once, "theming/styling")
 
     expect(twice.match(/<link rel="alternate" type="text\/plain" href="\/llms\.txt"/g)).toHaveLength(1)
     expect(twice.match(/"@type":"SoftwareApplication"/g)).toHaveLength(1)
     expect(twice.match(/data-jsonld="semiotic"/g)).toHaveLength(1)
+    expect(twice.match(/property="og:url"/g)).toHaveLength(1)
+    expect(twice).toContain('property="og:url" content="https://semiotic3.nteract.io/theming/styling"')
     expect(twice).toContain('rel="canonical" href="https://semiotic3.nteract.io/theming/styling"')
   })
 })

--- a/src/__tests__/scenarios/docs-prerender.test.ts
+++ b/src/__tests__/scenarios/docs-prerender.test.ts
@@ -7,9 +7,20 @@ describe("docs prerender helpers", () => {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="api" element={<Outlet />}>
-          <Route path="" element={<ApiIndex />} />
+          <Route
+            path=""
+            element={
+              <>
+                <h1>API</h1>
+                <ApiIndex />
+              </>
+            }
+          />
           <Route path="charts" element={<ChartsApi />} />
-          <Route path="typedoc" element={<ApiDocs />} />
+          <Route
+            path="typedoc"
+            element={<ApiDocs />}
+          />
         </Route>
         <Route path="charts" element={<Outlet />}>
           <Route path="line-chart" element={<LineChart />} />
@@ -19,8 +30,14 @@ describe("docs prerender helpers", () => {
           <Route path="theme-provider" element={<ThemeProviderDocs />} />
         </Route>
         <Route path="features/styling" element={<Redirect />} />
-        <Route path="cookbook" element={<Outlet />}>
-          <Route path="timeline" element={<Timeline />} />
+        <Route
+          path="cookbook"
+          element={<Outlet />}
+        >
+          <Route
+            path="timeline"
+            element={<Timeline />}
+          />
         </Route>
       </Routes>
     `
@@ -57,6 +74,7 @@ describe("docs prerender helpers", () => {
 
     expect(html).toContain("<title>Semiotic \u2014 Data Visualization for React</title>")
     expect(html).toContain('rel="canonical" href="https://semiotic3.nteract.io/"')
+    expect(html).toContain('data-jsonld="semiotic"')
     expect(html).toContain("AI / Machine-readable docs")
     expect(html).not.toContain("old fallback")
   })
@@ -78,6 +96,7 @@ describe("docs prerender helpers", () => {
 
     expect(twice.match(/<link rel="alternate" type="text\/plain" href="\/llms\.txt"/g)).toHaveLength(1)
     expect(twice.match(/"@type":"SoftwareApplication"/g)).toHaveLength(1)
+    expect(twice.match(/data-jsonld="semiotic"/g)).toHaveLength(1)
     expect(twice).toContain('rel="canonical" href="https://semiotic3.nteract.io/theming/styling"')
   })
 })

--- a/src/__tests__/scenarios/docs-prerender.test.ts
+++ b/src/__tests__/scenarios/docs-prerender.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest"
+import { extractRoutesFromSource, generatePage } from "../../../scripts/prerender.mjs"
+
+describe("docs prerender helpers", () => {
+  it("extracts nested docs routes without leaking the previous parent", () => {
+    const source = `
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="api" element={<Outlet />}>
+          <Route path="" element={<ApiIndex />} />
+          <Route path="charts" element={<ChartsApi />} />
+          <Route path="typedoc" element={<ApiDocs />} />
+        </Route>
+        <Route path="charts" element={<Outlet />}>
+          <Route path="line-chart" element={<LineChart />} />
+        </Route>
+        <Route path="theming" element={<Outlet />}>
+          <Route path="styling" element={<Styling />} />
+          <Route path="theme-provider" element={<ThemeProviderDocs />} />
+        </Route>
+        <Route path="features/styling" element={<Redirect />} />
+        <Route path="cookbook" element={<Outlet />}>
+          <Route path="timeline" element={<Timeline />} />
+        </Route>
+      </Routes>
+    `
+
+    const routes = extractRoutesFromSource(source)
+
+    expect(routes).toContain("")
+    expect(routes).toContain("api")
+    expect(routes).toContain("api/charts")
+    expect(routes).toContain("api/typedoc")
+    expect(routes).toContain("charts")
+    expect(routes).toContain("charts/line-chart")
+    expect(routes).toContain("theming/styling")
+    expect(routes).toContain("theming/theme-provider")
+    expect(routes).toContain("features/styling")
+    expect(routes).toContain("cookbook/timeline")
+    expect(routes).not.toContain("api/styling")
+  })
+
+  it("generates SEO metadata and a noscript fallback for the homepage", () => {
+    const shell = `
+      <html>
+        <head>
+          <title>Semiotic</title>
+          <link rel=canonical href=https://example.com/>
+        </head>
+        <body><noscript>
+          old fallback
+        </noscript><div id="root"></div></body>
+      </html>
+    `
+
+    const html = generatePage(shell, "")
+
+    expect(html).toContain("<title>Semiotic \u2014 Data Visualization for React</title>")
+    expect(html).toContain('rel="canonical" href="https://semiotic3.nteract.io/"')
+    expect(html).toContain("AI / Machine-readable docs")
+    expect(html).not.toContain("old fallback")
+  })
+
+  it("replaces minified canonical tags for nested routes", () => {
+    const html = generatePage(
+      '<html><head><title>Shell</title><link rel=canonical href=https://example.com></head><body><noscript>old</noscript></body></html>',
+      "theming/styling"
+    )
+
+    expect(html).toContain('rel="canonical" href="https://semiotic3.nteract.io/theming/styling"')
+    expect(html).not.toContain("https://example.com")
+  })
+
+  it("does not duplicate injected metadata when rerun", () => {
+    const shell = '<html><head><title>Shell</title><link rel=canonical href=https://example.com></head><body><noscript>old</noscript></body></html>'
+    const once = generatePage(shell, "")
+    const twice = generatePage(once, "theming/styling")
+
+    expect(twice.match(/<link rel="alternate" type="text\/plain" href="\/llms\.txt"/g)).toHaveLength(1)
+    expect(twice.match(/"@type":"SoftwareApplication"/g)).toHaveLength(1)
+    expect(twice).toContain('rel="canonical" href="https://semiotic3.nteract.io/theming/styling"')
+  })
+})

--- a/src/__tests__/scenarios/docs-prerender.test.ts
+++ b/src/__tests__/scenarios/docs-prerender.test.ts
@@ -104,4 +104,14 @@ describe("docs prerender helpers", () => {
     expect(twice).toContain('property="og:url" content="https://semiotic3.nteract.io/theming/styling"')
     expect(twice).toContain('rel="canonical" href="https://semiotic3.nteract.io/theming/styling"')
   })
+
+  it("preserves unrelated JSON-LD scripts", () => {
+    const unrelatedJsonLd = '<script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Other App"}</script>'
+    const shell = `<html><head><title>Shell</title>${unrelatedJsonLd}<meta property=og:url content=https://example.com><link rel=canonical href=https://example.com></head><body><noscript>old</noscript></body></html>`
+    const html = generatePage(shell, "")
+
+    expect(html).toContain(unrelatedJsonLd)
+    expect(html.match(/data-jsonld="semiotic"/g)).toHaveLength(1)
+    expect(html.match(/"@type":"SoftwareApplication"/g)).toHaveLength(2)
+  })
 })


### PR DESCRIPTION
This pull request significantly improves the prerendering logic for the docs site, making it more robust, SEO-friendly, and testable. The main changes include a smarter, indentation-aware route extraction for static prerendering, enhanced metadata injection for SEO and LLMs, and the addition of comprehensive tests for these features.

**Docs prerendering improvements:**

* Refactored `scripts/prerender.mjs` to use an indentation-aware algorithm (`extractRoutesFromSource`) for extracting nested routes from `App.js`, ensuring accurate prerendering of all docs routes, including `/api/*` and `/theming/*`.
* Enhanced the `generatePage` function to prevent duplicate metadata injection (like canonical links and JSON-LD), and to ensure consistent inclusion of LLM alternate links and noscript fallbacks for better SEO and accessibility.
* The prerendering process now rewrites the root `index.html` as well as nested routes, so the homepage is no longer just a SPA shell after `website:build`.

**Testing and reliability:**

* Added a new test suite (`src/__tests__/scenarios/docs-prerender.test.ts`) to verify correct route extraction, SEO metadata injection, canonical link replacement, and idempotency of metadata insertion.

**Documentation updates:**

* Updated the outstanding work documentation to reflect the improved prerendering status and clarified remaining API reference documentation tasks.