### PR TITLE
Improve theme bridge

### DIFF
--- a/OUTSTANDING_WORK.md
+++ b/OUTSTANDING_WORK.md
@@ -186,9 +186,9 @@ Theme presets updated: Tufte and Journalist presets include `annotation`, `tickF
 
 `ThemeProvider` now resolves the requested preset/object theme synchronously and seeds the scoped store through provider initialization. `useTheme()`, chart theme defaults, and `ThemeCSSWrapper` CSS variables see the requested theme on the first child render. Forced-colors initialization is also synchronous and restores the default light theme when forced-colors exits.
 
-### Canvas theme bridge fragility [YELLOW]
+### Canvas theme bridge fragility [DONE]
 
-Canvas renderers read theme values via `getComputedStyle`. If the dirty flag isn't set when the theme updates, canvas keeps old colors while SVG updates to the new theme. Currently works because theme changes trigger re-render → dirty flag, but the coupling is implicit.
+Canvas renderers read CSS-variable colors via `getComputedStyle`, and `useFrame` now owns the theme-change bridge explicitly: clear the CSS color cache, mark the frame dirty, and queue a repaint from a layout-timed effect whenever the ThemeStore theme changes. All four Stream Frame families pass `themeDirtyRef`, and `useFrame` has a regression test proving a theme update invalidates cached CSS-variable colors and schedules repaint work.
 
 ### Design system research gaps
 

--- a/src/components/stream/useFrame.test.ts
+++ b/src/components/stream/useFrame.test.ts
@@ -10,7 +10,8 @@ import { act, renderHook } from "@testing-library/react"
 import { describe, it, expect, beforeEach, afterEach } from "vitest"
 import { useFrame } from "./useFrame"
 import type { UseFrameInput } from "./useFrame"
-import { ThemeProvider, LIGHT_THEME, useThemeSelector } from "../store/ThemeStore"
+import { ThemeProvider, LIGHT_THEME, DARK_THEME, useThemeSelector } from "../store/ThemeStore"
+import { _resetCSSColorCacheForTest, resolveCSSColor } from "./renderers/resolveCSSColor"
 
 const DEFAULT_INPUT: UseFrameInput = {
   sizeProp: [800, 600],
@@ -234,6 +235,7 @@ describe("useFrame — scheduleRender (rAF coalescing)", () => {
   afterEach(() => {
     global.requestAnimationFrame = originalRAF
     global.cancelAnimationFrame = originalCAF
+    _resetCSSColorCacheForTest()
   })
 
   function flushRafs() {
@@ -382,6 +384,46 @@ describe("useFrame — theme-change effect", () => {
     // No new theme-change effect fire, no new rAF queued.
     expect(rafCallbacks).toHaveLength(0)
     expect(dirtyRef.current).toBe(false)
+  })
+
+  it("invalidates cached CSS-variable colors and queues repaint on ThemeStore changes", () => {
+    const dirtyRef = { current: false } as React.MutableRefObject<boolean>
+    const { result } = renderHook(
+      () => ({
+        frame: useFrame({ ...DEFAULT_INPUT, themeDirtyRef: dirtyRef }),
+        setTheme: useThemeSelector(
+          (s: { setTheme: (t: "light" | "dark" | "high-contrast") => void }) => s.setTheme,
+        ),
+      }),
+      { wrapper },
+    )
+
+    const canvas = document.createElement("canvas")
+    document.body.appendChild(canvas)
+    const ctx = { canvas } as CanvasRenderingContext2D
+    try {
+      canvas.style.setProperty("--semiotic-primary", "#111111")
+      _resetCSSColorCacheForTest()
+
+      expect(resolveCSSColor(ctx, "var(--semiotic-primary)")).toBe("#111111")
+      canvas.style.setProperty("--semiotic-primary", "#222222")
+      expect(resolveCSSColor(ctx, "var(--semiotic-primary)")).toBe("#111111")
+
+      dirtyRef.current = false
+      result.current.frame.rafRef.current = 0
+      rafCallbacks = []
+
+      act(() => {
+        result.current.setTheme("dark")
+      })
+
+      expect(result.current.frame.currentTheme).toBe(DARK_THEME)
+      expect(dirtyRef.current).toBe(true)
+      expect(rafCallbacks).toHaveLength(1)
+      expect(resolveCSSColor(ctx, "var(--semiotic-primary)")).toBe("#222222")
+    } finally {
+      canvas.remove()
+    }
   })
 })
 

--- a/src/components/stream/useFrame.test.ts
+++ b/src/components/stream/useFrame.test.ts
@@ -423,6 +423,10 @@ describe("useFrame — theme-change effect", () => {
       expect(resolveCSSColor(ctx, "var(--semiotic-primary)")).toBe("#222222")
     } finally {
       canvas.remove()
+      // resolveCSSColor lazily attaches a global MutationObserver/matchMedia
+      // listener via ensureGlobalObserver. Reset the cache + observer here so
+      // they don't leak into later tests in this file or other test files.
+      _resetCSSColorCacheForTest()
     }
   })
 })

--- a/src/components/stream/useFrame.ts
+++ b/src/components/stream/useFrame.ts
@@ -38,7 +38,7 @@
 "use client"
 
 import * as React from "react"
-import { useCallback, useEffect, useMemo, useRef } from "react"
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react"
 import type { ReactNode } from "react"
 import { useThemeSelector } from "../store/ThemeStore"
 import type { SemioticTheme } from "../store/ThemeStore"
@@ -49,6 +49,9 @@ import type { AnimateProp } from "./pipelineTransitionUtils"
 import type { TransitionConfig } from "./types"
 import { clearCSSColorCache } from "./renderers/resolveCSSColor"
 import type { HoverPointerCoords } from "./hoverUtils"
+
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect
 
 // ── Margin handling ─────────────────────────────────────────────────────────
 
@@ -331,7 +334,7 @@ export function useFrame(input: UseFrameInput): UseFrameResult {
   // Both the canvas-arg and argless call sites in the four frames
   // reduced to a single global counter bump; we use the argless form.
   const themeDirtyRef = input.themeDirtyRef
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!themeDirtyRef) return
     clearCSSColorCache()
     themeDirtyRef.current = true


### PR DESCRIPTION
This pull request strengthens the integration between theme changes and canvas rendering, ensuring that canvas renderers correctly update their colors when the theme changes. It introduces an explicit mechanism in `useFrame` to clear cached CSS-variable colors, mark the frame as dirty, and schedule a repaint whenever the theme updates. Additionally, new tests verify this behavior, and the implementation now uses an isomorphic layout effect to ensure proper synchronization between server and client environments.

**Theme change handling improvements:**

* `useFrame` now explicitly bridges theme changes: when the theme updates, it clears the CSS color cache, marks the frame dirty, and schedules a repaint using a layout-timed effect. This ensures canvas renderers always use up-to-date theme colors and removes implicit coupling between theme changes and canvas updates. [[1]](diffhunk://#diff-fbb4a34cc150f00e9572aa6eb822870894953c8e68dd30e0e7718940ad18e614L189-R191) [[2]](diffhunk://#diff-44cadc3ec67f9afb8225919b8292aafcbc6e513d5819aafc4198136344957132L334-R337)
* Introduced `useIsomorphicLayoutEffect` to use `useLayoutEffect` on the client and `useEffect` on the server, ensuring theme updates are handled synchronously in all environments. [[1]](diffhunk://#diff-44cadc3ec67f9afb8225919b8292aafcbc6e513d5819aafc4198136344957132L41-R41) [[2]](diffhunk://#diff-44cadc3ec67f9afb8225919b8292aafcbc6e513d5819aafc4198136344957132R53-R55)

**Testing enhancements:**

* Added a regression test to `useFrame.test.ts` that verifies cached CSS-variable colors are invalidated and a repaint is scheduled when the theme changes.
* Ensured test isolation by resetting the CSS color cache after each test in the relevant test suite.
* Extended test imports to cover new utilities for testing CSS color cache behavior.