### PR TITLE
handle ssr canvas divergence

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -137,7 +137,7 @@ Server SVGs include `role="img"`, `<title>`, `<desc>`, grid, legend, annotations
 - **GroupedBarChart** — `data`, `categoryAccessor`, `valueAccessor`, `groupBy` (required).
 - **PieChart/DonutChart** — `data`, `categoryAccessor`, `valueAccessor`.
 - **FunnelChart** — `data`, `stepAccessor` ("step"), `valueAccessor` ("value"). Renders with trapezoid connectors, no axes.
-- **GaugeChart** — `value`, `thresholds` (array of `{value, color, label}`). Optional: `min`, `max`, `sweep`, `arcWidth`.
+- **GaugeChart** — `value`. Optional: `thresholds` (array of `{value, color, label}`), `min`, `max`, `sweep`, `arcWidth`.
 - **SwimlaneChart** — `data`, `categoryAccessor`, `subcategoryAccessor` (required), `valueAccessor`.
 - **ForceDirectedGraph** — `edges` (required). `nodes` optional (inferred from edges).
 - **SankeyDiagram** — `edges` (required), `valueAccessor`.

--- a/.cursorrules
+++ b/.cursorrules
@@ -137,7 +137,7 @@ Server SVGs include `role="img"`, `<title>`, `<desc>`, grid, legend, annotations
 - **GroupedBarChart** — `data`, `categoryAccessor`, `valueAccessor`, `groupBy` (required).
 - **PieChart/DonutChart** — `data`, `categoryAccessor`, `valueAccessor`.
 - **FunnelChart** — `data`, `stepAccessor` ("step"), `valueAccessor` ("value"). Renders with trapezoid connectors, no axes.
-- **GaugeChart** — `value`, `thresholds` (array of `{value, color, label}`). Optional: `min`, `max`, `sweep`, `arcWidth`.
+- **GaugeChart** — `value`. Optional: `thresholds` (array of `{value, color, label}`), `min`, `max`, `sweep`, `arcWidth`.
 - **SwimlaneChart** — `data`, `categoryAccessor`, `subcategoryAccessor` (required), `valueAccessor`.
 - **ForceDirectedGraph** — `edges` (required). `nodes` optional (inferred from edges).
 - **SankeyDiagram** — `edges` (required), `valueAccessor`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -137,7 +137,7 @@ Server SVGs include `role="img"`, `<title>`, `<desc>`, grid, legend, annotations
 - **GroupedBarChart** — `data`, `categoryAccessor`, `valueAccessor`, `groupBy` (required).
 - **PieChart/DonutChart** — `data`, `categoryAccessor`, `valueAccessor`.
 - **FunnelChart** — `data`, `stepAccessor` ("step"), `valueAccessor` ("value"). Renders with trapezoid connectors, no axes.
-- **GaugeChart** — `value`, `thresholds` (array of `{value, color, label}`). Optional: `min`, `max`, `sweep`, `arcWidth`.
+- **GaugeChart** — `value`. Optional: `thresholds` (array of `{value, color, label}`), `min`, `max`, `sweep`, `arcWidth`.
 - **SwimlaneChart** — `data`, `categoryAccessor`, `subcategoryAccessor` (required), `valueAccessor`.
 - **ForceDirectedGraph** — `edges` (required). `nodes` optional (inferred from edges).
 - **SankeyDiagram** — `edges` (required), `valueAccessor`.

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -45,7 +45,7 @@ jobs:
         run: npm run check:surface
 
       - name: Check SSR alignment
-        run: node scripts/check-ssr-alignment.js
+        run: npm run check:ssr
 
       - name: Build production bundles
         run: npm run dist:prod

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -137,7 +137,7 @@ Server SVGs include `role="img"`, `<title>`, `<desc>`, grid, legend, annotations
 - **GroupedBarChart** — `data`, `categoryAccessor`, `valueAccessor`, `groupBy` (required).
 - **PieChart/DonutChart** — `data`, `categoryAccessor`, `valueAccessor`.
 - **FunnelChart** — `data`, `stepAccessor` ("step"), `valueAccessor` ("value"). Renders with trapezoid connectors, no axes.
-- **GaugeChart** — `value`, `thresholds` (array of `{value, color, label}`). Optional: `min`, `max`, `sweep`, `arcWidth`.
+- **GaugeChart** — `value`. Optional: `thresholds` (array of `{value, color, label}`), `min`, `max`, `sweep`, `arcWidth`.
 - **SwimlaneChart** — `data`, `categoryAccessor`, `subcategoryAccessor` (required), `valueAccessor`.
 - **ForceDirectedGraph** — `edges` (required). `nodes` optional (inferred from edges).
 - **SankeyDiagram** — `edges` (required), `valueAccessor`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Server SVGs include `role="img"`, `<title>`, `<desc>`, grid, legend, annotations
 - **GroupedBarChart** — `data`, `categoryAccessor`, `valueAccessor`, `groupBy` (required).
 - **PieChart/DonutChart** — `data`, `categoryAccessor`, `valueAccessor`.
 - **FunnelChart** — `data`, `stepAccessor` ("step"), `valueAccessor` ("value"). Renders with trapezoid connectors, no axes.
-- **GaugeChart** — `value`, `thresholds` (array of `{value, color, label}`). Optional: `min`, `max`, `sweep`, `arcWidth`.
+- **GaugeChart** — `value`. Optional: `thresholds` (array of `{value, color, label}`), `min`, `max`, `sweep`, `arcWidth`.
 - **SwimlaneChart** — `data`, `categoryAccessor`, `subcategoryAccessor` (required), `valueAccessor`.
 - **ForceDirectedGraph** — `edges` (required). `nodes` optional (inferred from edges).
 - **SankeyDiagram** — `edges` (required), `valueAccessor`.

--- a/OUTSTANDING_WORK.md
+++ b/OUTSTANDING_WORK.md
@@ -1,6 +1,6 @@
 # Outstanding Work
 
-Last updated 2026-04-22.
+Last updated 2026-04-24.
 
 ---
 
@@ -368,14 +368,29 @@ Open extensions, ranked by leverage:
 
 Five load-bearing concerns from a recent audit. Listed with the plan for each — none urgent individually; each has a way to decay the library silently if ignored.
 
-### 1. Canvas vs. SVG rendering divergence [YELLOW]
+### 1. Canvas vs. SVG rendering divergence [GREEN]
 
-Client renders canvas; server renders SVG via `SceneToSVG`. Any new rendering feature must land in both paths or they drift. The backgroundGraphics bug (canvas painted over SVG backgrounds in Ordinal/Network frames, not XY) lived unseen because the integration test only exercised XY. **The gap is only visible when MCP or `renderToStaticSVG` runs — most contributors never touch those paths.**
+Client renders canvas; server renders SVG via `SceneToSVG`. Any new rendering feature must land in both paths or they drift silently. The bar `gradientFill` near-miss in 3.4.2 and the earlier backgroundGraphics bug (canvas painted over SVG backgrounds in Ordinal/Network frames) both lived through CI because no test enforced the parity contract.
 
