### PR TITLE
Better streaming legend

### DIFF
--- a/OUTSTANDING_WORK.md
+++ b/OUTSTANDING_WORK.md
@@ -204,7 +204,9 @@ Curated categorical sequences maximizing neighbor contrast, and per-role typogra
 
 ### Legend auto-population from pushed categories [YELLOW]
 
-**Status**: short-circuited at 3.4.1 (empty legends no longer reserve margin); real auto-population deferred.
+**Status**: partially addressed. 3.4.1 short-circuited empty legends so they no longer reserve margin. Post-prerender follow-up wired `BarChart` to the shared `useOrdinalStreaming` path: `<BarChart colorBy="category">` with omitted `data` now starts tight, then populates its legend and reserves legend margin after categories arrive through `ref.current.push()` / `pushMany()`. Regression coverage lives in `BarChart.test.tsx`.
+
+**Still open**: the full frame-domain subscription design below is not landed. The current shared streaming-legend path discovers categories from pushed inserts and resets on `clear()`, but it does not yet shrink on `remove()` / `update()` domain changes, and it is not wired uniformly across every HOC or through `LinkedCharts` shared-category state.
 
 **Symptom**: A push-API chart (`<BarChart colorBy="category">`, no `data` prop) mounts before any categories exist, so `useChartLegendAndMargin` → `createLegend` produces a shell with `legendGroups: [{ items: [], label: "" }]`. Pre-3.4.1 that reserved 110px of right-margin for a legend and rendered only the empty header bar ("neatline"). 3.4.1 treats zero-item legends as absent — margin stays tight, no ghost header — but the legend still never populates as categories arrive via `push()`, which is the behavior users actually want.
 

--- a/OUTSTANDING_WORK.md
+++ b/OUTSTANDING_WORK.md
@@ -202,31 +202,18 @@ Curated categorical sequences maximizing neighbor contrast, and per-role typogra
 
 **Status**: Not scoped. `remove()`/`update()` return previous values — caller can push them back manually. A built-in `ref.current.undo()` needs an operation log with inverse operations. May be better as a userland wrapper.
 
-### Legend auto-population from pushed categories [YELLOW]
+### Legend auto-population from pushed categories [GREEN]
 
-**Status**: partially addressed. 3.4.1 short-circuited empty legends so they no longer reserve margin. Post-prerender follow-up wired `BarChart` to the shared `useOrdinalStreaming` path: `<BarChart colorBy="category">` with omitted `data` now starts tight, then populates its legend and reserves legend margin after categories arrive through `ref.current.push()` / `pushMany()`. Regression coverage lives in `BarChart.test.tsx`.
+**Status**: implemented. Empty push-mode legends still start suppressed (no ghost margin), but `StreamOrdinalFrame` and `StreamXYFrame` now accept `legendCategoryAccessor` + `onCategoriesChange` and emit the live legend-category domain after scene rebuilds. The callback is domain-deduped and fires for first push, `pushMany`, `remove`, `update`, and `clear`, so legends now shrink and relabel when the underlying frame domain changes.
 
-**Still open**: the full frame-domain subscription design below is not landed. The current shared streaming-legend path discovers categories from pushed inserts and resets on `clear()`, but it does not yet shrink on `remove()` / `update()` domain changes, and it is not wired uniformly across every HOC or through `LinkedCharts` shared-category state.
+`useChartSetup` wires the frame-domain props for HOCs that use the shared setup path. Manual XY streaming HOCs (`LineChart`, `AreaChart`, `BubbleChart`, `StackedAreaChart`) use the same `useStreamingLegend` domain props. `useChartLegendAndMargin` is also the common LinkedCharts registration point for static legends, so chart categories flow into unified legend/color state instead of requiring each HOC to opt in separately.
 
-**Symptom**: A push-API chart (`<BarChart colorBy="category">`, no `data` prop) mounts before any categories exist, so `useChartLegendAndMargin` → `createLegend` produces a shell with `legendGroups: [{ items: [], label: "" }]`. Pre-3.4.1 that reserved 110px of right-margin for a legend and rendered only the empty header bar ("neatline"). 3.4.1 treats zero-item legends as absent — margin stays tight, no ghost header — but the legend still never populates as categories arrive via `push()`, which is the behavior users actually want.
+`LinkedCharts` now owns a live category registry. Child charts register their current domains; LinkedCharts merges those with any parent `CategoryColorProvider` colors, provides stable shared colors to children, and renders/shrinks the unified legend from the live category set.
 
-**What's missing**: a subscription from the frame to the HOC telling it "the category list changed, rebuild the legend from the new domain". Current data flow is one-way (HOC → frame via props / ref imperatives); legend construction lives entirely in `useChartLegendAndMargin` and is memo'd against the `data` prop, which stays `undefined` forever under push API.
-
-**Sketched design**:
-1. Add `onCategoriesChange?: (categories: string[]) => void` prop to `StreamOrdinalFrame` (and, for XY charts that face the same latent issue with `colorBy`, `StreamXYFrame`). Fires after each `computeScene` when the relevant scale domain differs from last fire.
-2. `useChartSetup` holds a `const [pushedCategories, setPushedCategories] = useState<string[]>([])`, wires a stable `onCategoriesChange` handler that calls `setPushedCategories`, and threads `categories: pushedCategories` into `useChartLegendAndMargin`. The hook's `categories` param already exists (and short-circuits the data-based unique-values path inside `createLegend`), but no HOC surfaces it as a public prop yet — this design piggybacks on it for the internal push-tracking path.
-3. Debounce by identity: fire the callback only when the sorted category list is not shallow-equal to the prior one. Otherwise we'd re-render on every rAF.
-4. Document: declaring `colorBy` + pushing categories is now enough; passing an explicit `categories` prop remains supported for the case where users want a legend populated before any data arrives (e.g. categorical color consistency across a dashboard).
-
-**Known landmines**:
-- Make sure the callback fires after FIRST ingest, not just on subsequent changes — otherwise the initial push batch never triggers legend population.
-- Identity-based dedupe has to compare sorted arrays, not just `===`, since `oScale.domain()` returns a fresh array each call in OrdinalPipelineStore.
-- XY's colorBy-as-categorical case is analogous but uses `groupAccessor` in the store; same pattern but different accessor path.
-- `LinkedCharts` + `CategoryColorProvider` already handle shared-category legends across charts — make sure the auto-populated categories flow into the provider's shared list too, otherwise charts under `LinkedCharts` with push API would get mismatched colors across the shared legend.
-
-**Effort**: ~150 LOC across StreamOrdinalFrame / StreamXYFrame / useChartSetup / OrdinalPipelineStore (domain-change detection) / PipelineStore. Three or four tests: first-push fires, repeated pushes without domain change don't fire, domain shrinkage (category removed) fires with the reduced list, LinkedCharts share state.
-
-**Workaround until implemented**: pass the full dataset via `data` on first render (then use push for subsequent updates), OR accept that push-API + `colorBy` produces a category-less legend (current behavior post-3.4.1). Surfacing the hook-internal `categories` param as an HOC prop would be a smaller middle-ground change — one line per HOC — if an escape hatch is needed before the full auto-population work lands.
+Regression coverage:
+- `StreamOrdinalFrame.test.tsx` and `StreamXYFrame.test.tsx`: first push, remove, update, clear domain emissions.
+- `BarChart.test.tsx`: push-mode legend populates, shrinks, relabels, and clears through the public ref.
+- `LinkedCharts.test.tsx`: unified legend builds and shrinks from child category registrations.
 
 ---
 

--- a/integration-tests/streaming-regression.spec.ts
+++ b/integration-tests/streaming-regression.spec.ts
@@ -154,10 +154,14 @@ test.describe("Streaming Legend Regression", () => {
       const testCase = page.locator(`[data-testid="${testId}"]`)
       // Legend renders as SVG overlay with legend items
       const legendItems = testCase.locator('[role="option"], .legend-item, text')
-      const count = await legendItems.count()
 
-      // Should have at least 2 legend items
-      expect(count).toBeGreaterThanOrEqual(2)
+      // The streaming examples push categories over time. First canvas paint
+      // can happen after one datum, so poll until enough category domains have
+      // reached the legend instead of sampling the DOM once.
+      await expect.poll(
+        async () => legendItems.count(),
+        { timeout: 8000, message: `${name}: streaming legend never reached 2 items` }
+      ).toBeGreaterThanOrEqual(2)
     })
   }
 })

--- a/src/components/LinkedCharts.test.tsx
+++ b/src/components/LinkedCharts.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
-import { render, fireEvent, act as rtlAct } from "@testing-library/react"
+import { render, fireEvent, act as rtlAct, waitFor } from "@testing-library/react"
 import { renderHook, act } from "@testing-library/react"
-import { LinkedCharts, useSelection, useLinkedHover, useLinkedLegendSuppression, estimateLegendRowCount } from "./LinkedCharts"
+import { LinkedCharts, useSelection, useLinkedHover, useLinkedLegendSuppression, useLinkedChartCategories, estimateLegendRowCount } from "./LinkedCharts"
 import { CategoryColorProvider } from "./CategoryColors"
 import type { Datum } from "./charts/shared/datumTypes"
 