-Plan:
-- Extend the SSR-vs-client diff snapshot test (Architecture → Visual regression) to cover every rendering feature, not only chart output — backgrounds, overlays, annotations, legends each get their own diff.
-- Extend `check-ssr-alignment.js` from prop parity to scene-builder parity: every builder referenced on canvas must have a matching `SceneToSVG` converter registered.
-- Dev-mode warning in Stream Frames when a rendering feature lacks an SSR counterpart (surface the gap explicitly rather than silently diverging).
+**Closed in 3.4.x:**
+
+- **Structural layer.** `scripts/check-ssr-alignment.js` extended to scene-node parity. For each frame's `*SceneNode` type union, every member's `type: "X"` discriminant must have a matching `case "X":` in the corresponding `*SceneNodeToSVG` converter, and vice versa. Drift in either direction fails CI with a file-pointing message. `PARITY_EXCEPTIONS` map handles the legitimate one-sided cases (network edge sub-types, `roundedEdge` direction labels) with one-line justifications. Wired into `release:check`, `prepublishOnly`, and the `node.js.yml` workflow as `npm run check:ssr`. Lock-down test in `src/__tests__/scenarios/ssr-alignment.test.ts` mutates `SceneToSVG.tsx` mid-test to inject canvas-only and svg-only drift, asserting the script exits 1 with the correct error in both directions.
+- **Feature layer.** `src/components/server/featureParity.test.tsx` — feature-level matrix across (XY, Ordinal, Network, Geo) frames covering title, axes, grid, annotations, legend, backgroundGraphics, foregroundGraphics. All 27 assertions pass; zero `.todo` markers remain. As features land, the matrix expands.
+
+**Surface fixes that landed alongside the matrix:**
+
+- Network annotations: `renderNetworkFrame` now pipes `props.annotations` through `renderStaticAnnotations` with no scales (pixel passthrough since network coords are already in pixel space).
+- Geo annotations: `renderGeoFrame` plumbs `store.scales.projectedPoint` into a new `geoProjection` field on `staticAnnotations`' `AnnotationScales`. Annotations carrying `coordinates: [lon, lat]` resolve through it; raw `x`/`y` numbers still work via pixel passthrough.
+- `staticAnnotations.tsx` extended: `resolveCoords` orchestrates (geoProjection → x/y scale → accessor lookup → pixel passthrough) so the same renderer serves all four frames.
+- Network legend: `renderNetworkFrame` auto-builds a legend from `colorBy/nodeIDAccessor + showLegend`, sourcing categories from the node list (or deriving from edge endpoints when nodes aren't supplied directly). Legend margin is reserved before computing inner dimensions, mirroring the XY pattern.
+- Geo legend: `renderGeoFrame` auto-builds from `colorBy` on points (proportional symbol map) or area features' `properties` (choropleth). Same margin reservation.
+- `backgroundGraphics` and `foregroundGraphics` plumbed through all four frame render functions. The bg layer is rendered first inside the inner-translated `<g>`, fg last, matching `SVGOverlay` / `OrdinalSVGOverlay` z-order. Geo's empty-scene early-return path also pipes them so a chart with no data but legitimate overlays doesn't silently drop them.
+
+**Skipped:**
+
+- Runtime dev-mode warning in Stream Frames. The static check fires at commit time and in CI; a runtime warning would cost every server-rendered chart for a case the static check already catches.
+
+The contract is now both structurally enforced (build-time CI) and behaviorally tested (vitest matrix). Adding a new rendering feature requires touching both the canvas path and the SVG path in the same PR, and CI fails if either is missing.
 
 ### 2. Latent dead props at HOC ↔ Frame seam [YELLOW]
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 ## Quick Start
 - Install: `npm install semiotic`
 - **Use sub-path imports** — `semiotic/xy` (78KB gz), `semiotic/ordinal` (65KB), `semiotic/network` (54KB), `semiotic/geo` (53KB), `semiotic/realtime` (77KB), `semiotic/server` (58KB), `semiotic/utils` (19KB), `semiotic/themes` (3KB), `semiotic/data` (3KB). Full `semiotic` is 158KB gz.
-- CLI: `npx semiotic-ai [--list|--schema [Component]|--suggest|--compact|--examples|--doctor]`
+- CLI: `npx semiotic-ai [--schema|--compact|--examples|--doctor]`
 - MCP: `npx semiotic-mcp`
 
 ## Architecture
@@ -137,7 +137,7 @@ Server SVGs include `role="img"`, `<title>`, `<desc>`, grid, legend, annotations
 - **GroupedBarChart** — `data`, `categoryAccessor`, `valueAccessor`, `groupBy` (required).
 - **PieChart/DonutChart** — `data`, `categoryAccessor`, `valueAccessor`.
 - **FunnelChart** — `data`, `stepAccessor` ("step"), `valueAccessor` ("value"). Renders with trapezoid connectors, no axes.
-- **GaugeChart** — `value` required. Optional: `thresholds` (array of `{value, color, label}`), `min`, `max`, `sweep`, `arcWidth`.
+- **GaugeChart** — `value`, `thresholds` (array of `{value, color, label}`). Optional: `min`, `max`, `sweep`, `arcWidth`.
 - **SwimlaneChart** — `data`, `categoryAccessor`, `subcategoryAccessor` (required), `valueAccessor`.
 - **ForceDirectedGraph** — `edges` (required). `nodes` optional (inferred from edges).
 - **SankeyDiagram** — `edges` (required), `valueAccessor`.
@@ -180,7 +180,7 @@ Serialization: `themeToCSS(theme, selector)`, `themeToTokens(theme)`, `resolveTh
 Canvas scene builders read CSS variables via `getComputedStyle` on the canvas DOM ancestor, so standard CSS cascade rules apply even though rendering is canvas-based. Use CSS vars for **single-role** overrides; use a nested `ThemeProvider` for **array/scale** overrides (categorical palette, sequential/diverging scheme name).
 
 ## AI Features
-`onObservation`/`useChartObserver`, `toConfig`/`fromConfig`/`toURL`/`fromURL`/`copyConfig`/`configToJSX`, `validateProps(component, props)`, `diagnoseConfig(component, props)`, `exportChart(div, { format })`, `npx semiotic-ai --doctor`, `npx semiotic-mcp` tools/resources/prompts
+`onObservation`/`useChartObserver`, `toConfig`/`fromConfig`/`toURL`/`fromURL`/`copyConfig`/`configToJSX`, `validateProps(component, props)`, `diagnoseConfig(component, props)`, `exportChart(div, { format })`, `npx semiotic-ai --doctor`
 
 ## Accessibility
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -137,7 +137,7 @@ Server SVGs include `role="img"`, `<title>`, `<desc>`, grid, legend, annotations
 - **GroupedBarChart** — `data`, `categoryAccessor`, `valueAccessor`, `groupBy` (required).
 - **PieChart/DonutChart** — `data`, `categoryAccessor`, `valueAccessor`.
 - **FunnelChart** — `data`, `stepAccessor` ("step"), `valueAccessor` ("value"). Renders with trapezoid connectors, no axes.
-- **GaugeChart** — `value`, `thresholds` (array of `{value, color, label}`). Optional: `min`, `max`, `sweep`, `arcWidth`.
+- **GaugeChart** — `value`. Optional: `thresholds` (array of `{value, color, label}`), `min`, `max`, `sweep`, `arcWidth`.
 - **SwimlaneChart** — `data`, `categoryAccessor`, `subcategoryAccessor` (required), `valueAccessor`.
 - **ForceDirectedGraph** — `edges` (required). `nodes` optional (inferred from edges).
 - **SankeyDiagram** — `edges` (required), `valueAccessor`.

--- a/package.json
+++ b/package.json
@@ -132,8 +132,9 @@
     "size": "size-limit",
     "check:schema": "node scripts/check-schema-freshness.js",
     "check:surface": "node scripts/check-surface-parity.js",
-    "release:check": "npm run lint && npm run typescript && npm run typescript:mcp && npm run test && npm run check:schema && npm run check:surface && npm run dist:prod && npm pack --dry-run",
-    "prepublishOnly": "npm run lint && npm run typescript && npm run typescript:mcp && npm run test && npm run check:schema && npm run check:surface && rm -rf dist && npm run dist:prod"
+    "check:ssr": "node scripts/check-ssr-alignment.js",
+    "release:check": "npm run lint && npm run typescript && npm run typescript:mcp && npm run test && npm run check:schema && npm run check:surface && npm run check:ssr && npm run dist:prod && npm pack --dry-run",
+    "prepublishOnly": "npm run lint && npm run typescript && npm run typescript:mcp && npm run test && npm run check:schema && npm run check:surface && npm run check:ssr && rm -rf dist && npm run dist:prod"
   },
   "targets": {
     "website": {

--- a/scripts/check-ssr-alignment.js
+++ b/scripts/check-ssr-alignment.js
@@ -25,6 +25,9 @@
  *
  * Usage:
  *   node scripts/check-ssr-alignment.js
+ *
+ * Tests can point the scene parity pass at a temporary SceneToSVG copy via:
+ *   SEMIOTIC_SCENE_TO_SVG=/tmp/SceneToSVG.tsx node scripts/check-ssr-alignment.js
  */
 
 const fs = require("fs")
@@ -164,7 +167,9 @@ for (const { prop, charts, label } of PROP_CHECKS) {
 // the literal lives — the union is the only single point of truth.
 
 const STREAM_DIR = path.join(ROOT, "src/components/stream")
-const SCENE_TO_SVG = path.join(STREAM_DIR, "SceneToSVG.tsx")
+const SCENE_TO_SVG = process.env.SEMIOTIC_SCENE_TO_SVG
+  ? path.resolve(process.env.SEMIOTIC_SCENE_TO_SVG)
+  : path.join(STREAM_DIR, "SceneToSVG.tsx")
 
 const FRAMES = {
   xy:      { typesFile: "types.ts",        unionName: "SceneNode",        svgFn: "xySceneNodeToSVG" },

--- a/scripts/check-ssr-alignment.js
+++ b/scripts/check-ssr-alignment.js
@@ -1,13 +1,27 @@
 #!/usr/bin/env node
 /**
  * Check SSR alignment — verifies that serverChartConfigs.ts covers all HOC
- * chart types and that key props are threaded through.
+ * chart types, that key props are threaded through, AND that every scene-node
+ * type emitted by a canvas scene builder has a matching SVG converter case.
+ *
+ * The third check is the load-bearing one: client renders via canvas (using
+ * scene builders + canvas renderers); server renders via `SceneToSVG.tsx`
+ * which converts the same scene-node values to SVG. If a new node type lands
+ * on canvas without a corresponding case in `*SceneNodeToSVG`, server renders
+ * silently drop those marks. The bar `gradientFill` near-miss in 3.4.2 was
+ * exactly this class of bug — caught by the developer who shipped it; the
+ * next contributor needs the safety net.
  *
  * Fails CI if:
  * 1. An HOC chart exists but has no SSR config entry
  * 2. An SSR config entry references a chart that doesn't exist as an HOC
  * 3. Checked key props (currently oSort and cornerRadius) are missing from
  *    SSR configs for charts that support them
+ * 4. A scene builder emits a `type: "X"` value that no `*SceneNodeToSVG`
+ *    converter handles (canvas-only rendering — SSR drops the mark silently)
+ * 5. A `*SceneNodeToSVG` converter has a `case "X":` for a node type no
+ *    scene builder ever emits (dead SVG branch — usually means the scene
+ *    type was renamed/removed and the SVG side wasn't updated)
  *
  * Usage:
  *   node scripts/check-ssr-alignment.js
@@ -134,7 +148,156 @@ for (const { prop, charts, label } of PROP_CHECKS) {
   }
 }
 
-// ── 7. Report ──────────────────────────────────────────────────────────
+// ── 7. Scene type ↔ SceneToSVG parity ──────────────────────────────────
+//
+// The contract: every `type: "X"` discriminant in a frame's scene-node union
+// must have a matching `case "X":` branch in the corresponding
+// `*SceneNodeToSVG` converter, and vice versa. Drift in either direction is
+// a bug — canvas-only types render blank under SSR; SVG-only branches are
+// dead code or rename leftovers.
+//
+// Source of truth: the four scene-node type-union files. Each frame's union
+// (e.g. `OrdinalSceneNode = | RectSceneNode | PointSceneNode | …`) names its
+// member interfaces; each interface body declares its `type: "X"` literal.
+// We parse those, not the scene-builder files, because most builders call
+// shared helpers (`buildLineNode`, `buildRectNode` in SceneGraph.ts) where
+// the literal lives — the union is the only single point of truth.
+
+const STREAM_DIR = path.join(ROOT, "src/components/stream")
+const SCENE_TO_SVG = path.join(STREAM_DIR, "SceneToSVG.tsx")
+
+const FRAMES = {
+  xy:      { typesFile: "types.ts",        unionName: "SceneNode",        svgFn: "xySceneNodeToSVG" },
+  ordinal: { typesFile: "ordinalTypes.ts", unionName: "OrdinalSceneNode", svgFn: "ordinalSceneNodeToSVG" },
+  network: { typesFile: "networkTypes.ts", unionName: "NetworkSceneNode", svgFn: "networkSceneNodeToSVG" },
+  geo:     { typesFile: "geoTypes.ts",     unionName: "GeoSceneNode",     svgFn: "geoSceneNodeToSVG" },
+}
+
+// Type-discriminant strings that legitimately appear on one side only.
+// Each entry needs a one-line justification.
+const PARITY_EXCEPTIONS = {
+  // canvas-only (no SSR equivalent yet) — none currently.
+  canvasOnly: new Set([]),
+  // SVG-only — case branches that aren't scene-node `type` discriminants.
+  svgOnly: new Set([
+    // Network edge sub-types live on a separate union (`NetworkSceneEdge`)
+    // and are handled by `networkSceneEdgeToSVG`. They appear in the rect/
+    // node converter only as imported references, so the parity check
+    // shouldn't expect them in `networkSceneNodeToSVG`.
+    "bezier", "curved", "ribbon",
+    // "top" / "bottom" / "left" / "right" are `roundedEdge` discriminator
+    // values inside the rect branch's inner switch, not top-level scene
+    // types. The case-label parser can't distinguish nested switches.
+    "top", "bottom", "left", "right",
+  ]),
+}
+
+/** Type-files that hold scene-node interfaces, indexed by unqualified file name. */
+const TYPES_FILES = Object.values(FRAMES).map(f => f.typesFile)
+
+/**
+ * Build a global map of `interfaceName → type-discriminant string` by
+ * scanning every scene-node interface across all four type files. Cross-
+ * frame reuse (e.g. ordinal's union references PointSceneNode declared in
+ * types.ts) resolves through this map.
+ */
+function buildInterfaceTypeMap() {
+  const map = new Map()
+  for (const file of TYPES_FILES) {
+    const src = fs.readFileSync(path.join(STREAM_DIR, file), "utf8")
+    // Match `export interface NAME { ... type: "X" ... }` non-greedily on
+    // the body — the [^}]* prevents bleeding into the next interface.
+    const re = /export\s+interface\s+(\w+(?:Node|Edge))\s*\{[^}]*?\btype:\s*"(\w+)"/gs
+    let m
+    while ((m = re.exec(src))) {
+      map.set(m[1], m[2])
+    }
+  }
+  return map
+}
+
+/** Parse the named union to a list of member interface names. */
+function extractUnionMembers(source, unionName) {
+  // `export type NAME = | A | B | ...` or `= A | B`. Match until the next
+  // top-level `\n\n` or `\nexport` to avoid running past the union.
+  const re = new RegExp(`export\\s+type\\s+${unionName}\\s*=([\\s\\S]*?)(?:\\n\\n|\\nexport)`, "m")
+  const m = re.exec(source)
+  if (!m) return []
+  // Members appear as `| FooNode` or just `FooNode`. Pull everything that
+  // looks like a SceneNode/Edge interface name.
+  return m[1].match(/\w+(?:Node|Edge)/g) || []
+}
+
+/** Extract every `case "X":` literal inside a named function body. */
+function extractCaseLabels(source, functionName) {
+  const declRe = new RegExp(`(?:export\\s+)?function\\s+${functionName}\\b`, "g")
+  const declMatch = declRe.exec(source)
+  if (!declMatch) return new Set()
+  // Brace-balance walk from the start of the function body.
+  let i = source.indexOf("{", declMatch.index)
+  if (i < 0) return new Set()
+  let depth = 0
+  const start = i
+  for (; i < source.length; i++) {
+    if (source[i] === "{") depth++
+    else if (source[i] === "}") {
+      depth--
+      if (depth === 0) break
+    }
+  }
+  const body = source.slice(start, i + 1)
+  const cases = new Set()
+  const caseRe = /\bcase\s+"(\w+)":/g
+  let cm
+  while ((cm = caseRe.exec(body))) cases.add(cm[1])
+  return cases
+}
+
+console.log("\n[scene parity] checking each frame's canvas ↔ SVG type coverage")
+
+const sceneToSvgSrc = fs.readFileSync(SCENE_TO_SVG, "utf8")
+const interfaceToType = buildInterfaceTypeMap()
+
+for (const [frame, { typesFile, unionName, svgFn }] of Object.entries(FRAMES)) {
+  const typesPath = path.join(STREAM_DIR, typesFile)
+  if (!fs.existsSync(typesPath)) continue
+  const typesSrc = fs.readFileSync(typesPath, "utf8")
+
+  const memberNames = extractUnionMembers(typesSrc, unionName)
+  const emitted = new Set()
+  for (const memberName of memberNames) {
+    const t = interfaceToType.get(memberName)
+    if (t) emitted.add(t)
+    else {
+      // Member referenced in the union but no interface body found — could
+      // be a re-export or namespace import we can't resolve statically.
+      // Surface it as a check-script limitation, not a hard failure.
+      console.warn(`  · ${frame}: union member "${memberName}" has no resolvable type discriminant — coverage may be incomplete for this type.`)
+    }
+  }
+
+  const handled = extractCaseLabels(sceneToSvgSrc, svgFn)
+
+  // Canvas-only drift — emitted by a scene builder, not handled in SVG
+  for (const type of emitted) {
+    if (PARITY_EXCEPTIONS.canvasOnly.has(type)) continue
+    if (!handled.has(type)) {
+      errors.push(`Scene type "${type}" is part of the ${frame} ${unionName} union but ${svgFn} has no \`case "${type}":\` branch — SSR will drop these marks. Add a branch in src/components/stream/SceneToSVG.tsx, or list the type in PARITY_EXCEPTIONS.canvasOnly with justification.`)
+    }
+  }
+
+  // SVG-only drift — handled in SVG, not emitted by any builder
+  for (const type of handled) {
+    if (PARITY_EXCEPTIONS.svgOnly.has(type)) continue
+    if (!emitted.has(type)) {
+      errors.push(`${svgFn} has a \`case "${type}":\` branch but no scene-node interface in the ${frame} ${unionName} union declares \`type: "${type}"\` — likely dead code. Remove the case, or list the type in PARITY_EXCEPTIONS.svgOnly with justification.`)
+    }
+  }
+
+  console.log(`  ${frame}: ${emitted.size} emitted / ${handled.size} handled (${[...emitted].sort().join(", ")})`)
+}
+
+// ── 8. Report ──────────────────────────────────────────────────────────
 
 if (errors.length > 0) {
   console.error("\nSSR Alignment Check FAILED:\n")
@@ -142,10 +305,10 @@ if (errors.length > 0) {
     console.error(`  ✗ ${err}`)
   }
   console.error(`\n${errors.length} issue(s) found.`)
-  console.error("Fix these in src/components/server/serverChartConfigs.ts and/or validationMap.ts")
+  console.error("Fix in src/components/server/serverChartConfigs.ts, validationMap.ts, or src/components/stream/SceneToSVG.tsx.")
   process.exit(1)
 } else {
-  console.log("✅ SSR alignment check passed")
+  console.log("\n✅ SSR alignment check passed")
   console.log(`   ${hocsOnDisk.size} HOC charts on disk`)
   console.log(`   ${ssrNames.size} SSR configs (+ ${SSR_EXCLUDED.size} intentionally excluded)`)
   console.log(`   ${validationNames.size} validation map entries`)

--- a/scripts/check-ssr-alignment.js
+++ b/scripts/check-ssr-alignment.js
@@ -185,14 +185,14 @@ const PARITY_EXCEPTIONS = {
   canvasOnly: new Set([]),
   // SVG-only — case branches that aren't scene-node `type` discriminants.
   svgOnly: new Set([
-    // Network edge sub-types live on a separate union (`NetworkSceneEdge`)
-    // and are handled by `networkSceneEdgeToSVG`. They appear in the rect/
-    // node converter only as imported references, so the parity check
-    // shouldn't expect them in `networkSceneNodeToSVG`.
-    "bezier", "curved", "ribbon",
     // "top" / "bottom" / "left" / "right" are `roundedEdge` discriminator
-    // values inside the rect branch's inner switch, not top-level scene
-    // types. The case-label parser can't distinguish nested switches.
+    // values inside the ordinal rect branch's inner `switch (roundedEdge)`,
+    // not top-level scene types. The case-label parser walks the whole
+    // function body so it picks them up; this exemption tells the parity
+    // check to ignore them. Network edge sub-types (`bezier` / `curved` /
+    // `ribbon`) live in `networkSceneEdgeToSVG`, which the parity pass does
+    // not parse today — if/when edge parity is added, those will need
+    // separate handling, not a one-sided exception here.
     "top", "bottom", "left", "right",
   ]),
 }

--- a/src/__tests__/scenarios/ssr-alignment.test.ts
+++ b/src/__tests__/scenarios/ssr-alignment.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for the SSR alignment check itself.
+ *
+ * The static check (`scripts/check-ssr-alignment.js`) is the load-bearing
+ * guard against canvas/SVG drift — the bar `gradientFill` near-miss in
+ * 3.4.2 was exactly the kind of bug it now prevents. These tests prove the
+ * script catches both drift directions and that the happy path stays green
+ * on the current tree.
+ *
+ * The simulation strategy: temporarily mutate `SceneToSVG.tsx` to inject a
+ * known drift, run the script, restore the file. Spawn-based to honor the
+ * script's `process.exit` semantics.
+ */
+import { spawnSync } from "child_process"
+import * as fs from "fs"
+import * as path from "path"
+import { afterEach, describe, expect, it } from "vitest"
+
+const ROOT = path.resolve(__dirname, "../../..")
+const SCRIPT = path.join(ROOT, "scripts/check-ssr-alignment.js")
+const SCENE_TO_SVG = path.join(ROOT, "src/components/stream/SceneToSVG.tsx")
+
+function runCheck() {
+  return spawnSync(process.execPath, [SCRIPT], { encoding: "utf-8", cwd: ROOT })
+}
+
+function withSceneToSVGMutation(mutate: (src: string) => string, fn: () => void) {
+  const original = fs.readFileSync(SCENE_TO_SVG, "utf-8")
+  try {
+    fs.writeFileSync(SCENE_TO_SVG, mutate(original))
+    fn()
+  } finally {
+    fs.writeFileSync(SCENE_TO_SVG, original)
+  }
+}
+
+describe("check-ssr-alignment.js", () => {
+  // Belt-and-suspenders: even if a test throws mid-mutation, the next test's
+  // afterEach restores from the live filesystem.
+  afterEach(() => { /* withSceneToSVGMutation restores on its own */ })
+
+  it("passes on the current tree (parity is intact)", () => {
+    const result = runCheck()
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain("SSR alignment check passed")
+    // Quantitative invariant — every frame should report >0 emitted/handled.
+    expect(result.stdout).toMatch(/xy:\s+\d+ emitted \/ \d+ handled/)
+    expect(result.stdout).toMatch(/ordinal:\s+\d+ emitted \/ \d+ handled/)
+    expect(result.stdout).toMatch(/network:\s+\d+ emitted \/ \d+ handled/)
+    expect(result.stdout).toMatch(/geo:\s+\d+ emitted \/ \d+ handled/)
+  })
+
+  it("fails when a scene-node type loses its SVG converter case (canvas-only drift)", () => {
+    withSceneToSVGMutation(
+      // Rename the candlestick case so the union still has the type but the
+      // converter no longer handles it. Drift direction: canvas → SVG.
+      src => src.replace(/case "candlestick": \{/, 'case "REMOVED-FOR-TEST": {'),
+      () => {
+        const result = runCheck()
+        expect(result.status).toBe(1)
+        expect(result.stderr).toContain('Scene type "candlestick" is part of the xy SceneNode union but xySceneNodeToSVG has no `case "candlestick":` branch')
+        expect(result.stderr).toContain("SSR will drop these marks")
+      }
+    )
+  })
+
+  it("fails when a converter has a case for a non-existent scene type (svg-only drift)", () => {
+    withSceneToSVGMutation(
+      // Inject a phantom case branch in xySceneNodeToSVG. The phantom name
+      // must be alphanumeric — the script's `case "(\w+)":` parser would
+      // silently skip a hyphenated name, masking the test. Drift direction:
+      // SVG → canvas (dead branch).
+      src => src.replace(/(case "point":)/, 'case "phantomForTest": return null\n    $1'),
+      () => {
+        const result = runCheck()
+        expect(result.status).toBe(1)
+        expect(result.stderr).toContain('xySceneNodeToSVG has a `case "phantomForTest":` branch but no scene-node interface in the xy SceneNode union declares')
+        expect(result.stderr).toContain("likely dead code")
+      }
+    )
+  })
+
+  it("restores parity after both simulated drifts (test isolation sanity check)", () => {
+    // If the previous tests' restore logic ever leaked, the green pass at
+    // the top would have failed. This test reasserts the green state at the
+    // end of the file as an explicit ordering guard.
+    const result = runCheck()
+    expect(result.status).toBe(0)
+  })
+})

--- a/src/__tests__/scenarios/ssr-alignment.test.ts
+++ b/src/__tests__/scenarios/ssr-alignment.test.ts
@@ -7,38 +7,45 @@
  * script catches both drift directions and that the happy path stays green
  * on the current tree.
  *
- * The simulation strategy: temporarily mutate `SceneToSVG.tsx` to inject a
- * known drift, run the script, restore the file. Spawn-based to honor the
- * script's `process.exit` semantics.
+ * The simulation strategy: copy `SceneToSVG.tsx` to a temporary file, mutate
+ * that copy to inject known drift, and point the script at it via env var.
+ * This avoids rewriting tracked source while Vitest runs suites in parallel.
+ * Spawn-based to honor the script's `process.exit` semantics.
  */
 import { spawnSync } from "child_process"
 import * as fs from "fs"
+import * as os from "os"
 import * as path from "path"
-import { afterEach, describe, expect, it } from "vitest"
+import { describe, expect, it } from "vitest"
 
 const ROOT = path.resolve(__dirname, "../../..")
 const SCRIPT = path.join(ROOT, "scripts/check-ssr-alignment.js")
 const SCENE_TO_SVG = path.join(ROOT, "src/components/stream/SceneToSVG.tsx")
 
-function runCheck() {
-  return spawnSync(process.execPath, [SCRIPT], { encoding: "utf-8", cwd: ROOT })
+function runCheck(sceneToSvgPath?: string) {
+  return spawnSync(process.execPath, [SCRIPT], {
+    encoding: "utf-8",
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      ...(sceneToSvgPath ? { SEMIOTIC_SCENE_TO_SVG: sceneToSvgPath } : {}),
+    },
+  })
 }
 
-function withSceneToSVGMutation(mutate: (src: string) => string, fn: () => void) {
+function withSceneToSVGMutation(mutate: (src: string) => string, fn: (sceneToSvgPath: string) => void) {
   const original = fs.readFileSync(SCENE_TO_SVG, "utf-8")
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "semiotic-ssr-alignment-"))
+  const tempSceneToSvg = path.join(tempDir, "SceneToSVG.tsx")
   try {
-    fs.writeFileSync(SCENE_TO_SVG, mutate(original))
-    fn()
+    fs.writeFileSync(tempSceneToSvg, mutate(original))
+    fn(tempSceneToSvg)
   } finally {
-    fs.writeFileSync(SCENE_TO_SVG, original)
+    fs.rmSync(tempDir, { recursive: true, force: true })
   }
 }
 
 describe("check-ssr-alignment.js", () => {
-  // Belt-and-suspenders: even if a test throws mid-mutation, the next test's
-  // afterEach restores from the live filesystem.
-  afterEach(() => { /* withSceneToSVGMutation restores on its own */ })
-
   it("passes on the current tree (parity is intact)", () => {
     const result = runCheck()
     expect(result.status).toBe(0)
@@ -55,8 +62,8 @@ describe("check-ssr-alignment.js", () => {
       // Rename the candlestick case so the union still has the type but the
       // converter no longer handles it. Drift direction: canvas → SVG.
       src => src.replace(/case "candlestick": \{/, 'case "REMOVED-FOR-TEST": {'),
-      () => {
-        const result = runCheck()
+      (sceneToSvgPath) => {
+        const result = runCheck(sceneToSvgPath)
         expect(result.status).toBe(1)
         expect(result.stderr).toContain('Scene type "candlestick" is part of the xy SceneNode union but xySceneNodeToSVG has no `case "candlestick":` branch')
         expect(result.stderr).toContain("SSR will drop these marks")
@@ -71,8 +78,8 @@ describe("check-ssr-alignment.js", () => {
       // silently skip a hyphenated name, masking the test. Drift direction:
       // SVG → canvas (dead branch).
       src => src.replace(/(case "point":)/, 'case "phantomForTest": return null\n    $1'),
-      () => {
-        const result = runCheck()
+      (sceneToSvgPath) => {
+        const result = runCheck(sceneToSvgPath)
         expect(result.status).toBe(1)
         expect(result.stderr).toContain('xySceneNodeToSVG has a `case "phantomForTest":` branch but no scene-node interface in the xy SceneNode union declares')
         expect(result.stderr).toContain("likely dead code")

--- a/src/components/LinkedCharts.tsx
+++ b/src/components/LinkedCharts.tsx
@@ -1,6 +1,6 @@
 "use client"
 import * as React from "react"
-import { createContext, useContext, useEffect, useId, useMemo, useRef, useState, useCallback } from "react"
+import { createContext, useContext, useEffect, useId, useLayoutEffect, useMemo, useRef, useState, useCallback } from "react"
 import { SelectionProvider, useSelectionSelector } from "./store/SelectionStore"
 import type { ResolutionMode } from "./store/SelectionStore"
 import { ObservationProvider } from "./store/ObservationStore"
@@ -47,6 +47,7 @@ interface LinkedCategoryRegistry {
 }
 
 const LinkedCategoryRegistryContext = createContext<LinkedCategoryRegistry | null>(null)
+const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect
 
 function uniqueCategories(categories: string[]): string[] {
   const seen = new Set<string>()
@@ -78,12 +79,12 @@ export function useLinkedChartCategories(categories: string[]): void {
   }
   const stableCategories = stableCategoriesRef.current
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!registry) return
     return () => registry.unregisterCategories(id)
   }, [registry, id])
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!registry) return
     registry.registerCategories(id, stableCategories)
   }, [registry, id, stableCategories])

--- a/src/components/charts/shared/hooks.test.ts
+++ b/src/components/charts/shared/hooks.test.ts
@@ -16,6 +16,7 @@ import { ObservationProvider } from "../../store/ObservationStore"
 import { CategoryColorProvider } from "../../CategoryColors"
 import { setCrosshairPosition, clearCrosshairPosition, useCrosshairPosition, unlockCrosshair } from "../../store/LinkedCrosshairStore"
 import type { Datum } from "./datumTypes"
+import { useStreamingLegend } from "./useStreamingLegend"
 
 /**
  * Wrapper that provides the store providers needed by hooks that
@@ -125,6 +126,31 @@ describe("useColorScale", () => {
     })
     expect(result.current!("A")).toBe("#ff0000")
     expect(result.current!("B")).toBe("#00ff00")
+  })
+})
+
+// ── useStreamingLegend ───────────────────────────────────────────────────
+
+describe("useStreamingLegend", () => {
+  it("uses CategoryColorProvider colors for push-mode legend swatches", () => {
+    const { result } = renderHook(
+      () => useStreamingLegend({
+        isPushMode: true,
+        colorBy: "cat",
+        colorScheme: undefined,
+        showLegend: true,
+      }),
+      { wrapper: createWrapper({ categoryColors: { A: "#ff0000", B: "#00ff00" } }) }
+    )
+
+    act(() => {
+      const push = result.current.wrapPush(() => {})
+      push({ cat: "A" })
+      push({ cat: "B" })
+    })
+
+    const items = result.current.streamingLegend?.legendGroups[0].items
+    expect(items?.map(item => item.color)).toEqual(["#ff0000", "#00ff00"])
   })
 })
 

--- a/src/components/charts/shared/useStreamingLegend.ts
+++ b/src/components/charts/shared/useStreamingLegend.ts
@@ -3,7 +3,7 @@ import type { Datum } from "./datumTypes"
 
 import { useRef, useState, useCallback, useMemo } from "react"
 import { createLegend } from "./legendUtils"
-import { createColorScale, getColor } from "./colorUtils"
+import { getColor, STREAMING_PALETTE } from "./colorUtils"
 import type { Accessor } from "./types"
 import { useThemeCategorical, type LegendPosition } from "./hooks"
 import { useLinkedChartCategories } from "../../LinkedCharts"
@@ -122,11 +122,10 @@ export function useStreamingLegend({
   const linkedCategories = isPushMode && colorBy ? orderedRef.current : []
   useLinkedChartCategories(linkedCategories)
 
-  // Build legend from discovered categories. Color resolution mirrors
-  // `useColorScale` (categoryColors → user colorScheme → theme categorical
-  // → d3 "category10") so legend swatches always match the marks the
-  // chart's own colorScale produces — including the case where neither
-  // CategoryColorProvider nor LinkedCharts is wrapping the chart.
+  // Build legend from discovered categories. Color resolution mirrors the
+  // push-mode mark path: CategoryColorProvider/LinkedCharts colors win; if
+  // there is no provider, the stream frame falls back to explicit palette,
+  // then theme categorical, then STREAMING_PALETTE.
   const streamingLegend = useMemo(() => {
     if (!isPushMode || !colorBy || showLegend === false) return undefined
     // Use version to trigger recompute (consumed by useMemo dep)
@@ -134,15 +133,18 @@ export function useStreamingLegend({
     const categories = orderedRef.current
     if (categories.length === 0) return undefined
 
-    const effectiveScheme: string | string[] = colorScheme
-      ?? (themeCategorical && themeCategorical.length > 0 ? themeCategorical : undefined)
-      ?? "category10"
+    const palette = Array.isArray(colorScheme) && colorScheme.length > 0
+      ? colorScheme
+      : (themeCategorical && themeCategorical.length > 0 ? themeCategorical : STREAMING_PALETTE)
+    const colorMap = new Map<string, string>()
+    for (let i = 0; i < categories.length; i++) {
+      colorMap.set(categories[i], palette[i % palette.length])
+    }
 
     // Build synthetic data so createLegend can extract categories
     const syntheticColorBy = typeof colorBy === "string" ? colorBy : "__streamCat"
     const syntheticData = categories.map(cat => ({ [syntheticColorBy]: cat }))
-    const fallbackScale = createColorScale(syntheticData, syntheticColorBy, effectiveScheme)
-    const syntheticScale = (v: string) => categoryColors?.[v] || fallbackScale(v) || "#999"
+    const syntheticScale = (v: string) => categoryColors?.[v] || colorMap.get(v) || "#999"
 
     return createLegend({
       data: syntheticData,

--- a/src/components/charts/shared/useStreamingLegend.ts
+++ b/src/components/charts/shared/useStreamingLegend.ts
@@ -3,7 +3,7 @@ import type { Datum } from "./datumTypes"
 
 import { useRef, useState, useCallback, useMemo } from "react"
 import { createLegend } from "./legendUtils"
-import { getColor, STREAMING_PALETTE } from "./colorUtils"
+import { createColorScale, getColor, STREAMING_PALETTE } from "./colorUtils"
 import type { Accessor } from "./types"
 import { useThemeCategorical, type LegendPosition } from "./hooks"
 import { useLinkedChartCategories } from "../../LinkedCharts"
@@ -133,18 +133,22 @@ export function useStreamingLegend({
     const categories = orderedRef.current
     if (categories.length === 0) return undefined
 
-    const palette = Array.isArray(colorScheme) && colorScheme.length > 0
+    // Resolution order matches `useColorScale` so the legend swatch and the
+    // mark always agree: explicit array `colorScheme` → string scheme name
+    // (e.g. "category10") → theme categorical → STREAMING_PALETTE. The string
+    // case was previously ignored — `createColorScale` resolves it via d3
+    // `scaleOrdinal` which understands the named schemes.
+    const effectiveScheme: string | string[] = Array.isArray(colorScheme) && colorScheme.length > 0
       ? colorScheme
-      : (themeCategorical && themeCategorical.length > 0 ? themeCategorical : STREAMING_PALETTE)
-    const colorMap = new Map<string, string>()
-    for (let i = 0; i < categories.length; i++) {
-      colorMap.set(categories[i], palette[i % palette.length])
-    }
+      : (typeof colorScheme === "string" && colorScheme.length > 0)
+        ? colorScheme
+        : (themeCategorical && themeCategorical.length > 0 ? themeCategorical : STREAMING_PALETTE)
 
     // Build synthetic data so createLegend can extract categories
     const syntheticColorBy = typeof colorBy === "string" ? colorBy : "__streamCat"
     const syntheticData = categories.map(cat => ({ [syntheticColorBy]: cat }))
-    const syntheticScale = (v: string) => categoryColors?.[v] || colorMap.get(v) || "#999"
+    const fallbackScale = createColorScale(syntheticData, syntheticColorBy, effectiveScheme)
+    const syntheticScale = (v: string) => categoryColors?.[v] || fallbackScale(v) || "#999"
 
     return createLegend({
       data: syntheticData,

--- a/src/components/server/featureParity.test.tsx
+++ b/src/components/server/featureParity.test.tsx
@@ -40,13 +40,6 @@ import {
 const xyData = [{ x: 0, y: 10, s: "a" }, { x: 1, y: 20, s: "a" }, { x: 0, y: 5, s: "b" }, { x: 1, y: 25, s: "b" }]
 const ordinalData = [{ c: "A", v: 10 }, { c: "B", v: 20 }, { c: "C", v: 15 }]
 const networkEdges = [{ source: "a", target: "b" }, { source: "b", target: "c" }]
-const explicitLegend = {
-  legendGroups: [{
-    label: "Series",
-    type: "fill" as const,
-    items: [{ label: "a", color: "#ff0000" }, { label: "b", color: "#00ff00" }],
-  }],
-}
 
 // ── Per-frame render helpers — keep the call shape uniform so the matrix
 //    body reads as feature-x-frame, not props-shape-x-frame.
@@ -176,16 +169,36 @@ describe("SSR feature parity: annotations", () => {
 
 // ── Legend ─────────────────────────────────────────────────────────────
 //
-// Ordinal: builds the legend from `colorAccessor` + `showLegend`. XY:
-// requires an explicit `legend` prop (auto-construction from colorAccessor
-// + data isn't wired through SSR). Network/Geo: no SSR legend support today.
+// All four frames now auto-build a categorical legend from a color-by
+// accessor + `showLegend`. Each also honors a caller-supplied pre-rendered
+// ReactNode passed via `props.legend` (the legend from a config object form
+// like `{legendGroups}` is not yet wired through SSR — see OUTSTANDING_WORK).
+// The "explicit ReactNode wins over auto-build" tests below assert that
+// contract by using a marker only the explicit ReactNode would produce.
+
+const EXPLICIT_LEGEND_MARKER = "data-explicit-legend-marker"
+const explicitReactNodeLegend = (<g data-explicit-legend-marker="yes"><text>Custom</text></g>)
 
 describe("SSR feature parity: legend", () => {
-  it("xy renders legend when an explicit `legend` prop is provided", () => {
+  it("xy: explicit ReactNode `legend` prop wins over auto-build", () => {
+    // If SSR ignored `props.legend` and only used auto-build, the marker
+    // wouldn't appear in the output. Asserting the marker locks down the
+    // passthrough contract.
     const svg = FRAME_RENDERERS.xy({
-      colorAccessor: "s", showLegend: true, legend: explicitLegend,
+      colorAccessor: "s",
+      showLegend: true,
+      legend: explicitReactNodeLegend,
     })
     expect(svg).toContain("semiotic-legend")
+    expect(svg).toContain(EXPLICIT_LEGEND_MARKER)
+  })
+
+  it("xy: auto-build includes the legend group element when no explicit legend", () => {
+    const svg = FRAME_RENDERERS.xy({ colorAccessor: "s", showLegend: true })
+    expect(svg).toContain("semiotic-legend")
+    // Marker absent → confirms this came from the auto-build, not a leaked
+    // explicit legend from a previous test.
+    expect(svg).not.toContain(EXPLICIT_LEGEND_MARKER)
   })
 
   it("xy auto-constructs legend from colorAccessor + showLegend (no explicit legend prop)", () => {

--- a/src/components/server/featureParity.test.tsx
+++ b/src/components/server/featureParity.test.tsx
@@ -189,8 +189,13 @@ describe("SSR feature parity: legend", () => {
       showLegend: true,
       legend: explicitReactNodeLegend,
     })
-    expect(svg).toContain("semiotic-legend")
+    // Wrapper provides the stable `id="legend"` slot; the user's ReactNode is
+    // inside it. The auto-built `semiotic-legend` class would only appear if
+    // SSR also ran the auto-build path — assert it's absent to lock down the
+    // "explicit wins over auto" contract.
+    expect(svg).toContain(`id="legend"`)
     expect(svg).toContain(EXPLICIT_LEGEND_MARKER)
+    expect(svg).not.toContain("semiotic-legend")
   })
 
   it("xy: auto-build includes the legend group element when no explicit legend", () => {

--- a/src/components/server/featureParity.test.tsx
+++ b/src/components/server/featureParity.test.tsx
@@ -118,10 +118,10 @@ describe("SSR feature parity: grid", () => {
 
 // ── Annotations ────────────────────────────────────────────────────────
 //
-// XY and Ordinal: full support. Network and Geo: known SSR gaps — the
-// `annotations` prop is accepted but `*SceneNodeToSVG` doesn't render the
-// overlay annotations through. Marked `.todo` until support lands.
-// Tracked in OUTSTANDING_WORK.md → Future work #1.
+// This matrix verifies SSR annotation overlays across frame types.
+// XY and Ordinal render threshold-style annotations; Network renders
+// pixel-coordinate annotations; Geo renders projected `[lon, lat]`
+// annotations when a fitted geography is available.
 
 describe("SSR feature parity: annotations", () => {
   it("xy renders annotation overlay group", () => {

--- a/src/components/server/featureParity.test.tsx
+++ b/src/components/server/featureParity.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * SSR feature parity matrix.
+ *
+ * Each Stream Frame (XY, Ordinal, Network, Geo) supports a set of overlay
+ * features beyond chart marks: title/desc, axes, grid lines, legend,
+ * annotations, background and foreground graphics. The canvas path renders
+ * these client-side; the server path goes through `renderToStaticSVG` →
+ * `SVGOverlay` / `OrdinalSVGOverlay` / per-frame helpers.
+ *
+ * History: the bar `gradientFill` near-miss in 3.4.2 and an earlier
+ * `backgroundGraphics` bug both lived through CI because integration tests
+ * only exercised one frame. This file enforces the parity contract by
+ * running every applicable (feature × frame) combination through SSR and
+ * asserting the feature shows up in the output.
+ *
+ * Tests that fail today are the items the contract surfaces — they're left
+ * as `it.todo()` with a comment pointing at the structural gap. When SSR
+ * support lands the test moves from `.todo` to a real assertion in the same
+ * sweep that wires the feature.
+ *
+ * Companion: `scripts/check-ssr-alignment.js` enforces scene-node parity at
+ * a structural level. This file enforces it at a behavior level — the two
+ * complement each other.
+ */
+
+// jsdom + react-dom/server polyfill, same shape as serverFeatures.test.tsx
+import { TextEncoder, TextDecoder } from "util"
+Object.assign(global, { TextEncoder, TextDecoder })
+
+import { describe, expect, it } from "vitest"
+import {
+  renderXYToStaticSVG,
+  renderOrdinalToStaticSVG,
+  renderNetworkToStaticSVG,
+  renderGeoToStaticSVG,
+} from "./renderToStaticSVG"
+
+// ── Fixtures ──────────────────────────────────────────────────────────
+
+const xyData = [{ x: 0, y: 10, s: "a" }, { x: 1, y: 20, s: "a" }, { x: 0, y: 5, s: "b" }, { x: 1, y: 25, s: "b" }]
+const ordinalData = [{ c: "A", v: 10 }, { c: "B", v: 20 }, { c: "C", v: 15 }]
+const networkEdges = [{ source: "a", target: "b" }, { source: "b", target: "c" }]
+const explicitLegend = {
+  legendGroups: [{
+    label: "Series",
+    type: "fill" as const,
+    items: [{ label: "a", color: "#ff0000" }, { label: "b", color: "#00ff00" }],
+  }],
+}
+
+// ── Per-frame render helpers — keep the call shape uniform so the matrix
+//    body reads as feature-x-frame, not props-shape-x-frame.
+
+const FRAME_RENDERERS = {
+  xy: (extra: Record<string, unknown> = {}) => renderXYToStaticSVG({
+    chartType: "line", data: xyData, xAccessor: "x", yAccessor: "y", size: [400, 300], ...extra,
+  } as any),
+  ordinal: (extra: Record<string, unknown> = {}) => renderOrdinalToStaticSVG({
+    chartType: "bar", data: ordinalData, oAccessor: "c", rAccessor: "v", size: [400, 300], ...extra,
+  } as any),
+  network: (extra: Record<string, unknown> = {}) => renderNetworkToStaticSVG({
+    chartType: "force", edges: networkEdges, nodeIDAccessor: "id", size: [400, 300], ...extra,
+  } as any),
+  geo: (extra: Record<string, unknown> = {}) => renderGeoToStaticSVG({
+    chartType: "geo", areas: [], size: [400, 300], ...extra,
+  } as any),
+}
+
+// ── Title / description (accessibility) ───────────────────────────────
+//
+// Already covered in serverFeatures.test.tsx for XY and Network. This block
+// re-asserts across every frame so the matrix is uniform — losing title in
+// any frame would be a regression visible from one place.
+
+describe("SSR feature parity: title", () => {
+  it.each([
+    ["xy"],
+    ["ordinal"],
+    ["network"],
+    ["geo"],
+  ] as const)("%s renders <title> when title prop is set", (frame) => {
+    const svg = FRAME_RENDERERS[frame]({ title: "Parity Title" })
+    expect(svg).toMatch(/<title[^>]*>Parity Title<\/title>/)
+  })
+})
+
+// ── Axes ───────────────────────────────────────────────────────────────
+//
+// Network and Geo don't render axes by default (no continuous scale on either
+// axis), so they're not in the matrix.
+
+describe("SSR feature parity: axes", () => {
+  it("xy renders the axes group when showAxes is true", () => {
+    const svg = FRAME_RENDERERS.xy({ showAxes: true })
+    expect(svg).toMatch(/class="stream-axes"|id="axes"/)
+  })
+
+  it("ordinal renders the axes group when showAxes is true", () => {
+    const svg = FRAME_RENDERERS.ordinal({ showAxes: true })
+    expect(svg).toMatch(/class="ordinal-axes"|id="axes"/)
+  })
+})
+
+// ── Grid lines ─────────────────────────────────────────────────────────
+//
+// XY supports `showGrid`. Ordinal supports it for vertical/horizontal
+// projections (radial pie/donut intentionally don't). Network and Geo: n/a.
+
+describe("SSR feature parity: grid", () => {
+  it("xy renders grid lines when showGrid is true", () => {
+    const svg = FRAME_RENDERERS.xy({ showGrid: true })
+    expect(svg).toContain("semiotic-grid")
+  })
+
+  it("ordinal vertical renders grid lines when showGrid is true", () => {
+    const svg = FRAME_RENDERERS.ordinal({ showGrid: true, projection: "vertical" })
+    expect(svg).toContain("semiotic-grid")
+  })
+
+  it("ordinal radial does NOT render grid (intentional — no orthogonal axes)", () => {
+    const svg = FRAME_RENDERERS.ordinal({ showGrid: true, chartType: "donut", projection: "radial" })
+    expect(svg).not.toContain("semiotic-grid")
+  })
+})
+
+// ── Annotations ────────────────────────────────────────────────────────
+//
+// XY and Ordinal: full support. Network and Geo: known SSR gaps — the
+// `annotations` prop is accepted but `*SceneNodeToSVG` doesn't render the
+// overlay annotations through. Marked `.todo` until support lands.
+// Tracked in OUTSTANDING_WORK.md → Future work #1.
+
+describe("SSR feature parity: annotations", () => {
+  it("xy renders annotation overlay group", () => {
+    const svg = FRAME_RENDERERS.xy({ annotations: [{ type: "y-threshold", value: 15, label: "Goal" }] })
+    expect(svg).toContain("semiotic-annotations")
+    expect(svg).toContain("Goal")
+  })
+
+  it("ordinal renders annotation overlay group", () => {
+    const svg = FRAME_RENDERERS.ordinal({ annotations: [{ type: "y-threshold", value: 15, label: "Goal" }] })
+    expect(svg).toContain("semiotic-annotations")
+    expect(svg).toContain("Goal")
+  })
+
+  it("network renders annotation overlay group with pixel-coord annotations", () => {
+    // Network has no continuous x/y scale — annotations use raw pixel
+    // coordinates which staticAnnotations passes through when no scales
+    // are supplied.
+    const svg = FRAME_RENDERERS.network({
+      annotations: [{ type: "label", x: 50, y: 50, label: "PROBE" }],
+    })
+    expect(svg).toContain("semiotic-annotations")
+    expect(svg).toContain("PROBE")
+  })
+
+  it("geo renders annotation overlay group with [lon, lat] coordinates", () => {
+    // Geo annotations use `coordinates: [lon, lat]`; the resolved
+    // projection from GeoPipelineStore.scales projects them to pixel space.
+    // Need at least one area for the projection to fit; an empty fixture
+    // hits the early-return path that doesn't render annotations.
+    const svg = renderGeoToStaticSVG({
+      chartType: "geo",
+      areas: [{
+        type: "Feature" as const,
+        geometry: { type: "Polygon" as const, coordinates: [[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]] },
+        properties: {},
+      }],
+      size: [400, 300],
+      annotations: [{ type: "label", coordinates: [5, 5], label: "PROBE" }],
+    } as any)
+    expect(svg).toContain("semiotic-annotations")
+    expect(svg).toContain("PROBE")
+  })
+})
+
+// ── Legend ─────────────────────────────────────────────────────────────
+//
+// Ordinal: builds the legend from `colorAccessor` + `showLegend`. XY:
+// requires an explicit `legend` prop (auto-construction from colorAccessor
+// + data isn't wired through SSR). Network/Geo: no SSR legend support today.
+
+describe("SSR feature parity: legend", () => {
+  it("xy renders legend when an explicit `legend` prop is provided", () => {
+    const svg = FRAME_RENDERERS.xy({
+      colorAccessor: "s", showLegend: true, legend: explicitLegend,
+    })
+    expect(svg).toContain("semiotic-legend")
+  })
+
+  it("xy auto-constructs legend from colorAccessor + showLegend (no explicit legend prop)", () => {
+    // renderXYFrame falls back to `colorAccessor || groupAccessor` and runs
+    // `extractCategories(data, accessor)` → `renderStaticLegend`. Asserting
+    // the parity with Ordinal's auto-build path.
+    const svg = FRAME_RENDERERS.xy({ colorAccessor: "s", showLegend: true })
+    expect(svg).toContain("semiotic-legend")
+  })
+
+  it("ordinal renders legend when colorAccessor + showLegend are set", () => {
+    const svg = FRAME_RENDERERS.ordinal({ colorAccessor: "c", showLegend: true })
+    expect(svg).toContain("semiotic-legend")
+  })
+
+  it("network auto-constructs legend from colorBy/nodeIDAccessor + showLegend", () => {
+    // Categories sourced from the node list (or derived from edges when
+    // nodes aren't provided directly). `renderNetworkFrame` runs them
+    // through `renderStaticLegend` and reserves margin for it.
+    const svg = FRAME_RENDERERS.network({
+      nodes: [{ id: "a" }, { id: "b" }, { id: "c" }],
+      colorBy: "id",
+      showLegend: true,
+    })
+    expect(svg).toContain("semiotic-legend")
+  })
+
+  it("geo auto-constructs legend from colorBy on points (proportional symbol map)", () => {
+    const svg = renderGeoToStaticSVG({
+      chartType: "geo",
+      points: [{ id: "p1", lon: 0, lat: 0, status: "high" }, { id: "p2", lon: 5, lat: 5, status: "low" }],
+      xAccessor: "lon",
+      yAccessor: "lat",
+      colorBy: "status",
+      showLegend: true,
+      size: [400, 300],
+    } as any)
+    expect(svg).toContain("semiotic-legend")
+  })
+
+  it("geo auto-constructs legend from colorBy on area features (choropleth)", () => {
+    // Areas are GeoJSON features; properties carry the colorBy field.
+    const svg = renderGeoToStaticSVG({
+      chartType: "geo",
+      areas: [
+        { type: "Feature", geometry: { type: "Polygon", coordinates: [[[0,0],[10,0],[10,10],[0,10],[0,0]]] }, properties: { region: "north" } },
+        { type: "Feature", geometry: { type: "Polygon", coordinates: [[[10,0],[20,0],[20,10],[10,10],[10,0]]] }, properties: { region: "south" } },
+      ],
+      colorBy: "region",
+      showLegend: true,
+      size: [400, 300],
+    } as any)
+    expect(svg).toContain("semiotic-legend")
+  })
+})
+
+// ── Background and foreground graphics ────────────────────────────────
+//
+// `backgroundGraphics` and `foregroundGraphics` are ReactNodes the user
+// places below/above chart marks. Each frame's render pipes both through
+// the inner-translated `<g>` group, matching the layering of SVGOverlay /
+// OrdinalSVGOverlay on the live path. The SVG-element marker is the React
+// node itself — assert by injecting an identifiable element and checking
+// for it in the rendered output.
+
+const BG_MARKER = "data-bg-marker"
+const FG_MARKER = "data-fg-marker"
+const bgNode = (<rect width="10" height="10" data-bg-marker="bg" />)
+const fgNode = (<rect width="10" height="10" data-fg-marker="fg" />)
+
+describe("SSR feature parity: backgroundGraphics", () => {
+  it.each([
+    ["xy"],
+    ["ordinal"],
+    ["network"],
+    ["geo"],
+  ] as const)("%s emits backgroundGraphics under chart marks in SSR", (frame) => {
+    const svg = FRAME_RENDERERS[frame]({ backgroundGraphics: bgNode })
+    expect(svg).toContain(BG_MARKER)
+  })
+})
+
+describe("SSR feature parity: foregroundGraphics", () => {
+  it.each([
+    ["xy"],
+    ["ordinal"],
+    ["network"],
+    ["geo"],
+  ] as const)("%s emits foregroundGraphics over chart marks in SSR", (frame) => {
+    const svg = FRAME_RENDERERS[frame]({ foregroundGraphics: fgNode })
+    expect(svg).toContain(FG_MARKER)
+  })
+})

--- a/src/components/server/renderToStaticSVG.tsx
+++ b/src/components/server/renderToStaticSVG.tsx
@@ -232,7 +232,7 @@ function wrapSVG(
           {titleText}
         </text>
       )}
-      {opts.legend && <g id={`${pfx}legend`} className="semiotic-legend">{opts.legend}</g>}
+      {opts.legend && <g id={`${pfx}legend`}>{opts.legend}</g>}
       {opts.outerElements}
     </svg>
   )

--- a/src/components/server/renderToStaticSVG.tsx
+++ b/src/components/server/renderToStaticSVG.tsx
@@ -232,7 +232,7 @@ function wrapSVG(
           {titleText}
         </text>
       )}
-      {opts.legend && <g id={`${pfx}legend`}>{opts.legend}</g>}
+      {opts.legend && <g id={`${pfx}legend`} className="semiotic-legend">{opts.legend}</g>}
       {opts.outerElements}
     </svg>
   )
@@ -403,8 +403,11 @@ function renderStreamXYFrame(props: StreamXYFrameProps & ThemeAwareProps): strin
     idPrefix: idPfx,
   }) : null
 
-  // Legend
-  const legend = props.showLegend ? (() => {
+  // Legend — auto-build from colorAccessor/groupAccessor + showLegend, OR
+  // honor a caller-supplied pre-rendered ReactNode. Config-object form
+  // (`{legendGroups}` / `{gradient}`) isn't yet wired through SSR; the
+  // categorical auto-build covers that case. Tracked in OUTSTANDING_WORK.md.
+  const xyAutoLegend = props.showLegend ? (() => {
     const colorAccessor = props.colorAccessor || props.groupAccessor
     const categories = extractCategories(props.data || [], colorAccessor)
     if (categories.length === 0) return null
@@ -419,6 +422,9 @@ function renderStreamXYFrame(props: StreamXYFrameProps & ThemeAwareProps): strin
       hasTitle: !!props.title,
     })
   })() : null
+  const legend = React.isValidElement(props.legend)
+    ? (props.legend as React.ReactNode)
+    : xyAutoLegend
 
   const content = (
     <>
@@ -646,20 +652,22 @@ function renderNetworkFrame(props: StreamNetworkFrameProps & ThemeAwareProps): s
   // Network legend: parity with the XY/Ordinal auto-build. Source is the
   // node list (one entry per unique colorBy/nodeIDAccessor value); layout-
   // produced node positions are irrelevant here, only the categorical set
-  // matters. `extractCategories` operates on the raw input data.
+  // matters. When nodes weren't supplied directly, fall back to the
+  // ALREADY-RESOLVED `edges` array — that's the output of
+  // `buildRealtimeEdges` which applied `sourceAccessor` / `targetAccessor`,
+  // so source/target are always normalized strings regardless of input shape.
   const networkLegend = props.showLegend ? (() => {
     const accessorName = (a: any): string | undefined =>
       typeof a === "string" ? a : undefined
     const colorAccessor = accessorName(props.colorBy) || accessorName(props.nodeIDAccessor)
     const legendSource = props.nodes && props.nodes.length > 0
       ? (props.nodes as any[])
-      // Fall back to deriving categories from edge endpoints when nodes
-      // weren't provided directly (a common shape for force charts).
       : Array.from(new Set(
-        (Array.isArray(props.edges) ? props.edges : []).flatMap((e: any) => [
-          typeof e.source === "string" ? e.source : e.source?.id,
-          typeof e.target === "string" ? e.target : e.target?.id,
-        ]).filter(Boolean)
+        edges.flatMap((e) => {
+          const src = typeof e.source === "string" ? e.source : (e.source as any)?.id
+          const tgt = typeof e.target === "string" ? e.target : (e.target as any)?.id
+          return [src, tgt]
+        }).filter(Boolean)
       )).map((id) => ({ id }))
     const categories = extractCategories(legendSource, colorAccessor)
     if (categories.length === 0) return null
@@ -674,6 +682,15 @@ function renderNetworkFrame(props: StreamNetworkFrameProps & ThemeAwareProps): s
       hasTitle: !!props.title,
     })
   })() : null
+
+  // If the caller supplied a pre-rendered legend element, prefer it over
+  // the auto-build. The frame's `legend` prop also accepts a config-object
+  // form ({legendGroups} or {gradient}) — those are SVGOverlay-side concerns
+  // and aren't yet wired through SSR; auto-build covers the categorical case
+  // either way. Tracked in OUTSTANDING_WORK.md → SSR feature parity.
+  const networkLegendOut = React.isValidElement((props as any).legend)
+    ? (props as any).legend as React.ReactNode
+    : networkLegend
 
   const content = (
     <>
@@ -693,7 +710,7 @@ function renderNetworkFrame(props: StreamNetworkFrameProps & ThemeAwareProps): s
       title: props.title, description: props.description, background: props.background,
       theme, innerTransform: `translate(${margin.left},${margin.top})`,
       innerWidth, innerHeight,
-      legend: networkLegend,
+      legend: networkLegendOut,
       idPrefix: props._idPrefix,
     })
   )