@@ -146,6 +146,35 @@ describe("LinkedCharts", () => {
     expect(container.querySelector("svg")).toBeTruthy()
     expect(container.textContent).toContain("North")
     expect(container.textContent).toContain("South")
+  })
+
+  it("builds and shrinks unified legend categories from child chart registrations", async () => {
+    function RegisteringChart({ categories }: { categories: string[] }) {
+      useLinkedChartCategories(categories)
+      return <div>child</div>
+    }
+
+    const { container, rerender } = render(
+      <LinkedCharts>
+        <RegisteringChart categories={["A", "B"]} />
+      </LinkedCharts>
+    )
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("A")
+      expect(container.textContent).toContain("B")
+    })
+
+    rerender(
+      <LinkedCharts>
+        <RegisteringChart categories={["A"]} />
+      </LinkedCharts>
+    )
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("A")
+      expect(container.textContent).not.toContain("B")
+    })
   })
 
   it("does not render legend when showLegend is false", () => {

--- a/src/components/LinkedCharts.test.tsx
+++ b/src/components/LinkedCharts.test.tsx
@@ -127,9 +127,22 @@ describe("LinkedCharts", () => {
     expect(result.current).toBe(true)
   })
 
-  it("useLinkedLegendSuppression returns true by default inside LinkedCharts", () => {
+  it("useLinkedLegendSuppression returns false when LinkedCharts has no categories yet (no unified legend would render)", () => {
+    // Suppression now activates only once the unified legend has categories
+    // to render — otherwise child legends would silence themselves while
+    // <LinkedLegend> returns null on empty input, leaving no legend at all.
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <LinkedCharts>{children}</LinkedCharts>
+    )
+    const { result } = renderHook(() => useLinkedLegendSuppression(), { wrapper })
+    expect(result.current).toBe(false)
+  })
+
+  it("useLinkedLegendSuppression returns true once categories are present", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <CategoryColorProvider colors={{ A: "#f00", B: "#0f0" }}>
+        <LinkedCharts>{children}</LinkedCharts>
+      </CategoryColorProvider>
     )
     const { result } = renderHook(() => useLinkedLegendSuppression(), { wrapper })
     expect(result.current).toBe(true)

--- a/src/components/LinkedCharts.test.tsx
+++ b/src/components/LinkedCharts.test.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { render, fireEvent, act as rtlAct, waitFor } from "@testing-library/react"
 import { renderHook, act } from "@testing-library/react"
 import { LinkedCharts, useSelection, useLinkedHover, useLinkedLegendSuppression, useLinkedChartCategories, estimateLegendRowCount } from "./LinkedCharts"
-import { CategoryColorProvider } from "./CategoryColors"
+import { CategoryColorProvider, useCategoryColors } from "./CategoryColors"
 import type { Datum } from "./charts/shared/datumTypes"
 
 describe("LinkedCharts", () => {
@@ -127,6 +127,14 @@ describe("LinkedCharts", () => {
     expect(result.current).toBe(true)
   })
 
+  it("useLinkedLegendSuppression returns true by default inside LinkedCharts", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <LinkedCharts>{children}</LinkedCharts>
+    )
+    const { result } = renderHook(() => useLinkedLegendSuppression(), { wrapper })
+    expect(result.current).toBe(true)
+  })
+
   it("useLinkedLegendSuppression returns false when LinkedCharts has showLegend={false}", () => {
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <LinkedCharts showLegend={false}>{children}</LinkedCharts>
@@ -174,6 +182,44 @@ describe("LinkedCharts", () => {
     await waitFor(() => {
       expect(container.textContent).toContain("A")
       expect(container.textContent).not.toContain("B")
+    })
+  })
+
+  it("keeps generated category colors stable when registered category order changes", async () => {
+    function ColorSnapshot() {
+      const colors = useCategoryColors()
+      return <pre data-testid="colors">{JSON.stringify(colors)}</pre>
+    }
+
+    function RegisteringChart({ categories }: { categories: string[] }) {
+      useLinkedChartCategories(categories)
+      return <ColorSnapshot />
+    }
+
+    const { getByTestId, rerender } = render(
+      <LinkedCharts>
+        <RegisteringChart categories={["A", "B"]} />
+      </LinkedCharts>
+    )
+
+    await waitFor(() => {
+      const colors = JSON.parse(getByTestId("colors").textContent || "{}")
+      expect(colors.B).toBeTruthy()
+    })
+    const firstColors = JSON.parse(getByTestId("colors").textContent || "{}")
+    const bColor = firstColors.B
+
+    rerender(
+      <LinkedCharts>
+        <RegisteringChart categories={["C", "B"]} />
+      </LinkedCharts>
+    )
+
+    await waitFor(() => {
+      const colors = JSON.parse(getByTestId("colors").textContent || "{}")
+      expect(colors.A).toBeUndefined()
+      expect(colors.B).toBe(bColor)
+      expect(colors.C).toBeTruthy()
     })
   })
 

--- a/src/components/LinkedCharts.tsx
+++ b/src/components/LinkedCharts.tsx
@@ -406,13 +406,21 @@ export function LinkedCharts({
     ? showLegend
     : true
 
+  // Only suppress child-chart legends once the unified legend actually has
+  // categories to render. Setting LinkedLegendContext = true on first render
+  // (before any chart has registered) would silence child legends while
+  // <LinkedLegend> still returns null on empty categoryColors — leaving the
+  // page with no legend at all for one tick.
+  const hasCategories = Object.keys(categoryColors).length > 0
+  const suppressChildLegends = shouldShowLegend && hasCategories
+
   return (
     <SelectionProvider>
       <ObservationProvider>
         {selections && <ResolutionInit selections={selections} />}
         <LinkedCategoryRegistryContext.Provider value={registry}>
           <CategoryColorProvider colors={categoryColors}>
-            <LinkedLegendContext.Provider value={shouldShowLegend}>
+            <LinkedLegendContext.Provider value={suppressChildLegends}>
               {shouldShowLegend && legendPosition === "top" && (
                 <LinkedLegend
                   categoryColors={categoryColors}

--- a/src/components/LinkedCharts.tsx
+++ b/src/components/LinkedCharts.tsx
@@ -71,17 +71,27 @@ function sameCategories(a: readonly string[], b: readonly string[]): boolean {
 export function useLinkedChartCategories(categories: string[]): void {
   const registry = useContext(LinkedCategoryRegistryContext)
   const id = useId()
-  const categoriesKey = categories.join("\0")
-  const stableCategories = useMemo(
-    () => categoriesKey ? uniqueCategories(categoriesKey.split("\0")) : [],
-    [categoriesKey]
-  )
+  const nextCategories = uniqueCategories(categories)
+  const stableCategoriesRef = useRef<string[]>([])
+  if (!sameCategories(stableCategoriesRef.current, nextCategories)) {
+    stableCategoriesRef.current = nextCategories
+  }
+  const stableCategories = stableCategoriesRef.current
+
+  useEffect(() => {
+    if (!registry) return
+    return () => registry.unregisterCategories(id)
+  }, [registry, id])
 
   useEffect(() => {
     if (!registry) return
     registry.registerCategories(id, stableCategories)
-    return () => registry.unregisterCategories(id)
   }, [registry, id, stableCategories])
+}
+
+/** True when a chart can register live categories with a parent LinkedCharts. */
+export function useLinkedChartCategoryRegistryActive(): boolean {
+  return useContext(LinkedCategoryRegistryContext) !== null
 }
 
 // ── Props ──────────────────────────────────────────────────────────────────
@@ -93,7 +103,7 @@ export interface LinkedChartsProps {
   /**
    * Show a unified legend for all linked charts.
    * When true, child chart legends are automatically suppressed unless explicitly set.
-   * @default true (when a CategoryColorProvider is present)
+   * @default true
    */
   showLegend?: boolean
   /**
@@ -345,6 +355,7 @@ export function LinkedCharts({
 }: LinkedChartsProps) {
   const parentCategoryColors = useCategoryColors()
   const [registeredCategories, setRegisteredCategories] = useState<Record<string, string[]>>({})
+  const generatedCategoryColorsRef = useRef<Record<string, string>>({})
 
   const registry = useMemo<LinkedCategoryRegistry>(() => ({
     registerCategories: (id, categories) => {
@@ -373,12 +384,19 @@ export function LinkedCharts({
   }, [registeredCategories])
 
   const categoryColors = useMemo(() => {
-    const map: Record<string, string> = { ...(parentCategoryColors ?? {}) }
-    let paletteIndex = Object.keys(map).length
+    const parentMap = parentCategoryColors ?? {}
+    const generatedMap = generatedCategoryColorsRef.current
+    let paletteIndex = Object.keys(parentMap).length + Object.keys(generatedMap).length
+
     for (const category of dynamicCategories) {
-      if (map[category]) continue
-      map[category] = DEFAULT_COLORS[paletteIndex % DEFAULT_COLORS.length]
+      if (parentMap[category] || generatedMap[category]) continue
+      generatedMap[category] = DEFAULT_COLORS[paletteIndex % DEFAULT_COLORS.length]
       paletteIndex++
+    }
+
+    const map: Record<string, string> = { ...parentMap }
+    for (const category of dynamicCategories) {
+      map[category] = parentMap[category] ?? generatedMap[category]
     }
     return map
   }, [parentCategoryColors, dynamicCategories])
@@ -386,7 +404,7 @@ export function LinkedCharts({
   // Determine if we should show a unified legend
   const shouldShowLegend = showLegend !== undefined
     ? showLegend
-    : !!(categoryColors && Object.keys(categoryColors).length > 0)
+    : true
 
   return (
     <SelectionProvider>

--- a/src/components/LinkedCharts.tsx
+++ b/src/components/LinkedCharts.tsx
@@ -1,11 +1,12 @@
 "use client"
 import * as React from "react"
-import { createContext, useContext, useEffect, useMemo, useRef, useState, useCallback } from "react"
+import { createContext, useContext, useEffect, useId, useMemo, useRef, useState, useCallback } from "react"
 import { SelectionProvider, useSelectionSelector } from "./store/SelectionStore"
 import type { ResolutionMode } from "./store/SelectionStore"
 import { ObservationProvider } from "./store/ObservationStore"
 import { useLinkedHover, useSelection } from "./store/useSelection"
-import { useCategoryColors } from "./CategoryColors"
+import { CategoryColorProvider, useCategoryColors } from "./CategoryColors"
+import { DEFAULT_COLORS } from "./charts/shared/colorUtils"
 import Legend from "./Legend"
 import type { LegendGroup } from "./types/legendTypes"
 import { useResponsiveSize } from "./stream/useResponsiveSize"
@@ -38,6 +39,49 @@ const LinkedLegendContext = createContext<boolean>(false)
 /** Hook: returns true when a parent LinkedCharts is handling the legend. */
 export function useLinkedLegendSuppression(): boolean {
   return useContext(LinkedLegendContext)
+}
+
+interface LinkedCategoryRegistry {
+  registerCategories: (id: string, categories: string[]) => void
+  unregisterCategories: (id: string) => void
+}
+
+const LinkedCategoryRegistryContext = createContext<LinkedCategoryRegistry | null>(null)
+
+function uniqueCategories(categories: string[]): string[] {
+  const seen = new Set<string>()
+  const unique: string[] = []
+  for (const category of categories) {
+    if (seen.has(category)) continue
+    seen.add(category)
+    unique.push(category)
+  }
+  return unique
+}
+
+function sameCategories(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+/** Register a chart's current color categories with the nearest LinkedCharts. */
+export function useLinkedChartCategories(categories: string[]): void {
+  const registry = useContext(LinkedCategoryRegistryContext)
+  const id = useId()
+  const categoriesKey = categories.join("\0")
+  const stableCategories = useMemo(
+    () => categoriesKey ? uniqueCategories(categoriesKey.split("\0")) : [],
+    [categoriesKey]
+  )
+
+  useEffect(() => {
+    if (!registry) return
+    registry.registerCategories(id, stableCategories)
+    return () => registry.unregisterCategories(id)
+  }, [registry, id, stableCategories])
 }
 
 // ── Props ──────────────────────────────────────────────────────────────────
@@ -299,7 +343,45 @@ export function LinkedCharts({
   legendSelectionName = "legend",
   legendField = "category",
 }: LinkedChartsProps) {
-  const categoryColors = useCategoryColors()
+  const parentCategoryColors = useCategoryColors()
+  const [registeredCategories, setRegisteredCategories] = useState<Record<string, string[]>>({})
+
+  const registry = useMemo<LinkedCategoryRegistry>(() => ({
+    registerCategories: (id, categories) => {
+      const nextCategories = uniqueCategories(categories)
+      setRegisteredCategories(prev => {
+        if (sameCategories(prev[id] ?? [], nextCategories)) return prev
+        return { ...prev, [id]: nextCategories }
+      })
+    },
+    unregisterCategories: (id) => {
+      setRegisteredCategories(prev => {
+        if (!(id in prev)) return prev
+        const next = { ...prev }
+        delete next[id]
+        return next
+      })
+    }
+  }), [])
+
+  const dynamicCategories = useMemo(() => {
+    const merged: string[] = []
+    for (const categories of Object.values(registeredCategories)) {
+      for (const category of categories) merged.push(category)
+    }
+    return uniqueCategories(merged)
+  }, [registeredCategories])
+
+  const categoryColors = useMemo(() => {
+    const map: Record<string, string> = { ...(parentCategoryColors ?? {}) }
+    let paletteIndex = Object.keys(map).length
+    for (const category of dynamicCategories) {
+      if (map[category]) continue
+      map[category] = DEFAULT_COLORS[paletteIndex % DEFAULT_COLORS.length]
+      paletteIndex++
+    }
+    return map
+  }, [parentCategoryColors, dynamicCategories])
 
   // Determine if we should show a unified legend
   const shouldShowLegend = showLegend !== undefined
@@ -310,25 +392,29 @@ export function LinkedCharts({
     <SelectionProvider>
       <ObservationProvider>
         {selections && <ResolutionInit selections={selections} />}
-        <LinkedLegendContext.Provider value={shouldShowLegend}>
-          {shouldShowLegend && legendPosition === "top" && categoryColors && (
-            <LinkedLegend
-              categoryColors={categoryColors}
-              interaction={legendInteraction}
-              selectionName={legendSelectionName}
-              field={legendField}
-            />
-          )}
-          {children}
-          {shouldShowLegend && legendPosition === "bottom" && categoryColors && (
-            <LinkedLegend
-              categoryColors={categoryColors}
-              interaction={legendInteraction}
-              selectionName={legendSelectionName}
-              field={legendField}
-            />
-          )}
-        </LinkedLegendContext.Provider>
+        <LinkedCategoryRegistryContext.Provider value={registry}>
+          <CategoryColorProvider colors={categoryColors}>
+            <LinkedLegendContext.Provider value={shouldShowLegend}>
+              {shouldShowLegend && legendPosition === "top" && (
+                <LinkedLegend
+                  categoryColors={categoryColors}
+                  interaction={legendInteraction}
+                  selectionName={legendSelectionName}
+                  field={legendField}
+                />
+              )}
+              {children}
+              {shouldShowLegend && legendPosition === "bottom" && (
+                <LinkedLegend
+                  categoryColors={categoryColors}
+                  interaction={legendInteraction}
+                  selectionName={legendSelectionName}
+                  field={legendField}
+                />
+              )}
+            </LinkedLegendContext.Provider>
+          </CategoryColorProvider>
+        </LinkedCategoryRegistryContext.Provider>
       </ObservationProvider>
     </SelectionProvider>
   )

--- a/src/components/charts/ordinal/BarChart.test.tsx
+++ b/src/components/charts/ordinal/BarChart.test.tsx
@@ -20,12 +20,61 @@ vi.mock("../../stream/StreamOrdinalFrame", () => {
     __esModule: true,
     default: React.forwardRef((props: any, ref: any) => {
       lastOrdinalFrameProps = props
+      const dataRef = React.useRef<any[]>([])
+      const emitCategories = () => {
+        const accessor = props.legendCategoryAccessor
+        if (!props.onCategoriesChange || !accessor) return
+        const seen = new Set<string>()
+        const categories: string[] = []
+        for (const d of dataRef.current) {
+          const raw = typeof accessor === "function" ? accessor(d) : d[accessor]
+          if (raw == null) continue
+          const category = String(raw)
+          if (seen.has(category)) continue
+          seen.add(category)
+          categories.push(category)
+        }
+        props.onCategoriesChange(categories)
+      }
       React.useImperativeHandle(ref, () => ({
-        push: vi.fn(),
-        pushMany: vi.fn(),
-        remove: vi.fn(() => []),
-        update: vi.fn(() => []),
-        clear: vi.fn(),
+        push: vi.fn((d) => {
+          dataRef.current.push(d)
+          emitCategories()
+        }),
+        pushMany: vi.fn((data) => {
+          dataRef.current.push(...data)
+          emitCategories()
+        }),
+        remove: vi.fn((id) => {
+          const ids = new Set(Array.isArray(id) ? id : [id])
+          const accessor = props.dataIdAccessor
+          const removed: any[] = []
+          dataRef.current = dataRef.current.filter((d) => {
+            const dataId = typeof accessor === "function" ? accessor(d) : d[accessor]
+            if (!ids.has(dataId)) return true
+            removed.push(d)
+            return false
+          })
+          emitCategories()
+          return removed
+        }),
+        update: vi.fn((id, updater) => {
+          const ids = new Set(Array.isArray(id) ? id : [id])
+          const accessor = props.dataIdAccessor
+          const previous: any[] = []
+          dataRef.current = dataRef.current.map((d) => {
+            const dataId = typeof accessor === "function" ? accessor(d) : d[accessor]
+            if (!ids.has(dataId)) return d
+            previous.push(d)
+            return updater(d)
+          })
+          emitCategories()
+          return previous
+        }),
+        clear: vi.fn(() => {
+          dataRef.current = []
+          emitCategories()
+        }),
         getData: vi.fn(() => []),
         getScales: vi.fn(() => null),
       }))
@@ -350,6 +399,39 @@ describe("BarChart", () => {
       const labels = lastOrdinalFrameProps.legend.legendGroups[0].items.map((item: { label: string }) => item.label)
       expect(labels).toEqual(["A", "B"])
       expect(lastOrdinalFrameProps.margin.right).toBeGreaterThanOrEqual(110)
+    })
+
+    it("shrinks and updates pushed legend categories from the frame domain", async () => {
+      const ref = React.createRef<RealtimeFrameHandle>()
+      render(
+        <TooltipProvider>
+          <BarChart ref={ref} colorBy="category" dataIdAccessor="id" />
+        </TooltipProvider>
+      )
+
+      await act(async () => {
+        ref.current!.pushMany([
+          { id: "a", category: "A", value: 10 },
+          { id: "b", category: "B", value: 20 },
+        ])
+      })
+      expect(lastOrdinalFrameProps.legend.legendGroups[0].items.map((item: { label: string }) => item.label)).toEqual(["A", "B"])
+
+      await act(async () => {
+        ref.current!.remove("b")
+      })
+      expect(lastOrdinalFrameProps.legend.legendGroups[0].items.map((item: { label: string }) => item.label)).toEqual(["A"])
+
+      await act(async () => {
+        ref.current!.update("a", (d) => ({ ...d, category: "C" }))
+      })
+      expect(lastOrdinalFrameProps.legend.legendGroups[0].items.map((item: { label: string }) => item.label)).toEqual(["C"])
+
+      await act(async () => {
+        ref.current!.clear()
+      })
+      expect(lastOrdinalFrameProps.legend).toBeUndefined()
+      expect(lastOrdinalFrameProps.margin.right).toBeLessThan(110)
     })
   })
 

--- a/src/components/charts/ordinal/BarChart.test.tsx
+++ b/src/components/charts/ordinal/BarChart.test.tsx
@@ -1,6 +1,6 @@
 import { vi } from "vitest"
 import React from "react"
-import { render } from "@testing-library/react"
+import { act, render } from "@testing-library/react"
 import { BarChart } from "./BarChart"
 import { TooltipProvider } from "../../store/TooltipStore"
 import {
@@ -11,14 +11,24 @@ import {
   NAMED_COUNT_DATA as customData,
 } from "../../../test-utils/ordinalFixtures"
 import type { Datum } from "../shared/datumTypes"
+import type { RealtimeFrameHandle } from "../../realtime/types"
 
 // Mock OrdinalFrame to capture props
 let lastOrdinalFrameProps: any = null
 vi.mock("../../stream/StreamOrdinalFrame", () => {
   return {
     __esModule: true,
-    default: React.forwardRef((props: any, _ref: any) => {
+    default: React.forwardRef((props: any, ref: any) => {
       lastOrdinalFrameProps = props
+      React.useImperativeHandle(ref, () => ({
+        push: vi.fn(),
+        pushMany: vi.fn(),
+        remove: vi.fn(() => []),
+        update: vi.fn(() => []),
+        clear: vi.fn(),
+        getData: vi.fn(() => []),
+        getScales: vi.fn(() => null),
+      }))
       return <div className="stream-ordinal-frame"><svg /></div>
     })
   }
@@ -320,6 +330,27 @@ describe("BarChart", () => {
       expect(lastOrdinalFrameProps.legend).toBeUndefined()
       expect(lastOrdinalFrameProps.margin.right).toBeLessThan(110)
     })
+
+    it("populates legend categories from pushed data", async () => {
+      const ref = React.createRef<RealtimeFrameHandle>()
+      render(
+        <TooltipProvider>
+          <BarChart ref={ref} colorBy="category" />
+        </TooltipProvider>
+      )
+
+      expect(lastOrdinalFrameProps.legend).toBeUndefined()
+      expect(lastOrdinalFrameProps.margin.right).toBeLessThan(110)
+
+      await act(async () => {
+        ref.current!.push({ category: "A", value: 10 })
+        ref.current!.push({ category: "B", value: 20 })
+      })
+
+      const labels = lastOrdinalFrameProps.legend.legendGroups[0].items.map((item: { label: string }) => item.label)
+      expect(labels).toEqual(["A", "B"])
+      expect(lastOrdinalFrameProps.margin.right).toBeGreaterThanOrEqual(110)
+    })
   })
 
   describe("hoverAnnotation", () => {
@@ -401,7 +432,7 @@ describe("BarChart", () => {
   })
 
   describe("push API", () => {
-    it("ref exposes push, pushMany, getData, and clear", () => {
+    it("ref exposes push, pushMany, getData, getScales, and clear", () => {
       const ref = React.createRef<any>()
       render(
         <TooltipProvider>
@@ -412,22 +443,27 @@ describe("BarChart", () => {
       expect(typeof ref.current.push).toBe("function")
       expect(typeof ref.current.pushMany).toBe("function")
       expect(typeof ref.current.getData).toBe("function")
+      expect(typeof ref.current.getScales).toBe("function")
       expect(typeof ref.current.clear).toBe("function")
     })
 
-    it("push does not throw when frame ref is not connected", () => {
+    it("push methods remain safe through the streaming legend wrapper", () => {
       const ref = React.createRef<any>()
       render(
         <TooltipProvider>
           <BarChart ref={ref} categoryAccessor="category" valueAccessor="value" />
         </TooltipProvider>
       )
-      expect(() => ref.current.push({ category: "A", value: 10 })).not.toThrow()
-      expect(() => ref.current.pushMany([{ category: "B", value: 20 }])).not.toThrow()
-      expect(() => ref.current.clear()).not.toThrow()
+      expect(() => {
+        act(() => {
+          ref.current.push({ category: "A", value: 10 })
+          ref.current.pushMany([{ category: "B", value: 20 }])
+          ref.current.clear()
+        })
+      }).not.toThrow()
     })
 
-    it("getData returns empty array when frame ref is not connected", () => {
+    it("getData and getScales delegate to the frame handle", () => {
       const ref = React.createRef<any>()
       render(
         <TooltipProvider>
@@ -435,6 +471,7 @@ describe("BarChart", () => {
         </TooltipProvider>
       )
       expect(ref.current.getData()).toEqual([])
+      expect(ref.current.getScales()).toBeNull()
     })
   })
 

--- a/src/components/charts/ordinal/BarChart.tsx
+++ b/src/components/charts/ordinal/BarChart.tsx
@@ -1,7 +1,7 @@
 "use client"
 import type { Datum } from "../shared/datumTypes"
 import * as React from "react"
-import { useMemo, forwardRef, useRef, useImperativeHandle } from "react"
+import { useMemo, forwardRef, useRef } from "react"
 import StreamOrdinalFrame from "../../stream/StreamOrdinalFrame"
 import type { StreamOrdinalFrameProps, StreamOrdinalFrameHandle } from "../../stream/ordinalTypes"
 import { getColor } from "../shared/colorUtils"
@@ -17,6 +17,7 @@ import { validateArrayData } from "../shared/validateChartData"
 import { wrapStyleWithSelection } from "../shared/selectionUtils"
 import type { RealtimeFrameHandle } from "../../realtime/types"
 import { useChartSetup } from "../shared/useChartSetup"
+import { useOrdinalStreaming } from "../shared/useOrdinalStreaming"
 
 /**
  * BarChart component props
@@ -88,15 +89,6 @@ export const BarChart = forwardRef(function BarChart<TDatum extends Datum = Datu
   })
 
   const frameRef = useRef<StreamOrdinalFrameHandle>(null)
-  useImperativeHandle(ref, () => ({
-    push: (point) => frameRef.current?.push(point),
-    pushMany: (points) => frameRef.current?.pushMany(points),
-    remove: (id) => frameRef.current?.remove(id) ?? [],
-    update: (id, updater) => frameRef.current?.update(id, updater) ?? [],
-    clear: () => frameRef.current?.clear(),
-    getData: () => frameRef.current?.getData() ?? [],
-    getScales: () => frameRef.current?.getScales() ?? null
-  }))
 
   const {
     data,
@@ -147,6 +139,7 @@ export const BarChart = forwardRef(function BarChart<TDatum extends Datum = Datu
   const valueLabel = resolved.valueLabel
 
   const safeData = data || []
+  const isPushMode = data === undefined
 
   // ── Shared setup (color, legend, selection, loading/empty) ────────────
   const setup = useChartSetup({
@@ -172,6 +165,17 @@ export const BarChart = forwardRef(function BarChart<TDatum extends Datum = Datu
     emptyContent,
     width,
     height,
+  })
+
+  const { effectiveLegendProps, effectiveMargin } = useOrdinalStreaming({
+    ref,
+    frameRef,
+    isPushMode,
+    colorBy,
+    colorScheme,
+    showLegend,
+    legendPosition: legendPositionProp,
+    setup,
   })
 
   if (setup.earlyReturn) return setup.earlyReturn
@@ -247,7 +251,7 @@ export const BarChart = forwardRef(function BarChart<TDatum extends Datum = Datu
     size: [width, height],
     responsiveWidth: props.responsiveWidth,
     responsiveHeight: props.responsiveHeight,
-    margin: setup.margin,
+    margin: effectiveMargin,
     barPadding,
     ...(roundedTop != null && { roundedTop }),
     // Resolve boolean `true` to the same default opacities AreaChart uses
@@ -269,7 +273,7 @@ export const BarChart = forwardRef(function BarChart<TDatum extends Datum = Datu
     showGrid,
     showCategoryTicks,
     oSort: sort,
-    ...setup.legendBehaviorProps,
+    ...effectiveLegendProps,
     ...(title && { title }),
     ...(description && { description }),
     ...(summary && { summary }),

--- a/src/components/charts/ordinal/BarChart.tsx
+++ b/src/components/charts/ordinal/BarChart.tsx
@@ -139,7 +139,6 @@ export const BarChart = forwardRef(function BarChart<TDatum extends Datum = Datu
   const valueLabel = resolved.valueLabel
 
   const safeData = data || []
-  const isPushMode = data === undefined
 
   // ── Shared setup (color, legend, selection, loading/empty) ────────────
   const setup = useChartSetup({
@@ -170,11 +169,6 @@ export const BarChart = forwardRef(function BarChart<TDatum extends Datum = Datu
   const { effectiveLegendProps, effectiveMargin } = useOrdinalStreaming({
     ref,
     frameRef,
-    isPushMode,
-    colorBy,
-    colorScheme,
-    showLegend,
-    legendPosition: legendPositionProp,
     setup,
   })
 

--- a/src/components/charts/ordinal/DonutChart.tsx
+++ b/src/components/charts/ordinal/DonutChart.tsx
@@ -87,7 +87,6 @@ export const DonutChart = forwardRef(function DonutChart<TDatum extends Datum = 
 
   const safeData = data || []
   const effectiveColorBy = colorBy || categoryAccessor
-  const isPushMode = data === undefined
 
   const setup = useChartSetup({
     data: safeData,
@@ -178,10 +177,7 @@ export const DonutChart = forwardRef(function DonutChart<TDatum extends Datum = 
   })
 
   const { effectiveLegendProps, effectiveMargin } = useOrdinalStreaming({
-    ref, frameRef, isPushMode,
-    colorBy: effectiveColorBy,
-    colorScheme, showLegend,
-    legendPosition: legendPositionProp,
+    ref, frameRef,
     setup,
   })
 

--- a/src/components/charts/ordinal/GroupedBarChart.tsx
+++ b/src/components/charts/ordinal/GroupedBarChart.tsx
@@ -99,7 +99,6 @@ export const GroupedBarChart = forwardRef(function GroupedBarChart<TDatum extend
 
   const safeData = data || []
   const effectiveColorBy = colorBy || groupBy
-  const isPushMode = data === undefined
 
   const setup = useChartSetup({
     data: safeData,
@@ -178,10 +177,7 @@ export const GroupedBarChart = forwardRef(function GroupedBarChart<TDatum extend
   })
 
   const { effectiveLegendProps, effectiveMargin } = useOrdinalStreaming({
-    ref, frameRef, isPushMode,
-    colorBy: effectiveColorBy,
-    colorScheme, showLegend,
-    legendPosition: legendPositionProp,
+    ref, frameRef,
     setup,
   })
 

--- a/src/components/charts/ordinal/PieChart.tsx
+++ b/src/components/charts/ordinal/PieChart.tsx
@@ -80,7 +80,6 @@ export const PieChart = forwardRef(function PieChart<TDatum extends Datum = Datu
 
   const safeData = data || []
   const effectiveColorBy = colorBy || categoryAccessor
-  const isPushMode = data === undefined
 
   const setup = useChartSetup({
     data: safeData,
@@ -155,10 +154,7 @@ export const PieChart = forwardRef(function PieChart<TDatum extends Datum = Datu
   })
 
   const { effectiveLegendProps, effectiveMargin } = useOrdinalStreaming({
-    ref, frameRef, isPushMode,
-    colorBy: effectiveColorBy,
-    colorScheme, showLegend,
-    legendPosition: legendPositionProp,
+    ref, frameRef,
     setup,
   })
 

--- a/src/components/charts/ordinal/StackedBarChart.tsx
+++ b/src/components/charts/ordinal/StackedBarChart.tsx
@@ -100,7 +100,6 @@ export const StackedBarChart = forwardRef(function StackedBarChart<TDatum extend
 
   const safeData = data || []
   const effectiveColorBy = colorBy || stackBy
-  const isPushMode = data === undefined
 
   const setup = useChartSetup({
     data: safeData,
@@ -177,10 +176,7 @@ export const StackedBarChart = forwardRef(function StackedBarChart<TDatum extend
   })
 
   const { effectiveLegendProps, effectiveMargin } = useOrdinalStreaming({
-    ref, frameRef, isPushMode,
-    colorBy: effectiveColorBy,
-    colorScheme, showLegend,
-    legendPosition: legendPositionProp,
+    ref, frameRef,
     setup,
   })
 

--- a/src/components/charts/ordinal/SwimlaneChart.tsx
+++ b/src/components/charts/ordinal/SwimlaneChart.tsx
@@ -138,7 +138,6 @@ export const SwimlaneChart = forwardRef(function SwimlaneChart<TDatum extends Da
 
   const safeData = data || []
   const effectiveColorBy = colorBy || subcategoryAccessor
-  const isPushMode = data === undefined
 
   // Mode-aware `barPadding`: sparkline uses 1px by default (or less when so
   // many categories are present that 1px would shrink each lane below 2px).
@@ -240,10 +239,7 @@ export const SwimlaneChart = forwardRef(function SwimlaneChart<TDatum extends Da
   })
 
   const { effectiveLegendProps, effectiveMargin } = useOrdinalStreaming({
-    ref, frameRef, isPushMode,
-    colorBy: effectiveColorBy,
-    colorScheme, showLegend,
-    legendPosition: legendPositionProp,
+    ref, frameRef,
     setup,
   })
 

--- a/src/components/charts/shared/hooks.ts
+++ b/src/components/charts/shared/hooks.ts
@@ -1,6 +1,6 @@
 import { useMemo, useCallback, useState, useId, useEffect } from "react"
 import { useCategoryColors } from "../../CategoryColors"
-import { useLinkedLegendSuppression } from "../../LinkedCharts"
+import { useLinkedChartCategories, useLinkedChartCategoryRegistryActive, useLinkedLegendSuppression } from "../../LinkedCharts"
 import { createColorScale, getColor, COLOR_SCHEMES } from "./colorUtils"
 import { createLegend } from "./legendUtils"
 import { normalizeLinkedHover } from "./selectionUtils"
@@ -14,7 +14,6 @@ import type { MarginType, PartialMargin } from "../../types/marginType"
 import type { TransitionConfig } from "../../stream/types"
 import { useTheme } from "../../ThemeProvider"
 import type { Datum } from "./datumTypes"
-import { useLinkedChartCategories } from "../../LinkedCharts"
 
 /**
  * Default fill color used when no colorBy is specified
@@ -441,22 +440,24 @@ export function useChartLegendAndMargin({
   legendPosition: LegendPosition
 } {
   const linkedLegendActive = useLinkedLegendSuppression()
+  const linkedCategoryRegistryActive = useLinkedChartCategoryRegistryActive()
   // Suppress child legend when LinkedCharts is handling it, unless explicitly overridden
   const shouldShowLegend = showLegend !== undefined
     ? showLegend
     : linkedLegendActive ? false : !!colorBy
+  const shouldResolveCategories = !!colorBy && (shouldShowLegend || linkedCategoryRegistryActive)
 
   const legendCategories = useMemo(() => {
-    if (!colorBy) return []
-    if (categories && categories.length > 0) return categories
+    if (!shouldResolveCategories) return []
+    if (categories !== undefined) return categories
     const vals = new Set<string>()
     for (const d of data) {
       const v = typeof colorBy === "function" ? colorBy(d) : d[colorBy as string]
       if (v != null) vals.add(String(v))
     }
     return Array.from(vals)
-  }, [categories, colorBy, data])
-  useLinkedChartCategories(colorBy ? legendCategories : [])
+  }, [categories, colorBy, data, shouldResolveCategories])
+  useLinkedChartCategories(linkedCategoryRegistryActive && colorBy ? legendCategories : [])
 
   const legend = useMemo(() => {
     if (!shouldShowLegend || !colorBy) return undefined

--- a/src/components/charts/shared/hooks.ts
+++ b/src/components/charts/shared/hooks.ts
@@ -14,6 +14,7 @@ import type { MarginType, PartialMargin } from "../../types/marginType"
 import type { TransitionConfig } from "../../stream/types"
 import { useTheme } from "../../ThemeProvider"
 import type { Datum } from "./datumTypes"
+import { useLinkedChartCategories } from "../../LinkedCharts"
 
 /**
  * Default fill color used when no colorBy is specified
@@ -445,9 +446,21 @@ export function useChartLegendAndMargin({
     ? showLegend
     : linkedLegendActive ? false : !!colorBy
 
+  const legendCategories = useMemo(() => {
+    if (!colorBy) return []
+    if (categories && categories.length > 0) return categories
+    const vals = new Set<string>()
+    for (const d of data) {
+      const v = typeof colorBy === "function" ? colorBy(d) : d[colorBy as string]
+      if (v != null) vals.add(String(v))
+    }
+    return Array.from(vals)
+  }, [categories, colorBy, data])
+  useLinkedChartCategories(colorBy ? legendCategories : [])
+
   const legend = useMemo(() => {
     if (!shouldShowLegend || !colorBy) return undefined
-    const built = createLegend({ data, colorBy, colorScale, getColor, categories })
+    const built = createLegend({ data, colorBy, colorScale, getColor, categories: legendCategories })
     // Suppress empty legends — when a chart using the push API mounts with no
     // `data` yet and no explicit `categories`, createLegend returns a shell
     // with zero items. Returning it would reserve margin for a legend that
@@ -456,7 +469,7 @@ export function useChartLegendAndMargin({
     const totalItems = built.legendGroups.reduce((sum, g) => sum + g.items.length, 0)
     if (totalItems === 0) return undefined
     return built
-  }, [shouldShowLegend, colorBy, data, colorScale, categories])
+  }, [shouldShowLegend, colorBy, data, colorScale, legendCategories])
 
   const margin = useMemo<MarginType>(() => {
     const userSides: Partial<MarginType> = typeof userMargin === "number"

--- a/src/components/charts/shared/useChartSetup.ts
+++ b/src/components/charts/shared/useChartSetup.ts
@@ -233,7 +233,7 @@ export function useChartSetup(input: ChartSetupInput): ChartSetupResult {
     legendPosition: legendPositionProp,
     userMargin,
     defaults: marginDefaults,
-    categories: isPushMode ? activeCategories : undefined,
+    categories: activeCategories,
   })
 
   // ── Legend behavior props (to spread into frame) ───────────────────────

--- a/src/components/charts/shared/useChartSetup.ts
+++ b/src/components/charts/shared/useChartSetup.ts
@@ -18,7 +18,7 @@
 "use client"
 import type { Datum } from "./datumTypes"
 
-import { useMemo } from "react"
+import { useCallback, useMemo, useState } from "react"
 import { useColorScale, useChartSelection, useChartLegendAndMargin, useLegendInteraction, DEFAULT_COLOR, getCrosshairProps } from "./hooks"
 import type { LegendInteractionMode, LegendPosition } from "./hooks"
 import type { Accessor, SelectionConfig, LinkedHoverProp } from "./types"
@@ -163,6 +163,15 @@ export function useChartSetup(input: ChartSetupInput): ChartSetupResult {
     width,
     height,
   } = input
+  const isPushMode = rawData === undefined
+  const [frameCategories, setFrameCategories] = useState<string[]>([])
+
+  const onCategoriesChange = useCallback((categories: string[]) => {
+    setFrameCategories(prev => {
+      if (prev.length === categories.length && prev.every((v, i) => v === categories[i])) return prev
+      return categories
+    })
+  }, [])
 
   // ── Selection hooks (always called) ────────────────────────────────────
   const colorByField = typeof input.colorBy === "string" ? input.colorBy : undefined
@@ -196,8 +205,13 @@ export function useChartSetup(input: ChartSetupInput): ChartSetupResult {
     return Array.from(vals)
   }, [data, colorBy])
 
+  const activeCategories = useMemo(() => {
+    if (isPushMode && frameCategories.length > 0) return frameCategories
+    return allCategories
+  }, [isPushMode, frameCategories, allCategories])
+
   // ── Legend interaction ─────────────────────────────────────────────────
-  const legendState = useLegendInteraction(legendInteraction, colorBy, allCategories)
+  const legendState = useLegendInteraction(legendInteraction, colorBy, activeCategories)
 
   // ── Merge hover highlight > legend selection > cross-chart selection ───
   const effectiveSelectionHook = useMemo(() => {
@@ -219,6 +233,7 @@ export function useChartSetup(input: ChartSetupInput): ChartSetupResult {
     legendPosition: legendPositionProp,
     userMargin,
     defaults: marginDefaults,
+    categories: isPushMode ? activeCategories : undefined,
   })
 
   // ── Legend behavior props (to spread into frame) ───────────────────────
@@ -234,8 +249,12 @@ export function useChartSetup(input: ChartSetupInput): ChartSetupResult {
       props.legendHighlightedCategory = legendState.highlightedCategory
       props.legendIsolatedCategories = legendState.isolatedCategories
     }
+    if (isPushMode && colorBy) {
+      props.legendCategoryAccessor = colorBy
+      props.onCategoriesChange = onCategoriesChange
+    }
     return props
-  }, [legend, legendPosition, legendInteraction, legendState.onLegendHover, legendState.onLegendClick, legendState.highlightedCategory, legendState.isolatedCategories])
+  }, [legend, legendPosition, legendInteraction, legendState.onLegendHover, legendState.onLegendClick, legendState.highlightedCategory, legendState.isolatedCategories, isPushMode, colorBy, onCategoriesChange])
 
   // ── Loading / empty state (computed after all hooks) ───────────────────
   const loadingEl = renderLoadingState(loading, width, height)
@@ -244,7 +263,7 @@ export function useChartSetup(input: ChartSetupInput): ChartSetupResult {
 
   return {
     colorScale,
-    allCategories,
+    allCategories: activeCategories,
     legendState,
     effectiveSelectionHook,
     activeSelectionHook,

--- a/src/components/charts/shared/useOrdinalStreaming.ts
+++ b/src/components/charts/shared/useOrdinalStreaming.ts
@@ -5,28 +5,15 @@ import type { Ref, RefObject } from "react"
 import { useImperativeHandle } from "react"
 import type { StreamOrdinalFrameHandle } from "../../stream/ordinalTypes"
 import type { RealtimeFrameHandle } from "../../realtime/types"
-import type { Accessor } from "./types"
-import type { LegendPosition } from "./hooks"
 
 interface UseOrdinalStreamingConfig {
   /** External ref for push API */
   ref: Ref<RealtimeFrameHandle>
   /** Internal frame ref */
   frameRef: RefObject<StreamOrdinalFrameHandle | null>
-  /** True when data prop is undefined (push API mode) */
-  isPushMode: boolean
-  /** Color-by accessor (may be derived from stackBy/groupBy/etc.) */
-  colorBy: Accessor<string> | undefined
-  /** Color scheme name or array — undefined lets useColorScale consult the theme */
-  colorScheme: string | string[] | undefined
-  /** Whether legend is requested */
-  showLegend: boolean | undefined
-  /** Legend position */
-  legendPosition?: LegendPosition
-  /** Results from useChartSetup — needed for legend/margin merge */
+  /** Results from useChartSetup that should be forwarded to the stream frame */
   setup: {
     legendBehaviorProps: Datum
-    legendPosition: LegendPosition
     margin: { top: number; right: number; bottom: number; left: number }
   }
 }

--- a/src/components/charts/shared/useOrdinalStreaming.ts
+++ b/src/components/charts/shared/useOrdinalStreaming.ts
@@ -2,8 +2,7 @@
 import type { Datum } from "./datumTypes"
 
 import type { Ref, RefObject } from "react"
-import { useCallback, useImperativeHandle, useMemo } from "react"
-import { useStreamingLegend } from "./useStreamingLegend"
+import { useImperativeHandle } from "react"
 import type { StreamOrdinalFrameHandle } from "../../stream/ordinalTypes"
 import type { RealtimeFrameHandle } from "../../realtime/types"
 import type { Accessor } from "./types"
@@ -33,17 +32,17 @@ interface UseOrdinalStreamingConfig {
 }
 
 interface UseOrdinalStreamingResult {
-  /** Legend props merged with streaming legend (spread into streamProps) */
+  /** Legend/category-domain props from useChartSetup (spread into streamProps) */
   effectiveLegendProps: Datum
-  /** Margin merged with streaming legend margin adjustments */
+  /** Margin from useChartSetup, including frame-domain legend expansion */
   effectiveMargin: { top: number; right: number; bottom: number; left: number }
 }
 
 /**
  * Shared hook for ordinal charts that support push API + streaming legend.
  *
- * Consolidates: useStreamingLegend, wrappedPush/pushMany,
- * useImperativeHandle, effectiveLegendProps, effectiveMargin.
+ * Consolidates imperative handle forwarding and returns the legend/margin
+ * props that useChartSetup derives from static data or frame-reported domains.
  *
  * Used by: StackedBarChart, GroupedBarChart, PieChart, DonutChart, SwimlaneChart.
  * NOT used by LikertChart (custom accumulator + deterministic legend).
@@ -51,65 +50,20 @@ interface UseOrdinalStreamingResult {
 export function useOrdinalStreaming({
   ref,
   frameRef,
-  isPushMode,
-  colorBy,
-  colorScheme,
-  showLegend,
-  legendPosition,
   setup,
 }: UseOrdinalStreamingConfig): UseOrdinalStreamingResult {
-  const streaming = useStreamingLegend({
-    isPushMode,
-    colorBy,
-    colorScheme,
-    showLegend,
-    legendPosition,
-  })
-
-  const wrappedPush = useCallback(
-    streaming.wrapPush((d: Datum) => frameRef.current?.push(d)),
-    [streaming.wrapPush]
-  )
-  const wrappedPushMany = useCallback(
-    streaming.wrapPushMany((d: any[]) => frameRef.current?.pushMany(d)),
-    [streaming.wrapPushMany]
-  )
-
   useImperativeHandle(ref, () => ({
-    push: wrappedPush,
-    pushMany: wrappedPushMany,
+    push: (d: Datum) => frameRef.current?.push(d),
+    pushMany: (d: Datum[]) => frameRef.current?.pushMany(d),
     remove: (id: string | string[]) => frameRef.current?.remove(id) ?? [],
     update: (id, updater) => frameRef.current?.update(id, updater) ?? [],
-    clear: () => {
-      streaming.resetCategories()
-      frameRef.current?.clear()
-    },
+    clear: () => frameRef.current?.clear(),
     getData: () => frameRef.current?.getData() ?? [],
     getScales: () => frameRef.current?.getScales() ?? null
-  }), [wrappedPush, wrappedPushMany, streaming.resetCategories])
+  }), [frameRef])
 
-  const effectiveLegendProps = useMemo(() => {
-    if (streaming.streamingLegend) {
-      return {
-        ...setup.legendBehaviorProps,
-        legend: streaming.streamingLegend,
-        legendPosition: legendPosition || setup.legendPosition,
-      }
-    }
-    return setup.legendBehaviorProps
-  }, [setup.legendBehaviorProps, setup.legendPosition, streaming.streamingLegend, legendPosition])
-
-  const effectiveMargin = useMemo(() => {
-    if (streaming.streamingMarginAdjust) {
-      const m = { ...setup.margin }
-      for (const [key, val] of Object.entries(streaming.streamingMarginAdjust)) {
-        const k = key as keyof typeof m
-        if (m[k] < val) m[k] = val
-      }
-      return m
-    }
-    return setup.margin
-  }, [setup.margin, streaming.streamingMarginAdjust])
+  const effectiveLegendProps = setup.legendBehaviorProps
+  const effectiveMargin = setup.margin
 
   return { effectiveLegendProps, effectiveMargin }
 }

--- a/src/components/charts/shared/useOrdinalStreaming.ts
+++ b/src/components/charts/shared/useOrdinalStreaming.ts
@@ -84,7 +84,8 @@ export function useOrdinalStreaming({
       streaming.resetCategories()
       frameRef.current?.clear()
     },
-    getData: () => frameRef.current?.getData() ?? []
+    getData: () => frameRef.current?.getData() ?? [],
+    getScales: () => frameRef.current?.getScales() ?? null
   }), [wrappedPush, wrappedPushMany, streaming.resetCategories])
 
   const effectiveLegendProps = useMemo(() => {

--- a/src/components/charts/shared/useStreamingLegend.ts
+++ b/src/components/charts/shared/useStreamingLegend.ts
@@ -6,6 +6,7 @@ import { createLegend } from "./legendUtils"
 import { getColor, STREAMING_PALETTE } from "./colorUtils"
 import type { Accessor } from "./types"
 import type { LegendPosition } from "./hooks"
+import { useLinkedChartCategories } from "../../LinkedCharts"
 
 /**
  * Hook that discovers categories from streamed (pushed) data and builds
@@ -76,6 +77,16 @@ export function useStreamingLegend({
     [isPushMode, colorBy, extractCategory]
   )
 
+  const setCategoryDomain = useCallback((categories: string[]) => {
+    if (!isPushMode || !colorBy) return
+    const next = Array.from(new Set(categories.map(String)))
+    const current = orderedRef.current
+    if (current.length === next.length && current.every((v, i) => v === next[i])) return
+    categoriesRef.current = new Set(next)
+    orderedRef.current = next
+    setVersion(v => v + 1)
+  }, [isPushMode, colorBy])
+
   /** Wrap push to intercept data for category discovery */
   const wrapPush = useCallback(
     (originalPush: (d: Datum) => void) => {
@@ -104,6 +115,9 @@ export function useStreamingLegend({
     orderedRef.current = []
     setVersion(v => v + 1)
   }, [])
+
+  const linkedCategories = isPushMode && colorBy ? orderedRef.current : []
+  useLinkedChartCategories(linkedCategories)
 
   // Build legend from discovered categories
   const streamingLegend = useMemo(() => {
@@ -146,6 +160,13 @@ export function useStreamingLegend({
     wrapPush,
     wrapPushMany,
     resetCategories,
+    categories: orderedRef.current,
+    categoryDomainProps: isPushMode && colorBy
+      ? {
+        legendCategoryAccessor: colorBy,
+        onCategoriesChange: setCategoryDomain,
+      }
+      : {},
     streamingLegend,
     streamingMarginAdjust,
   }

--- a/src/components/charts/shared/useStreamingLegend.ts
+++ b/src/components/charts/shared/useStreamingLegend.ts
@@ -3,10 +3,11 @@ import type { Datum } from "./datumTypes"
 
 import { useRef, useState, useCallback, useMemo } from "react"
 import { createLegend } from "./legendUtils"
-import { getColor, STREAMING_PALETTE } from "./colorUtils"
+import { createColorScale, getColor } from "./colorUtils"
 import type { Accessor } from "./types"
-import type { LegendPosition } from "./hooks"
+import { useThemeCategorical, type LegendPosition } from "./hooks"
 import { useLinkedChartCategories } from "../../LinkedCharts"
+import { useCategoryColors } from "../../CategoryColors"
 
 /**
  * Hook that discovers categories from streamed (pushed) data and builds
@@ -47,6 +48,8 @@ export function useStreamingLegend({
   const orderedRef = useRef<string[]>([])
   // State version — incremented only when a NEW category is discovered
   const [version, setVersion] = useState(0)
+  const categoryColors = useCategoryColors()
+  const themeCategorical = useThemeCategorical()
 
   const extractCategory = useCallback(
     (datum: Datum): string | null => {
@@ -119,7 +122,11 @@ export function useStreamingLegend({
   const linkedCategories = isPushMode && colorBy ? orderedRef.current : []
   useLinkedChartCategories(linkedCategories)
 
-  // Build legend from discovered categories
+  // Build legend from discovered categories. Color resolution mirrors
+  // `useColorScale` (categoryColors → user colorScheme → theme categorical
+  // → d3 "category10") so legend swatches always match the marks the
+  // chart's own colorScale produces — including the case where neither
+  // CategoryColorProvider nor LinkedCharts is wrapping the chart.
   const streamingLegend = useMemo(() => {
     if (!isPushMode || !colorBy || showLegend === false) return undefined
     // Use version to trigger recompute (consumed by useMemo dep)
@@ -127,16 +134,15 @@ export function useStreamingLegend({
     const categories = orderedRef.current
     if (categories.length === 0) return undefined
 
-    const palette = Array.isArray(colorScheme) ? colorScheme : STREAMING_PALETTE
-    const colorMap = new Map<string, string>()
-    for (let i = 0; i < categories.length; i++) {
-      colorMap.set(categories[i], palette[i % palette.length])
-    }
+    const effectiveScheme: string | string[] = colorScheme
+      ?? (themeCategorical && themeCategorical.length > 0 ? themeCategorical : undefined)
+      ?? "category10"
 
     // Build synthetic data so createLegend can extract categories
     const syntheticColorBy = typeof colorBy === "string" ? colorBy : "__streamCat"
     const syntheticData = categories.map(cat => ({ [syntheticColorBy]: cat }))
-    const syntheticScale = (v: string) => colorMap.get(v) || "#999"
+    const fallbackScale = createColorScale(syntheticData, syntheticColorBy, effectiveScheme)
+    const syntheticScale = (v: string) => categoryColors?.[v] || fallbackScale(v) || "#999"
 
     return createLegend({
       data: syntheticData,
@@ -144,7 +150,7 @@ export function useStreamingLegend({
       colorScale: syntheticScale,
       getColor,
     })
-  }, [isPushMode, colorBy, showLegend, colorScheme, version])
+  }, [isPushMode, colorBy, showLegend, colorScheme, categoryColors, themeCategorical, version])
 
   /** Margin adjustment needed for streaming legend */
   const streamingMarginAdjust = useMemo(() => {

--- a/src/components/charts/xy/AreaChart.tsx
+++ b/src/components/charts/xy/AreaChart.tsx
@@ -17,6 +17,7 @@ import { validateArrayData } from "../shared/validateChartData"
 import { wrapStyleWithSelection } from "../shared/selectionUtils"
 import { mergeShapeStyle } from "../shared/mergeShapeStyle"
 import { useResolvedSelection } from "../shared/useResolvedSelection"
+import { useStreamingLegend } from "../shared/useStreamingLegend"
 
 /**
  * AreaChart component props
@@ -294,6 +295,14 @@ export const AreaChart = forwardRef(function AreaChart<TDatum extends Datum = Da
   const emptyEl = !loadingEl ? renderEmptyState(data, width, height, emptyContent) : null
 
   const safeData = data || []
+  const isPushMode = data === undefined
+  const streaming = useStreamingLegend({
+    isPushMode,
+    colorBy,
+    colorScheme,
+    showLegend,
+    legendPosition: legendPositionProp,
+  })
 
   // ── Dev-mode warnings ─────────────────────────────────────────────────
   warnMissingField("AreaChart", safeData, "xAccessor", xAccessor)
@@ -363,7 +372,8 @@ export const AreaChart = forwardRef(function AreaChart<TDatum extends Datum = Da
     return Array.from(vals)
   }, [safeData, colorBy])
 
-  const legendState = useLegendInteraction(legendInteraction, colorBy, allCategories)
+  const activeCategories = isPushMode && streaming.categories.length > 0 ? streaming.categories : allCategories
+  const legendState = useLegendInteraction(legendInteraction, colorBy, activeCategories)
 
   // Merge legend selection with cross-chart selection
   const effectiveSelectionHook = useMemo(() => {
@@ -440,6 +450,18 @@ export const AreaChart = forwardRef(function AreaChart<TDatum extends Datum = Da
     userMargin,
     defaults: resolved.marginDefaults,
   })
+  const effectiveLegend = streaming.streamingLegend || legend
+  const effectiveMargin = useMemo(() => {
+    if (streaming.streamingMarginAdjust) {
+      const m = { ...margin }
+      for (const [key, val] of Object.entries(streaming.streamingMarginAdjust)) {
+        const k = key as keyof typeof m
+        if (m[k] < val) m[k] = val
+      }
+      return m
+    }
+    return margin
+  }, [margin, streaming.streamingMarginAdjust])
 
   // Default tooltip showing all configured fields. `xFormat`/`yFormat`
   // cascade from the HOC so the tooltip values read the same way as the axis.
@@ -490,7 +512,7 @@ export const AreaChart = forwardRef(function AreaChart<TDatum extends Datum = Da
     size: [width, height],
     responsiveWidth: props.responsiveWidth,
     responsiveHeight: props.responsiveHeight,
-    margin,
+    margin: effectiveMargin,
     showAxes: resolved.showAxes,
     xLabel,
     yLabel,
@@ -499,7 +521,8 @@ export const AreaChart = forwardRef(function AreaChart<TDatum extends Datum = Da
     enableHover,
     ...(props.pointIdAccessor && { pointIdAccessor: props.pointIdAccessor }),
     showGrid,
-    ...(legend && { legend, legendPosition }),
+    ...streaming.categoryDomainProps,
+    ...(effectiveLegend && { legend: effectiveLegend, legendPosition }),
     ...(legendInteraction && legendInteraction !== "none" && {
       legendHoverBehavior: legendState.onLegendHover,
       legendClickBehavior: legendState.onLegendClick,

--- a/src/components/charts/xy/BubbleChart.tsx
+++ b/src/components/charts/xy/BubbleChart.tsx
@@ -381,7 +381,8 @@ export const BubbleChart = forwardRef(function BubbleChart<TDatum extends Datum 
     return Array.from(vals)
   }, [safeData, colorBy])
 
-  const legendState = useLegendInteraction(legendInteraction, colorBy, allCategories)
+  const activeCategories = isPushMode && streaming.categories.length > 0 ? streaming.categories : allCategories
+  const legendState = useLegendInteraction(legendInteraction, colorBy, activeCategories)
 
   // Merge legend selection with cross-chart selection
   const effectiveSelectionHook = useMemo(() => {
@@ -511,6 +512,7 @@ export const BubbleChart = forwardRef(function BubbleChart<TDatum extends Datum 
     yFormat,
     enableHover,
     showGrid,
+    ...streaming.categoryDomainProps,
     ...(effectiveLegend && { legend: effectiveLegend, legendPosition: effectiveLegendPosition }),
     ...(legendInteraction && legendInteraction !== "none" && {
       legendHoverBehavior: legendState.onLegendHover,

--- a/src/components/charts/xy/LineChart.tsx
+++ b/src/components/charts/xy/LineChart.tsx
@@ -19,6 +19,7 @@ import { wrapStyleWithSelection } from "../shared/selectionUtils"
 import { useResolvedSelection } from "../shared/useResolvedSelection"
 import type { AnomalyConfig, ForecastConfig } from "../shared/statisticalOverlays"
 import { buildForecastLazy, buildAnomalyAnnotationsLazy, createSegmentLineStyleLazy, SEGMENT_FIELD } from "../shared/statisticalOverlaysLazy"
+import { useStreamingLegend } from "../shared/useStreamingLegend"
 
 /**
  * LineChart component props
@@ -391,6 +392,14 @@ export const LineChart = forwardRef(
   const emptyEl = !loadingEl ? renderEmptyState(data, width, height, emptyContent) : null
 
   const safeData = data || []
+  const isPushMode = data === undefined
+  const streaming = useStreamingLegend({
+    isPushMode,
+    colorBy,
+    colorScheme,
+    showLegend: directLabel && showLegend === undefined ? false : showLegend,
+    legendPosition: legendPositionProp,
+  })
 
   // ── Dev-mode warnings ─────────────────────────────────────────────────
   warnMissingField("LineChart", safeData, "xAccessor", xAccessor)
@@ -717,7 +726,8 @@ export const LineChart = forwardRef(
     return Array.from(vals)
   }, [effectiveData, colorBy])
 
-  const legendState = useLegendInteraction(legendInteraction, colorBy, allCategories)
+  const activeCategories = isPushMode && streaming.categories.length > 0 ? streaming.categories : allCategories
+  const legendState = useLegendInteraction(legendInteraction, colorBy, activeCategories)
 
   // Merge hover highlight > legend selection > cross-chart selection
   const effectiveSelectionHook = useMemo(() => {
@@ -899,6 +909,18 @@ export const LineChart = forwardRef(
     userMargin,
     defaults: directLabelMarginDefaults,
   })
+  const effectiveLegend = streaming.streamingLegend || legend
+  const effectiveMargin = useMemo(() => {
+    if (streaming.streamingMarginAdjust) {
+      const m = { ...margin }
+      for (const [key, val] of Object.entries(streaming.streamingMarginAdjust)) {
+        const k = key as keyof typeof m
+        if (m[k] < val) m[k] = val
+      }
+      return m
+    }
+    return margin
+  }, [margin, streaming.streamingMarginAdjust])
 
   // Default tooltip showing all configured fields. `xFormat`/`yFormat`
   // cascade from the HOC so the tooltip values read the same way as the axis.
@@ -961,7 +983,7 @@ export const LineChart = forwardRef(
     size: [width, height],
     responsiveWidth: props.responsiveWidth,
     responsiveHeight: props.responsiveHeight,
-    margin,
+    margin: effectiveMargin,
     showAxes: resolved.showAxes,
     xLabel,
     yLabel,
@@ -969,7 +991,8 @@ export const LineChart = forwardRef(
     yFormat,
     enableHover,
     showGrid,
-    ...(legend && { legend, legendPosition }),
+    ...streaming.categoryDomainProps,
+    ...(effectiveLegend && { legend: effectiveLegend, legendPosition }),
     ...(legendInteraction && legendInteraction !== "none" && {
       legendHoverBehavior: legendState.onLegendHover,
       legendClickBehavior: legendState.onLegendClick,

--- a/src/components/charts/xy/StackedAreaChart.tsx
+++ b/src/components/charts/xy/StackedAreaChart.tsx
@@ -359,7 +359,8 @@ export const StackedAreaChart = forwardRef(function StackedAreaChart<TDatum exte
     return Array.from(vals)
   }, [safeData, colorBy])
 
-  const legendState = useLegendInteraction(legendInteraction, colorBy, allCategories)
+  const activeCategories = isPushMode && streaming.categories.length > 0 ? streaming.categories : allCategories
+  const legendState = useLegendInteraction(legendInteraction, colorBy, activeCategories)
 
   // Merge legend selection with cross-chart selection
   const effectiveSelectionHook = useMemo(() => {
@@ -504,6 +505,7 @@ export const StackedAreaChart = forwardRef(function StackedAreaChart<TDatum exte
     enableHover,
     ...(props.pointIdAccessor && { pointIdAccessor: props.pointIdAccessor }),
     showGrid,
+    ...streaming.categoryDomainProps,
     ...(effectiveLegend && { legend: effectiveLegend, legendPosition: effectiveLegendPosition }),
     ...(legendInteraction && legendInteraction !== "none" && {
       legendHoverBehavior: legendState.onLegendHover,

--- a/src/components/stream/StreamOrdinalFrame.test.tsx
+++ b/src/components/stream/StreamOrdinalFrame.test.tsx
@@ -222,6 +222,42 @@ describe("StreamOrdinalFrame", () => {
       expect(ref.current!.getData().length).toBe(3)
     })
 
+    it("emits legend category domain changes after push, remove, update, and clear", async () => {
+      const ref = React.createRef<StreamOrdinalFrameHandle>()
+      const onCategoriesChange = vi.fn()
+      render(
+        <StreamOrdinalFrame
+          ref={ref}
+          chartType="bar"
+          runtimeMode="streaming"
+          categoryAccessor="cat"
+          valueAccessor="val"
+          dataIdAccessor="id"
+          legendCategoryAccessor="cat"
+          onCategoriesChange={onCategoriesChange}
+        />
+      )
+
+      await act(async () => {
+        ref.current!.pushMany([
+          { id: "a", cat: "A", val: 10 },
+          { id: "b", cat: "B", val: 20 },
+        ])
+      })
+      expect(onCategoriesChange).toHaveBeenLastCalledWith(["A", "B"])
+
+      await act(async () => { ref.current!.remove("b") })
+      expect(onCategoriesChange).toHaveBeenLastCalledWith(["A"])
+
+      await act(async () => {
+        ref.current!.update("a", d => ({ ...d, cat: "C" }))
+      })
+      expect(onCategoriesChange).toHaveBeenLastCalledWith(["C"])
+
+      await act(async () => { ref.current!.clear() })
+      expect(onCategoriesChange).toHaveBeenLastCalledWith([])
+    })
+
     it("replace swaps the full dataset in one call", async () => {
       const ref = React.createRef<StreamOrdinalFrameHandle>()
       render(

--- a/src/components/stream/StreamOrdinalFrame.tsx
+++ b/src/components/stream/StreamOrdinalFrame.tsx
@@ -352,6 +352,10 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
     const canvasRef = useRef<HTMLCanvasElement>(null)
     const hoverRef = useRef<HoverData | null>(null)
     const lastLegendCategoriesRef = useRef<string[]>([])
+    const legendCategoryAccessorRef = useRef(legendCategoryAccessor)
+    const onCategoriesChangeRef = useRef(onCategoriesChange)
+    legendCategoryAccessorRef.current = legendCategoryAccessor
+    onCategoriesChangeRef.current = onCategoriesChange
 
     // ── State ────────────────────────────────────────────────────────────
 
@@ -440,6 +444,16 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
 
     // scheduleRender comes from useFrame above.
 
+    const emitLegendCategories = useCallback(() => {
+      const accessor = legendCategoryAccessorRef.current
+      const onChange = onCategoriesChangeRef.current
+      if (!onChange || !accessor) return
+      const categories = extractCategoryDomain(storeRef.current?.getData() ?? [], accessor)
+      if (sameCategoryDomain(categories, lastLegendCategoriesRef.current)) return
+      lastLegendCategoriesRef.current = categories
+      onChange(categories)
+    }, [])
+
     // Update config when it changes
     useEffect(() => {
       storeRef.current?.updateConfig(pipelineConfig)
@@ -460,6 +474,7 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
         const needsRender = store.ingest(changeset)
         if (needsRender) {
           dirtyRef.current = true
+          emitLegendCategories()
           scheduleRender()
         }
       })
@@ -478,9 +493,10 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
     const clearAll = useCallback(() => {
       adapterRef.current?.clear()
       storeRef.current?.clear()
+      emitLegendCategories()
       dirtyRef.current = true
       scheduleRender()
-    }, [scheduleRender])
+    }, [emitLegendCategories, scheduleRender])
 
     // Data replacement. Routes through `setReplacementData`, which emits
     // `{ bounded: true, preserveCategoryOrder: true }`. Three effects:
@@ -525,6 +541,7 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
             setHoverPoint(null)
           }
           dirtyRef.current = true
+          emitLegendCategories()
           scheduleRender()
         }
         return removed
@@ -534,6 +551,7 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
         const previous = storeRef.current?.update(id, updater) ?? []
         if (previous.length > 0) {
           dirtyRef.current = true
+          emitLegendCategories()
           scheduleRender()
         }
         return previous
@@ -544,7 +562,7 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
         return storeRef.current?.getData() ?? []
       },
       getScales: () => storeRef.current?.scales ?? null
-    }), [pushPoint, pushManyPoints, replaceData, clearAll, scheduleRender])
+    }), [pushPoint, pushManyPoints, replaceData, clearAll, emitLegendCategories, scheduleRender])
 
     // ── Controlled data prop ─────────────────────────────────────────────
 
@@ -712,14 +730,6 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
       focusedNavPointRef.current = null
       onPointerMove(e)
     }, [onPointerMove])
-
-    const emitLegendCategories = useCallback(() => {
-      if (!onCategoriesChange || !legendCategoryAccessor) return
-      const categories = extractCategoryDomain(storeRef.current?.getData() ?? [], legendCategoryAccessor)
-      if (sameCategoryDomain(categories, lastLegendCategoriesRef.current)) return
-      lastLegendCategoriesRef.current = categories
-      onCategoriesChange(categories)
-    }, [legendCategoryAccessor, onCategoriesChange])
 
     // ── Render function ──────────────────────────────────────────────────
 

--- a/src/components/stream/StreamOrdinalFrame.tsx
+++ b/src/components/stream/StreamOrdinalFrame.tsx
@@ -65,6 +65,7 @@ import { violinCanvasRenderer } from "./renderers/violinCanvasRenderer"
 import { connectorCanvasRenderer } from "./renderers/connectorCanvasRenderer"
 import { trapezoidCanvasRenderer, funnelLabelRenderer } from "./renderers/trapezoidCanvasRenderer"
 import { barFunnelHatchRenderer, barFunnelLabelRenderer } from "./renderers/barFunnelCanvasRenderer"
+import { extractCategoryDomain, sameCategoryDomain } from "./categoryDomain"
 
 // ── Renderer dispatch ──────────────────────────────────────────────────
 
@@ -284,6 +285,8 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
       legendHighlightedCategory,
       legendIsolatedCategories,
       legendPosition,
+      legendCategoryAccessor,
+      onCategoriesChange,
       backgroundGraphics,
       foregroundGraphics,
       title,
@@ -348,6 +351,7 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
 
     const canvasRef = useRef<HTMLCanvasElement>(null)
     const hoverRef = useRef<HoverData | null>(null)
+    const lastLegendCategoriesRef = useRef<string[]>([])
 
     // ── State ────────────────────────────────────────────────────────────
 
@@ -709,6 +713,14 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
       onPointerMove(e)
     }, [onPointerMove])
 
+    const emitLegendCategories = useCallback(() => {
+      if (!onCategoriesChange || !legendCategoryAccessor) return
+      const categories = extractCategoryDomain(storeRef.current?.getData() ?? [], legendCategoryAccessor)
+      if (sameCategoryDomain(categories, lastLegendCategoriesRef.current)) return
+      lastLegendCategoriesRef.current = categories
+      onCategoriesChange(categories)
+    }, [legendCategoryAccessor, onCategoriesChange])
+
     // ── Render function ──────────────────────────────────────────────────
 
     renderFnRef.current = () => {
@@ -733,6 +745,7 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
       const wasDirty = dirtyRef.current
       if (wasDirty && !transitionActive) {
         store.computeScene({ width: adjustedWidth, height: adjustedHeight })
+        emitLegendCategories()
         dirtyRef.current = false
       }
 

--- a/src/components/stream/StreamOrdinalFrame.tsx
+++ b/src/components/stream/StreamOrdinalFrame.tsx
@@ -474,7 +474,10 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
         const needsRender = store.ingest(changeset)
         if (needsRender) {
           dirtyRef.current = true
-          emitLegendCategories()
+          // Legend-category emission deferred to the post-computeScene path
+          // in the render loop — single canonical emit point per data change,
+          // already rAF-throttled. Calling here too would scan the full
+          // buffer twice per push at high streaming frequencies.
           scheduleRender()
         }
       })
@@ -493,10 +496,10 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
     const clearAll = useCallback(() => {
       adapterRef.current?.clear()
       storeRef.current?.clear()
-      emitLegendCategories()
       dirtyRef.current = true
+      // emitLegendCategories runs after computeScene in the render loop.
       scheduleRender()
-    }, [emitLegendCategories, scheduleRender])
+    }, [scheduleRender])
 
     // Data replacement. Routes through `setReplacementData`, which emits
     // `{ bounded: true, preserveCategoryOrder: true }`. Three effects:
@@ -541,7 +544,7 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
             setHoverPoint(null)
           }
           dirtyRef.current = true
-          emitLegendCategories()
+          // Legend emit deferred to post-computeScene render path.
           scheduleRender()
         }
         return removed
@@ -551,7 +554,7 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
         const previous = storeRef.current?.update(id, updater) ?? []
         if (previous.length > 0) {
           dirtyRef.current = true
-          emitLegendCategories()
+          // Legend emit deferred to post-computeScene render path.
           scheduleRender()
         }
         return previous
@@ -562,7 +565,7 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
         return storeRef.current?.getData() ?? []
       },
       getScales: () => storeRef.current?.scales ?? null
-    }), [pushPoint, pushManyPoints, replaceData, clearAll, emitLegendCategories, scheduleRender])
+    }), [pushPoint, pushManyPoints, replaceData, clearAll, scheduleRender])
 
     // ── Controlled data prop ─────────────────────────────────────────────
 

--- a/src/components/stream/StreamXYFrame.test.tsx
+++ b/src/components/stream/StreamXYFrame.test.tsx
@@ -235,6 +235,42 @@ describe("StreamXYFrame", () => {
       expect(ref.current!.getData().length).toBe(3)
     })
 
+    it("emits legend category domain changes after push, remove, update, and clear", async () => {
+      const ref = React.createRef<StreamXYFrameHandle>()
+      const onCategoriesChange = vi.fn()
+      render(
+        <StreamXYFrame
+          ref={ref}
+          chartType="scatter"
+          runtimeMode="streaming"
+          timeAccessor="t"
+          valueAccessor="v"
+          pointIdAccessor="id"
+          legendCategoryAccessor="series"
+          onCategoriesChange={onCategoriesChange}
+        />
+      )
+
+      await act(async () => {
+        ref.current!.pushMany([
+          { id: "a", t: 1, v: 10, series: "A" },
+          { id: "b", t: 2, v: 20, series: "B" },
+        ])
+      })
+      expect(onCategoriesChange).toHaveBeenLastCalledWith(["A", "B"])
+
+      await act(async () => { ref.current!.remove("b") })
+      expect(onCategoriesChange).toHaveBeenLastCalledWith(["A"])
+
+      await act(async () => {
+        ref.current!.update("a", d => ({ ...d, series: "C" }))
+      })
+      expect(onCategoriesChange).toHaveBeenLastCalledWith(["C"])
+
+      await act(async () => { ref.current!.clear() })
+      expect(onCategoriesChange).toHaveBeenLastCalledWith([])
+    })
+
     it("clear empties the data buffer", async () => {
       const ref = React.createRef<StreamXYFrameHandle>()
       render(

--- a/src/components/stream/StreamXYFrame.tsx
+++ b/src/components/stream/StreamXYFrame.tsx
@@ -49,6 +49,7 @@ import { heatmapCanvasRenderer } from "./renderers/heatmapCanvasRenderer"
 import { candlestickCanvasRenderer } from "./renderers/candlestickCanvasRenderer"
 import type { StreamRendererFn } from "./renderers/types"
 import { resolveNodeColor } from "./sceneUtils"
+import { extractCategoryDomain, sameCategoryDomain } from "./categoryDomain"
 
 // ── Auto-date tick formatting ─────────────────────────────────────────
 
@@ -407,6 +408,8 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
       legendHighlightedCategory,
       legendIsolatedCategories,
       legendPosition,
+      legendCategoryAccessor,
+      onCategoriesChange,
       backgroundGraphics,
       foregroundGraphics,
       canvasPreRenderers,
@@ -519,6 +522,7 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
     // on every pointermove. Initialized to LIGHT_THEME.primary so the first
     // hover before a paint still returns a valid color.
     const themePrimaryRef = useRef<string>(LIGHT_THEME.primary)
+    const lastLegendCategoriesRef = useRef<string[]>([])
 
     // Staleness state — initialized here, set by useStalenessCheck below
     const [isStale, setIsStale] = useState(false)
@@ -936,6 +940,14 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
       onPointerMove(e)
     }, [onPointerMove])
 
+    const emitLegendCategories = useCallback(() => {
+      if (!onCategoriesChange || !legendCategoryAccessor) return
+      const categories = extractCategoryDomain(storeRef.current?.getData() ?? [], legendCategoryAccessor)
+      if (sameCategoryDomain(categories, lastLegendCategoriesRef.current)) return
+      lastLegendCategoriesRef.current = categories
+      onCategoriesChange(categories)
+    }, [legendCategoryAccessor, onCategoriesChange])
+
     // ── Render function ──────────────────────────────────────────────────
 
     renderFnRef.current = () => {
@@ -963,6 +975,7 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
       // Compute scene graph (scales + scene nodes) — only when data changed
       if (needsDataRepaint && !isTransitioning) {
         store.computeScene({ width: adjustedWidth, height: adjustedHeight })
+        emitLegendCategories()
       }
 
       const dpr = getDevicePixelRatio()

--- a/src/components/stream/StreamXYFrame.tsx
+++ b/src/components/stream/StreamXYFrame.tsx
@@ -523,6 +523,10 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
     // hover before a paint still returns a valid color.
     const themePrimaryRef = useRef<string>(LIGHT_THEME.primary)
     const lastLegendCategoriesRef = useRef<string[]>([])
+    const legendCategoryAccessorRef = useRef(legendCategoryAccessor)
+    const onCategoriesChangeRef = useRef(onCategoriesChange)
+    legendCategoryAccessorRef.current = legendCategoryAccessor
+    onCategoriesChangeRef.current = onCategoriesChange
 
     // Staleness state — initialized here, set by useStalenessCheck below
     const [isStale, setIsStale] = useState(false)
@@ -626,6 +630,16 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
 
     // scheduleRender comes from useFrame above.
 
+    const emitLegendCategories = useCallback(() => {
+      const accessor = legendCategoryAccessorRef.current
+      const onChange = onCategoriesChangeRef.current
+      if (!onChange || !accessor) return
+      const categories = extractCategoryDomain(storeRef.current?.getData() ?? [], accessor)
+      if (sameCategoryDomain(categories, lastLegendCategoriesRef.current)) return
+      lastLegendCategoriesRef.current = categories
+      onChange(categories)
+    }, [])
+
     // Update config when it changes — also schedule re-render since style
     // callbacks (pointStyle, areaStyle, etc.) may have changed.
     useEffect(() => {
@@ -647,6 +661,7 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
         const needsRender = store.ingest(changeset)
         if (needsRender) {
           dirtyRef.current = true
+          emitLegendCategories()
           scheduleRender()
         }
       }, { chunkThreshold, chunkSize })
@@ -670,9 +685,10 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
     const clearAll = useCallback(() => {
       adapterRef.current?.clear()
       storeRef.current?.clear()
+      emitLegendCategories()
       dirtyRef.current = true
       scheduleRender()
-    }, [scheduleRender])
+    }, [emitLegendCategories, scheduleRender])
 
     useImperativeHandle(ref, () => ({
       push: pushPoint,
@@ -687,6 +703,7 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
             setHoverPoint(null)
           }
           dirtyRef.current = true
+          emitLegendCategories()
           scheduleRender()
         }
         return removed
@@ -696,6 +713,7 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
         const previous = storeRef.current?.update(id, updater) ?? []
         if (previous.length > 0) {
           dirtyRef.current = true
+          emitLegendCategories()
           scheduleRender()
         }
         return previous
@@ -708,7 +726,7 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
       },
       getScales: () => storeRef.current?.scales ?? null,
       getExtents: () => storeRef.current?.getExtents() ?? null
-    }), [pushPoint, pushManyPoints, clearAll, scheduleRender])
+    }), [pushPoint, pushManyPoints, clearAll, emitLegendCategories, scheduleRender])
 
     // ── Controlled data prop ─────────────────────────────────────────────
 
@@ -939,14 +957,6 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
       focusedNavPointRef.current = null
       onPointerMove(e)
     }, [onPointerMove])
-
-    const emitLegendCategories = useCallback(() => {
-      if (!onCategoriesChange || !legendCategoryAccessor) return
-      const categories = extractCategoryDomain(storeRef.current?.getData() ?? [], legendCategoryAccessor)
-      if (sameCategoryDomain(categories, lastLegendCategoriesRef.current)) return
-      lastLegendCategoriesRef.current = categories
-      onCategoriesChange(categories)
-    }, [legendCategoryAccessor, onCategoriesChange])
 
     // ── Render function ──────────────────────────────────────────────────
 

--- a/src/components/stream/StreamXYFrame.tsx
+++ b/src/components/stream/StreamXYFrame.tsx
@@ -661,7 +661,10 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
         const needsRender = store.ingest(changeset)
         if (needsRender) {
           dirtyRef.current = true
-          emitLegendCategories()
+          // Legend-category emission deferred to the post-computeScene path
+          // in the render loop — that's the single canonical emit point per
+          // data change, already rAF-throttled. Calling here too would scan
+          // the full buffer twice per push at high streaming frequencies.
           scheduleRender()
         }
       }, { chunkThreshold, chunkSize })
@@ -685,10 +688,10 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
     const clearAll = useCallback(() => {
       adapterRef.current?.clear()
       storeRef.current?.clear()
-      emitLegendCategories()
       dirtyRef.current = true
+      // emitLegendCategories runs after computeScene in the render loop.
       scheduleRender()
-    }, [emitLegendCategories, scheduleRender])
+    }, [scheduleRender])
 
     useImperativeHandle(ref, () => ({
       push: pushPoint,
@@ -703,7 +706,7 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
             setHoverPoint(null)
           }
           dirtyRef.current = true
-          emitLegendCategories()
+          // Legend emit deferred to post-computeScene render path.
           scheduleRender()
         }
         return removed
@@ -713,7 +716,7 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
         const previous = storeRef.current?.update(id, updater) ?? []
         if (previous.length > 0) {
           dirtyRef.current = true
-          emitLegendCategories()
+          // Legend emit deferred to post-computeScene render path.
           scheduleRender()
         }
         return previous
@@ -726,7 +729,7 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
       },
       getScales: () => storeRef.current?.scales ?? null,
       getExtents: () => storeRef.current?.getExtents() ?? null
-    }), [pushPoint, pushManyPoints, clearAll, emitLegendCategories, scheduleRender])
+    }), [pushPoint, pushManyPoints, clearAll, scheduleRender])
 
     // ── Controlled data prop ─────────────────────────────────────────────
 

--- a/src/components/stream/categoryDomain.ts
+++ b/src/components/stream/categoryDomain.ts
@@ -1,0 +1,32 @@
+import type { Datum } from "../charts/shared/datumTypes"
+
+export type CategoryDomainAccessor<T = Datum> = string | ((d: T) => unknown)
+
+export function extractCategoryDomain<T extends Datum>(
+  data: T[],
+  accessor: CategoryDomainAccessor<T> | undefined
+): string[] {
+  if (!accessor) return []
+  const seen = new Set<string>()
+  const categories: string[] = []
+
+  for (const d of data) {
+    if (!d || typeof d !== "object") continue
+    const raw = typeof accessor === "function" ? accessor(d) : d[accessor]
+    if (raw == null) continue
+    const category = String(raw)
+    if (seen.has(category)) continue
+    seen.add(category)
+    categories.push(category)
+  }
+
+  return categories
+}
+
+export function sameCategoryDomain(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}

--- a/src/components/stream/ordinalTypes.ts
+++ b/src/components/stream/ordinalTypes.ts
@@ -433,6 +433,10 @@ export interface StreamOrdinalFrameProps<T = Datum> {
   legendHighlightedCategory?: string | null
   legendIsolatedCategories?: Set<string>
   legendPosition?: "right" | "left" | "top" | "bottom"
+  /** Accessor used to report the current legend category domain in push mode. */
+  legendCategoryAccessor?: string | ((d: T) => string)
+  /** Fires when the current legend category domain changes after scene rebuilds. */
+  onCategoriesChange?: (categories: string[]) => void
   backgroundGraphics?: ReactNode
   foregroundGraphics?: ReactNode
   title?: string | ReactNode

--- a/src/components/stream/types.ts
+++ b/src/components/stream/types.ts
@@ -592,6 +592,10 @@ export interface StreamXYFrameProps<T = Datum> {
   legendHighlightedCategory?: string | null
   legendIsolatedCategories?: Set<string>
   legendPosition?: "right" | "left" | "top" | "bottom"
+  /** Accessor used to report the current legend category domain in push mode. */
+  legendCategoryAccessor?: string | ((d: T) => string)
+  /** Fires when the current legend category domain changes after scene rebuilds. */
+  onCategoriesChange?: (categories: string[]) => void
 
   // ── Background / foreground graphics ───────────
   /** SVG elements rendered behind the canvas (in pixel space) */


### PR DESCRIPTION
This pull request implements automatic legend category population and unified legend management for charts using the push API, and adds comprehensive regression test coverage for these features. The most important changes include the introduction of a live category registry in `LinkedCharts`, new hooks for category registration, and updates to tests and chart components to verify and utilize the new behavior.

### Legend auto-population and unified legend management

* [`LinkedCharts.tsx`](diffhunk://#diff-d4c73adb258921e8b75be29d84f5a14c6f1e2e16c99654888f266b20053d1051R44-R86): Introduced a `LinkedCategoryRegistryContext` and `useLinkedChartCategories` hook. Child charts now register their live category domains with the parent `LinkedCharts`, which merges them with any parent color providers, assigns stable colors, and renders a unified legend that dynamically updates as categories are added or removed. [[1]](diffhunk://#diff-d4c73adb258921e8b75be29d84f5a14c6f1e2e16c99654888f266b20053d1051R44-R86) [[2]](diffhunk://#diff-d4c73adb258921e8b75be29d84f5a14c6f1e2e16c99654888f266b20053d1051L302-R384) [[3]](diffhunk://#diff-d4c73adb258921e8b75be29d84f5a14c6f1e2e16c99654888f266b20053d1051R395-R398) [[4]](diffhunk://#diff-d4c73adb258921e8b75be29d84f5a14c6f1e2e16c99654888f266b20053d1051L323-R407) [[5]](diffhunk://#diff-d4c73adb258921e8b75be29d84f5a14c6f1e2e16c99654888f266b20053d1051R416-R417)
* [`OUTSTANDING_WORK.md`](diffhunk://#diff-fbb4a34cc150f00e9572aa6eb822870894953c8e68dd30e0e7718940ad18e614L205-R216): Updated the status of legend auto-population to "implemented" and documented the new data flow, including how `StreamOrdinalFrame`/`StreamXYFrame` and `LinkedCharts` interact to provide live legend updates.

### Test coverage for streaming legends

* [`BarChart.test.tsx`](diffhunk://#diff-b7122cdcd0f964b2bda80d0c0767acbe1e76366c3fda432730bcd4ac2848278bR14-R80): Added tests to verify that legends populate, shrink, relabel, and clear in response to push, remove, update, and clear operations on the chart data, ensuring correct behavior of the streaming legend logic. [[1]](diffhunk://#diff-b7122cdcd0f964b2bda80d0c0767acbe1e76366c3fda432730bcd4ac2848278bR14-R80) [[2]](diffhunk://#diff-b7122cdcd0f964b2bda80d0c0767acbe1e76366c3fda432730bcd4ac2848278bR382-R435)
* [`LinkedCharts.test.tsx`](diffhunk://#diff-5297a34a7867762ea7ed205d81d214388f2782564c6e24a687aaa309c0e5c20eR151-R179): Added a test to ensure that the unified legend in `LinkedCharts` builds and shrinks its category set based on child chart registrations.

### Refactoring and API safety

* [`BarChart.test.tsx`](diffhunk://#diff-b7122cdcd0f964b2bda80d0c0767acbe1e76366c3fda432730bcd4ac2848278bL404-R517): Improved test coverage and safety by ensuring all imperative frame methods (`push`, `pushMany`, `getData`, `getScales`, `clear`) remain safe and function correctly through the streaming legend wrapper. [[1]](diffhunk://#diff-b7122cdcd0f964b2bda80d0c0767acbe1e76366c3fda432730bcd4ac2848278bL404-R517) [[2]](diffhunk://#diff-b7122cdcd0f964b2bda80d0c0767acbe1e76366c3fda432730bcd4ac2848278bR528-R556)

### Supporting hooks and utilities

* [`BarChart.tsx`](diffhunk://#diff-f61629472ff997877cd8693f9a25c06a24b57019ea8ce3a4367a1614cade29baR20): Prepared for integration with the new streaming legend system by importing the `useOrdinalStreaming` hook (to be used for managing streaming legend state).

These changes ensure that legends in push-API charts are always up-to-date with the current data and that unified legends in linked chart groups accurately reflect all active categories.