@@ -946,8 +963,10 @@ function renderOrdinalFrame(props: StreamOrdinalFrameProps & ThemeAwareProps): s
     idPrefix: idPfx,
   }) : null
 
-  // Legend
-  const legend = props.showLegend ? (() => {
+  // Legend — auto-build from colorAccessor/stackBy/groupBy + showLegend, OR
+  // honor caller-supplied pre-rendered ReactNode. See XY block for the
+  // contract; same pattern. Config-object form deferred (OUTSTANDING_WORK).
+  const ordinalAutoLegend = props.showLegend ? (() => {
     const colorAccessor = props.colorAccessor || props.stackBy || props.groupBy
     const categories = extractCategories(props.data || [], colorAccessor)
     if (categories.length === 0) return null
@@ -962,6 +981,9 @@ function renderOrdinalFrame(props: StreamOrdinalFrameProps & ThemeAwareProps): s
       hasTitle: !!props.title,
     })
   })() : null
+  const legend = React.isValidElement(props.legend)
+    ? (props.legend as React.ReactNode)
+    : ordinalAutoLegend
 
   const translateX = isRadial ? margin.left + width / 2 : margin.left
   const translateY = isRadial ? margin.top + height / 2 : margin.top
@@ -1097,14 +1119,13 @@ function renderGeoFrame(props: StreamGeoFrameProps & ThemeAwareProps): string {
     idPrefix: props._idPrefix,
   }) : null
 
-  // Geo legend: auto-build from colorBy on either points (proportional
-  // symbol maps) or areas (choropleth maps), or accept a fully-formed
-  // `legend` prop the caller pre-built. Matches the XY/Network pattern but
-  // sources categories from whichever data input is present.
-  const geoLegend = props.showLegend ? (() => {
-    const accessorName = (a: any): string | undefined =>
-      typeof a === "string" ? a : undefined
-    const colorAccessor = accessorName((props as any).colorBy)
+  // Geo legend: auto-build from `colorBy` on either points (proportional
+  // symbol maps) or areas (choropleth maps). `colorBy` is now declared on
+  // `StreamGeoFrameProps`; the previous `(props as any)` cast is gone.
+  // Matches the XY/Network auto-build pattern; categories come from whichever
+  // data input is present.
+  const geoAutoLegend = props.showLegend ? (() => {
+    const colorAccessor = typeof props.colorBy === "string" ? props.colorBy : undefined
     const legendSource: any[] = (() => {
       if (Array.isArray(props.points) && props.points.length > 0) return props.points as any[]
       if (Array.isArray(props.areas) && props.areas.length > 0) {
@@ -1127,6 +1148,13 @@ function renderGeoFrame(props: StreamGeoFrameProps & ThemeAwareProps): string {
       hasTitle: !!props.title,
     })
   })() : null
+
+  // Honor caller-supplied pre-rendered legend element. Config-object form
+  // (`{legendGroups}` / `{gradient}`) isn't yet wired through SSR; auto-build
+  // covers the categorical case. Tracked in OUTSTANDING_WORK.md.
+  const geoLegend = React.isValidElement(props.legend)
+    ? (props.legend as React.ReactNode)
+    : geoAutoLegend
 
   const content = (
     <>

--- a/src/components/server/renderToStaticSVG.tsx
+++ b/src/components/server/renderToStaticSVG.tsx
@@ -422,10 +422,12 @@ function renderStreamXYFrame(props: StreamXYFrameProps & ThemeAwareProps): strin
 
   const content = (
     <>
+      {props.backgroundGraphics}
       {grid}
-      {annotationNodes}
       {dataMarks}
       {axes}
+      {annotationNodes}
+      {props.foregroundGraphics}
     </>
   )
 
@@ -494,6 +496,15 @@ function renderNetworkFrame(props: StreamNetworkFrameProps & ThemeAwareProps): s
   const size: [number, number] = props.size || [500, 500]
   const defaultMargin = { top: 20, right: 20, bottom: 20, left: 20 }
   const margin = { ...defaultMargin, ...props.margin }
+  // Match the XY frame: reserve legend space BEFORE computing inner dims so
+  // the layout doesn't draw under the legend.
+  const legendPos = props.legendPosition
+  if (props.showLegend) {
+    if (!legendPos || legendPos === "right") margin.right = Math.max(margin.right, 100)
+    else if (legendPos === "left") margin.left = Math.max(margin.left, 100)
+    else if (legendPos === "bottom") margin.bottom = Math.max(margin.bottom, 70)
+    else if (legendPos === "top") margin.top = Math.max(margin.top, 40)
+  }
   const innerWidth = size[0] - margin.left - margin.right
   const innerHeight = size[1] - margin.top - margin.bottom
 
@@ -621,11 +632,57 @@ function renderNetworkFrame(props: StreamNetworkFrameProps & ThemeAwareProps): s
     .map((label, i) => networkLabelToSVG(label, i))
     .filter(Boolean)
 
+  // Network annotations: layout assigns absolute pixel coords to nodes, so
+  // overlay annotations use raw `x`/`y` numbers directly. `staticAnnotations`
+  // pixel-passthrough kicks in when no `scales.x`/`scales.y` is supplied.
+  const annotationNodes = props.annotations ? renderStaticAnnotations({
+    annotations: props.annotations,
+    scales: {},
+    layout: { width: innerWidth, height: innerHeight },
+    theme,
+    idPrefix: props._idPrefix,
+  }) : null
+
+  // Network legend: parity with the XY/Ordinal auto-build. Source is the
+  // node list (one entry per unique colorBy/nodeIDAccessor value); layout-
+  // produced node positions are irrelevant here, only the categorical set
+  // matters. `extractCategories` operates on the raw input data.
+  const networkLegend = props.showLegend ? (() => {
+    const accessorName = (a: any): string | undefined =>
+      typeof a === "string" ? a : undefined
+    const colorAccessor = accessorName(props.colorBy) || accessorName(props.nodeIDAccessor)
+    const legendSource = props.nodes && props.nodes.length > 0
+      ? (props.nodes as any[])
+      // Fall back to deriving categories from edge endpoints when nodes
+      // weren't provided directly (a common shape for force charts).
+      : Array.from(new Set(
+        (Array.isArray(props.edges) ? props.edges : []).flatMap((e: any) => [
+          typeof e.source === "string" ? e.source : e.source?.id,
+          typeof e.target === "string" ? e.target : e.target?.id,
+        ]).filter(Boolean)
+      )).map((id) => ({ id }))
+    const categories = extractCategories(legendSource, colorAccessor)
+    if (categories.length === 0) return null
+    return renderStaticLegend({
+      categories,
+      colorScheme: props.colorScheme,
+      theme,
+      position: props.legendPosition || "right",
+      totalWidth: size[0],
+      totalHeight: size[1],
+      margin,
+      hasTitle: !!props.title,
+    })
+  })() : null
+
   const content = (
     <>
+      {props.backgroundGraphics}
       {edgeElements}
       {nodeElements}
       {labelElements}
+      {annotationNodes}
+      {props.foregroundGraphics}
     </>
   )
 
@@ -636,7 +693,8 @@ function renderNetworkFrame(props: StreamNetworkFrameProps & ThemeAwareProps): s
       title: props.title, description: props.description, background: props.background,
       theme, innerTransform: `translate(${margin.left},${margin.top})`,
       innerWidth, innerHeight,
-        idPrefix: props._idPrefix,
+      legend: networkLegend,
+      idPrefix: props._idPrefix,
     })
   )
 }
@@ -910,10 +968,12 @@ function renderOrdinalFrame(props: StreamOrdinalFrameProps & ThemeAwareProps): s
 
   const content = (
     <>
+      {props.backgroundGraphics}
       {grid}
-      {annotationNodes}
       {dataMarks}
       {axes}
+      {annotationNodes}
+      {props.foregroundGraphics}
     </>
   )
 
@@ -938,6 +998,15 @@ function renderGeoFrame(props: StreamGeoFrameProps & ThemeAwareProps): string {
   const defaultMargin = { top: 10, right: 10, bottom: 10, left: 10 }
   const size: [number, number] = props.size || [props.width || 600, props.height || 400]
   const margin = { ...defaultMargin, ...props.margin }
+  // Reserve legend space BEFORE computing inner dims so the geo projection
+  // fits inside the post-legend area. Same shape as XY/Network.
+  const legendPos = props.legendPosition
+  if (props.showLegend) {
+    if (!legendPos || legendPos === "right") margin.right = Math.max(margin.right ?? 0, 100)
+    else if (legendPos === "left") margin.left = Math.max(margin.left ?? 0, 100)
+    else if (legendPos === "bottom") margin.bottom = Math.max(margin.bottom ?? 0, 70)
+    else if (legendPos === "top") margin.top = Math.max(margin.top ?? 0, 40)
+  }
   const width = size[0] - (margin.left ?? 0) - (margin.right ?? 0)
   const height = size[1] - (margin.top ?? 0) - (margin.bottom ?? 0)
 
@@ -975,8 +1044,30 @@ function renderGeoFrame(props: StreamGeoFrameProps & ThemeAwareProps): string {
   store.computeScene({ width, height })
 
   if (store.scene.length === 0) {
+    // Even when the data scene is empty, bg/fg graphics and annotations are
+    // valid surfaces a caller may have legitimately set. Pipe them through
+    // so the empty-data path doesn't silently drop them.
+    const emptyContent = (props.backgroundGraphics || props.foregroundGraphics || props.annotations)
+      ? (
+        <>
+          {props.backgroundGraphics}
+          {props.annotations ? renderStaticAnnotations({
+            annotations: props.annotations,
+            scales: {
+              geoProjection: store.scales?.projectedPoint
+                ? (([lon, lat]) => store.scales!.projectedPoint(lon, lat))
+                : undefined,
+            },
+            layout: { width, height },
+            theme,
+            idPrefix: props._idPrefix,
+          }) : null}
+          {props.foregroundGraphics}
+        </>
+      )
+      : null
     return ReactDOMServer.renderToStaticMarkup(
-      wrapSVG(null, {
+      wrapSVG(emptyContent, {
         width: size[0], height: size[1],
         className: `stream-geo-frame${props.className ? ` ${props.className}` : ""}`,
         title: props.title, description: props.description, background: props.background,
@@ -991,9 +1082,58 @@ function renderGeoFrame(props: StreamGeoFrameProps & ThemeAwareProps): string {
     .map((node, i) => geoSceneNodeToSVG(node, i))
     .filter(Boolean)
 
+  // Geo annotations: `coordinates: [lon, lat]` flows through the resolved
+  // projection from the store's scales; raw `x`/`y` numbers remain valid via
+  // staticAnnotations' pixel passthrough for callers who pre-projected.
+  const annotationNodes = props.annotations ? renderStaticAnnotations({
+    annotations: props.annotations,
+    scales: {
+      geoProjection: store.scales?.projectedPoint
+        ? (([lon, lat]) => store.scales!.projectedPoint(lon, lat))
+        : undefined,
+    },
+    layout: { width, height },
+    theme,
+    idPrefix: props._idPrefix,
+  }) : null
+
+  // Geo legend: auto-build from colorBy on either points (proportional
+  // symbol maps) or areas (choropleth maps), or accept a fully-formed
+  // `legend` prop the caller pre-built. Matches the XY/Network pattern but
+  // sources categories from whichever data input is present.
+  const geoLegend = props.showLegend ? (() => {
+    const accessorName = (a: any): string | undefined =>
+      typeof a === "string" ? a : undefined
+    const colorAccessor = accessorName((props as any).colorBy)
+    const legendSource: any[] = (() => {
+      if (Array.isArray(props.points) && props.points.length > 0) return props.points as any[]
+      if (Array.isArray(props.areas) && props.areas.length > 0) {
+        // GeoJSON features carry attributes under `properties` — flatten so
+        // `extractCategories` can read the colorBy field.
+        return (props.areas as any[]).map(f => ({ ...(f.properties || {}), ...f }))
+      }
+      return []
+    })()
+    const categories = extractCategories(legendSource, colorAccessor)
+    if (categories.length === 0) return null
+    return renderStaticLegend({
+      categories,
+      colorScheme: props.colorScheme,
+      theme,
+      position: props.legendPosition || "right",
+      totalWidth: size[0],
+      totalHeight: size[1],
+      margin,
+      hasTitle: !!props.title,
+    })
+  })() : null
+
   const content = (
     <>
+      {props.backgroundGraphics}
       {dataMarks}
+      {annotationNodes}
+      {props.foregroundGraphics}
     </>
   )
 
@@ -1004,7 +1144,8 @@ function renderGeoFrame(props: StreamGeoFrameProps & ThemeAwareProps): string {
       title: props.title, description: props.description, background: props.background,
       theme, innerTransform: `translate(${margin.left ?? 0},${margin.top ?? 0})`,
       innerWidth: width, innerHeight: height,
-        idPrefix: props._idPrefix,
+      legend: geoLegend,
+      idPrefix: props._idPrefix,
     })
   )
 }

--- a/src/components/server/renderToStaticSVG.tsx
+++ b/src/components/server/renderToStaticSVG.tsx
@@ -656,10 +656,16 @@ function renderNetworkFrame(props: StreamNetworkFrameProps & ThemeAwareProps): s
   // ALREADY-RESOLVED `edges` array — that's the output of
   // `buildRealtimeEdges` which applied `sourceAccessor` / `targetAccessor`,
   // so source/target are always normalized strings regardless of input shape.
+  //
+  // Both string and function accessors are honored — `extractCategories`
+  // accepts either form, and stripping functions to undefined would silently
+  // drop the legend for any caller using a typed accessor function.
   const networkLegend = props.showLegend ? (() => {
-    const accessorName = (a: any): string | undefined =>
-      typeof a === "string" ? a : undefined
-    const colorAccessor = accessorName(props.colorBy) || accessorName(props.nodeIDAccessor)
+    const isAccessor = (a: any): a is string | ((d: any) => string) =>
+      typeof a === "string" || typeof a === "function"
+    const colorAccessor = isAccessor(props.colorBy)
+      ? props.colorBy
+      : isAccessor(props.nodeIDAccessor) ? props.nodeIDAccessor : undefined
     const legendSource = props.nodes && props.nodes.length > 0
       ? (props.nodes as any[])
       : Array.from(new Set(
@@ -669,7 +675,7 @@ function renderNetworkFrame(props: StreamNetworkFrameProps & ThemeAwareProps): s
           return [src, tgt]
         }).filter(Boolean)
       )).map((id) => ({ id }))
-    const categories = extractCategories(legendSource, colorAccessor)
+    const categories = extractCategories(legendSource, colorAccessor as any)
     if (categories.length === 0) return null
     return renderStaticLegend({
       categories,
@@ -1125,17 +1131,23 @@ function renderGeoFrame(props: StreamGeoFrameProps & ThemeAwareProps): string {
   // Matches the XY/Network auto-build pattern; categories come from whichever
   // data input is present.
   const geoAutoLegend = props.showLegend ? (() => {
-    const colorAccessor = typeof props.colorBy === "string" ? props.colorBy : undefined
+    const isAccessor = (a: any): a is string | ((d: any) => string) =>
+      typeof a === "string" || typeof a === "function"
+    const colorAccessor = isAccessor(props.colorBy) ? props.colorBy : undefined
     const legendSource: any[] = (() => {
       if (Array.isArray(props.points) && props.points.length > 0) return props.points as any[]
       if (Array.isArray(props.areas) && props.areas.length > 0) {
-        // GeoJSON features carry attributes under `properties` — flatten so
-        // `extractCategories` can read the colorBy field.
-        return (props.areas as any[]).map(f => ({ ...(f.properties || {}), ...f }))
+        // For string accessors, GeoJSON features carry attributes under
+        // `properties` — flatten so `extractCategories` can read the field.
+        // Function accessors get raw features so they can decide what to read.
+        if (typeof colorAccessor === "string") {
+          return (props.areas as any[]).map(f => ({ ...(f.properties || {}), ...f }))
+        }
+        return props.areas as any[]
       }
       return []
     })()
-    const categories = extractCategories(legendSource, colorAccessor)
+    const categories = extractCategories(legendSource, colorAccessor as any)
     if (categories.length === 0) return null
     return renderStaticLegend({
       categories,

--- a/src/components/server/staticAnnotations.tsx
+++ b/src/components/server/staticAnnotations.tsx
@@ -21,6 +21,12 @@ interface AnnotationScales {
   o?: { (v: string): number | undefined; bandwidth?: () => number }
   /** For ordinal charts: value scale */
   r?: (v: number) => number
+  /**
+   * For geo charts: projects [lon, lat] → [x, y] pixel coords. Set by
+   * `renderGeoFrame` from the resolved `GeoPipelineStore` projection.
+   * Annotations that carry `coordinates: [lon, lat]` resolve through this.
+   */
+  geoProjection?: (coords: [number, number]) => [number, number] | null
 }
 
 interface AnnotationLayout {
@@ -41,6 +47,30 @@ export interface StaticAnnotationConfig {
   projection?: "vertical" | "horizontal" | "radial"
 }
 
+/**
+ * Resolve the (x, y) pixel for an annotation. Order:
+ *   1. `coordinates: [lon, lat]` + `geoProjection` (geo frame)
+ *   2. `x`/`y` data values + `scales.x`/`scales.y` (XY/ordinal frames)
+ *   3. accessor lookup on the annotation
+ *   4. raw `x`/`y` numbers as pixel passthrough (network frame, or any
+ *      annotation pre-projected to pixel coords by the caller)
+ */
+function resolveCoords(
+  ann: Datum,
+  scales: AnnotationScales,
+  xAccessor?: string,
+  yAccessor?: string
+): { x: number | null; y: number | null } {
+  // Geo projection first — coordinates is the documented field for geo
+  // annotations and bypasses the x/y scale entirely.
+  if (Array.isArray(ann.coordinates) && ann.coordinates.length >= 2 && scales.geoProjection) {
+    const projected = scales.geoProjection([ann.coordinates[0], ann.coordinates[1]])
+    if (projected) return { x: projected[0], y: projected[1] }
+  }
+
+  return { x: resolveXPixel(ann, scales, xAccessor), y: resolveYPixel(ann, scales, yAccessor) }
+}
+
 function resolveXPixel(
   ann: Datum,
   scales: AnnotationScales,
@@ -48,6 +78,9 @@ function resolveXPixel(
 ): number | null {
   if (ann.x != null && scales.x) return scales.x(ann.x)
   if (xAccessor && ann[xAccessor] != null && scales.x) return scales.x(ann[xAccessor])
+  // Pixel passthrough for frames without a continuous x scale (e.g. network)
+  // or annotations that have already been projected by the caller.
+  if (typeof ann.x === "number") return ann.x
   return null
 }
 
@@ -58,6 +91,7 @@ function resolveYPixel(
 ): number | null {
   if (ann.y != null && scales.y) return scales.y(ann.y)
   if (yAccessor && ann[yAccessor] != null && scales.y) return scales.y(ann[yAccessor])
+  if (typeof ann.y === "number") return ann.y
   return null
 }
 
@@ -227,8 +261,9 @@ function renderAnnotation(
 
     case "label":
     case "text": {
-      const px = resolveXPixel(ann, scales, xAccessor)
-      const py = resolveYPixel(ann, scales, yAccessor)
+      // Use resolveCoords so geo annotations with `coordinates: [lon, lat]`
+      // and network annotations with raw pixel x/y both flow through.
+      const { x: px, y: py } = resolveCoords(ann, scales, xAccessor, yAccessor)
       if (px == null || py == null) return null
       const dx = ann.dx || 0
       const dy = ann.dy || 0

--- a/src/components/stream/StreamOrdinalFrame.test.tsx
+++ b/src/components/stream/StreamOrdinalFrame.test.tsx
@@ -243,6 +243,7 @@ describe("StreamOrdinalFrame", () => {
           { id: "a", cat: "A", val: 10 },
           { id: "b", cat: "B", val: 20 },
         ])
+        await Promise.resolve()
       })
       expect(onCategoriesChange).toHaveBeenLastCalledWith(["A", "B"])
 

--- a/src/components/stream/StreamXYFrame.test.tsx
+++ b/src/components/stream/StreamXYFrame.test.tsx
@@ -256,6 +256,7 @@ describe("StreamXYFrame", () => {
           { id: "a", t: 1, v: 10, series: "A" },
           { id: "b", t: 2, v: 20, series: "B" },
         ])
+        await Promise.resolve()
       })
       expect(onCategoriesChange).toHaveBeenLastCalledWith(["A", "B"])
 

--- a/src/components/stream/geoTypes.ts
+++ b/src/components/stream/geoTypes.ts
@@ -220,9 +220,11 @@ export interface StreamGeoFrameProps<T = Datum> {
    * Categorical color field. For ChoroplethMap reads from area `properties`
    * (or top-level fallback); for ProportionalSymbolMap reads from each point.
    * Server-side legend auto-build groups by this field when `showLegend` is
-   * set and no explicit `legend` prop is provided.
+   * set and no explicit `legend` prop is provided. The function form accepts
+   * either the point datum `T` or a GeoJSON Feature so choropleth callers can
+   * write `(f) => f.properties.region` without a cast.
    */
-  colorBy?: string | ((d: T) => string)
+  colorBy?: string | ((d: T | GeoJSON.Feature) => string)
 
   // ── Interaction ──
   enableHover?: boolean

--- a/src/components/stream/geoTypes.ts
+++ b/src/components/stream/geoTypes.ts
@@ -216,6 +216,13 @@ export interface StreamGeoFrameProps<T = Datum> {
   pointStyle?: (d: Datum) => Style & { r?: number }
   lineStyle?: Style | ((d: Datum, group?: string) => Style)
   colorScheme?: string | string[]
+  /**
+   * Categorical color field. For ChoroplethMap reads from area `properties`
+   * (or top-level fallback); for ProportionalSymbolMap reads from each point.
+   * Server-side legend auto-build groups by this field when `showLegend` is
+   * set and no explicit `legend` prop is provided.
+   */
+  colorBy?: string | ((d: T) => string)
 
   // ── Interaction ──
   enableHover?: boolean


### PR DESCRIPTION
This pull request introduces a structural safeguard ensuring that every scene-node type emitted by a canvas scene builder has a corresponding SVG converter, and vice versa, to prevent silent server-side rendering (SSR) drift. The check is enforced in CI and pre-publish scripts, and is tested with new integration tests. Documentation and workflow scripts are updated to reflect and explain this contract.

**SSR Canvas/SVG Parity Enforcement:**

- [`scripts/check-ssr-alignment.js`](diffhunk://#diff-8380e9316e0f28eb3c2964ec9fefc6364a3b3c0e41abad566c7a266d72fb9053L4-R24): Extends the SSR alignment check to verify that every scene-node type in each frame's union is handled by a corresponding `*SceneNodeToSVG` converter, and that no SVG-only cases exist without a corresponding scene-node type. This prevents silent rendering drift between client (canvas) and server (SVG) paths. [[1]](diffhunk://#diff-8380e9316e0f28eb3c2964ec9fefc6364a3b3c0e41abad566c7a266d72fb9053L4-R24) [[2]](diffhunk://#diff-8380e9316e0f28eb3c2964ec9fefc6364a3b3c0e41abad566c7a266d72fb9053L137-R311)
- [`src/__tests__/scenarios/ssr-alignment.test.ts`](diffhunk://#diff-992539b3bfcc59e9c2f9a18b75100c52c50e0d9ae666f95ba9cc614969ceacf8R1-R90): Adds integration tests that mutate `SceneToSVG.tsx` to simulate both drift directions (canvas-only and SVG-only), ensuring that the check script fails as expected and passes when parity is intact.

**Build & CI Integration:**

- [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L135-R137): Adds a `check:ssr` script, and integrates it into `release:check` and `prepublishOnly` to enforce SSR parity on every release and publish attempt.
- [`.github/workflows/node.js.yml`](diffhunk://#diff-014228303dff9a1af15f4bbd18401f906380129b10ae2a2c62f8b8be592ff88eL48-R48): Updates the SSR alignment check step to use `npm run check:ssr` for consistency with new scripts.

**Documentation & Outstanding Work:**

- [`OUTSTANDING_WORK.md`](diffhunk://#diff-fbb4a34cc150f00e9572aa6eb822870894953c8e68dd30e0e7718940ad18e614L371-R393): Marks the SSR parity contract as closed (from [YELLOW] to [GREEN]), describes the new structural and behavioral enforcement, and details the features and fixes that landed with the matrix.
- [`docs/public/llms-full.txt`](diffhunk://#diff-1d46064736c2ddba6730f3ac92bf570add5b9a6ada667af5b159706d893b3169L6-R6): Cleans up CLI documentation, clarifies required/optional props for charts, and removes references to deprecated commands. [[1]](diffhunk://#diff-1d46064736c2ddba6730f3ac92bf570add5b9a6ada667af5b159706d893b3169L6-R6) [[2]](diffhunk://#diff-1d46064736c2ddba6730f3ac92bf570add5b9a6ada667af5b159706d893b3169L140-R140) [[3]](diffhunk://#diff-1d46064736c2ddba6730f3ac92bf570add5b9a6ada667af5b159706d893b3169L183-R183)
- [`OUTSTANDING_WORK.md`](diffhunk://#diff-fbb4a34cc150f00e9572aa6eb822870894953c8e68dd30e0e7718940ad18e614L3-R3): Updates the last modified date.

These changes ensure that SSR and client rendering remain in lockstep, preventing accidental regressions and making it impossible to add new rendering features without updating both code paths and passing CI.