### PR TITLE
Add useCustomChartSetup & composeOverlays

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -105,19 +105,19 @@ Not supported: Tree, Treemap, CirclePack, Orbit, ChoroplethMap, FlowMap, Scatter
 
 When the catalog doesn't fit, three HOCs let you supply a layout function that emits scene primitives directly. The frame still owns hit testing, transitions, decay, theme cascade, and SSR — your layout owns geometry only.
 
-- **`CustomChart`** (`semiotic/xy`) — XY layouts: waffle, calendar heatmap, custom point/line/area arrangements
+- **`XYCustomChart`** (`semiotic/xy`) — XY layouts: waffle, calendar heatmap, custom point/line/area arrangements
 - **`OrdinalCustomChart`** (`semiotic/ordinal`) — category × value layouts: marimekko, parallel coordinates, bullet, fan chart, slope graph
 - **`NetworkCustomChart`** (`semiotic/network`) — graph layouts: flextree, dagre, custom force/radial
 
 All three accept `layout` and `layoutConfig` (your own typed config), but the layout context and return shape differ by chart family:
 
-- **`CustomChart` / `OrdinalCustomChart`** — `layout: (ctx) => { nodes, overlays? }`. Context exposes `data`, `scales`, `dimensions` (with plot rect — center-anchored for radial ordinal, top-left otherwise), `theme` (semantic + categorical), `resolveColor(key)`, and `config`. XY scales: `{ x, y }` (linear). Ordinal scales: `{ o, r, projection }` (band + linear).
+- **`XYCustomChart` / `OrdinalCustomChart`** — `layout: (ctx) => { nodes, overlays? }`. Context exposes `data`, `scales`, `dimensions` (with plot rect — center-anchored for radial ordinal, top-left otherwise), `theme` (semantic + categorical), `resolveColor(key)`, and `config`. XY scales: `{ x, y }` (linear). Ordinal scales: `{ o, r, projection }` (band + linear).
 - **`NetworkCustomChart`** — `layout: (ctx) => { sceneNodes?, sceneEdges?, labels?, overlays? }`. Context exposes `nodes`, `edges`, `dimensions`, `theme`, `resolveColor(key)`, and `config` — graph data, no `data`/`scales`. Network layouts often run an external positioner (`d3-flextree`, `dagre`) on nodes/edges, then emit network scene primitives (`circle`, `rect`, `arc` for nodes; `line`, `bezier`, `curved` for edges).
 
 XY/ordinal frames render whatever you put in `nodes` (rect, point, area, line, wedge, connector, etc.). Network frames split node-shaped scenes from edge-shaped scenes — give them `sceneNodes` for the round/rect/arc visuals and `sceneEdges` for the connecting paths. All three frames handle painting, hit testing, accessibility, transitions, decay, and SSR for you.
 
 ```tsx
-import { CustomChart } from "semiotic/xy"
+import { XYCustomChart } from "semiotic/xy"
 import { OrdinalCustomChart } from "semiotic/ordinal"
 import { NetworkCustomChart } from "semiotic/network"
 import {
@@ -126,7 +126,7 @@ import {
   flextreeLayout, dagreLayout,             // network
 } from "semiotic/recipes"
 
-<CustomChart data={cells} layout={waffleLayout} layoutConfig={{ rows: 10, columns: 10, ... }} />
+<XYCustomChart data={cells} layout={waffleLayout} layoutConfig={{ rows: 10, columns: 10, ... }} />
 <OrdinalCustomChart data={revenue} layout={marimekkoLayout} layoutConfig={{ ... }} />
 <NetworkCustomChart nodes={nodes} edges={edges} layout={flextreeLayout} layoutConfig={{ ... }} />
 ```
@@ -152,7 +152,7 @@ Writing your own recipe: prefer `showXxx` boolean toggles for chrome opt-out, `x
 
 ### Interaction (hover, brush, selection): the parent component owns it
 
-Recipes are pure functions, so they can't carry interactive state (hover, brush ranges, selection). The pattern: recipes accept a **predicate prop** (e.g. `parallelCoordinatesLayout`'s `highlightFn?: (d) => boolean`) and the parent component manages state. Wire `onObservation` (`{ type: "hover" | "hover-end" | ... }`) on `OrdinalCustomChart` / `CustomChart` / `NetworkCustomChart` to update parent state, then feed a derived predicate back into `layoutConfig`. Matching rows render at full opacity; non-matching dim. Highlighted rows z-order on top so neighbors don't cover them.
+Recipes are pure functions, so they can't carry interactive state (hover, brush ranges, selection). The pattern: recipes accept a **predicate prop** (e.g. `parallelCoordinatesLayout`'s `highlightFn?: (d) => boolean`) and the parent component manages state. Wire `onObservation` (`{ type: "hover" | "hover-end" | ... }`) on `OrdinalCustomChart` / `XYCustomChart` / `NetworkCustomChart` to update parent state, then feed a derived predicate back into `layoutConfig`. Matching rows render at full opacity; non-matching dim. Highlighted rows z-order on top so neighbors don't cover them.
 
 ```tsx
 const [hovered, setHovered] = useState(null)
@@ -174,7 +174,7 @@ The same predicate hook is the integration point for richer interactions on the 
 
 ### Built-in chrome works when the layout uses standard scales
 
-Layouts that draw *within* the frame's standard scales can just use the HOC's chrome. Pass `showAxes` on `CustomChart` / `OrdinalCustomChart` and the frame will render the same x/y or o/r axes the built-in HOCs do — useful for custom XY layouts that overlay points/lines on regular axes. The recipe-managed chrome is for the cases where standard axes can't help (variable-width bars under a band scale, per-row independent scales, etc.).
+Layouts that draw *within* the frame's standard scales can just use the HOC's chrome. Pass `showAxes` on `XYCustomChart` / `OrdinalCustomChart` and the frame will render the same x/y or o/r axes the built-in HOCs do — useful for custom XY layouts that overlay points/lines on regular axes. The recipe-managed chrome is for the cases where standard axes can't help (variable-width bars under a band scale, per-row independent scales, etc.).
 
 **Notes:**
 - Coords are plot-relative (the frame translates the canvas/SVG group by `margin`). Read `ctx.dimensions.plot` for the drawing rect. Radial ordinal projection is the one exception: `plot.x = -width/2`, `plot.y = -height/2` because the canvas ctx is center-translated.

--- a/.cursorrules
+++ b/.cursorrules
@@ -105,19 +105,19 @@ Not supported: Tree, Treemap, CirclePack, Orbit, ChoroplethMap, FlowMap, Scatter
 
 When the catalog doesn't fit, three HOCs let you supply a layout function that emits scene primitives directly. The frame still owns hit testing, transitions, decay, theme cascade, and SSR — your layout owns geometry only.
 
-- **`CustomChart`** (`semiotic/xy`) — XY layouts: waffle, calendar heatmap, custom point/line/area arrangements
+- **`XYCustomChart`** (`semiotic/xy`) — XY layouts: waffle, calendar heatmap, custom point/line/area arrangements
 - **`OrdinalCustomChart`** (`semiotic/ordinal`) — category × value layouts: marimekko, parallel coordinates, bullet, fan chart, slope graph
 - **`NetworkCustomChart`** (`semiotic/network`) — graph layouts: flextree, dagre, custom force/radial
 
 All three accept `layout` and `layoutConfig` (your own typed config), but the layout context and return shape differ by chart family:
 
-- **`CustomChart` / `OrdinalCustomChart`** — `layout: (ctx) => { nodes, overlays? }`. Context exposes `data`, `scales`, `dimensions` (with plot rect — center-anchored for radial ordinal, top-left otherwise), `theme` (semantic + categorical), `resolveColor(key)`, and `config`. XY scales: `{ x, y }` (linear). Ordinal scales: `{ o, r, projection }` (band + linear).
+- **`XYCustomChart` / `OrdinalCustomChart`** — `layout: (ctx) => { nodes, overlays? }`. Context exposes `data`, `scales`, `dimensions` (with plot rect — center-anchored for radial ordinal, top-left otherwise), `theme` (semantic + categorical), `resolveColor(key)`, and `config`. XY scales: `{ x, y }` (linear). Ordinal scales: `{ o, r, projection }` (band + linear).
 - **`NetworkCustomChart`** — `layout: (ctx) => { sceneNodes?, sceneEdges?, labels?, overlays? }`. Context exposes `nodes`, `edges`, `dimensions`, `theme`, `resolveColor(key)`, and `config` — graph data, no `data`/`scales`. Network layouts often run an external positioner (`d3-flextree`, `dagre`) on nodes/edges, then emit network scene primitives (`circle`, `rect`, `arc` for nodes; `line`, `bezier`, `curved` for edges).
 
 XY/ordinal frames render whatever you put in `nodes` (rect, point, area, line, wedge, connector, etc.). Network frames split node-shaped scenes from edge-shaped scenes — give them `sceneNodes` for the round/rect/arc visuals and `sceneEdges` for the connecting paths. All three frames handle painting, hit testing, accessibility, transitions, decay, and SSR for you.
 
 ```tsx
-import { CustomChart } from "semiotic/xy"
+import { XYCustomChart } from "semiotic/xy"
 import { OrdinalCustomChart } from "semiotic/ordinal"
 import { NetworkCustomChart } from "semiotic/network"
 import {
@@ -126,7 +126,7 @@ import {
   flextreeLayout, dagreLayout,             // network
 } from "semiotic/recipes"
 
-<CustomChart data={cells} layout={waffleLayout} layoutConfig={{ rows: 10, columns: 10, ... }} />
+<XYCustomChart data={cells} layout={waffleLayout} layoutConfig={{ rows: 10, columns: 10, ... }} />
 <OrdinalCustomChart data={revenue} layout={marimekkoLayout} layoutConfig={{ ... }} />
 <NetworkCustomChart nodes={nodes} edges={edges} layout={flextreeLayout} layoutConfig={{ ... }} />
 ```
@@ -152,7 +152,7 @@ Writing your own recipe: prefer `showXxx` boolean toggles for chrome opt-out, `x
 
 ### Interaction (hover, brush, selection): the parent component owns it
 
-Recipes are pure functions, so they can't carry interactive state (hover, brush ranges, selection). The pattern: recipes accept a **predicate prop** (e.g. `parallelCoordinatesLayout`'s `highlightFn?: (d) => boolean`) and the parent component manages state. Wire `onObservation` (`{ type: "hover" | "hover-end" | ... }`) on `OrdinalCustomChart` / `CustomChart` / `NetworkCustomChart` to update parent state, then feed a derived predicate back into `layoutConfig`. Matching rows render at full opacity; non-matching dim. Highlighted rows z-order on top so neighbors don't cover them.
+Recipes are pure functions, so they can't carry interactive state (hover, brush ranges, selection). The pattern: recipes accept a **predicate prop** (e.g. `parallelCoordinatesLayout`'s `highlightFn?: (d) => boolean`) and the parent component manages state. Wire `onObservation` (`{ type: "hover" | "hover-end" | ... }`) on `OrdinalCustomChart` / `XYCustomChart` / `NetworkCustomChart` to update parent state, then feed a derived predicate back into `layoutConfig`. Matching rows render at full opacity; non-matching dim. Highlighted rows z-order on top so neighbors don't cover them.
 
 ```tsx
 const [hovered, setHovered] = useState(null)
@@ -174,7 +174,7 @@ The same predicate hook is the integration point for richer interactions on the 
 
 ### Built-in chrome works when the layout uses standard scales
 
-Layouts that draw *within* the frame's standard scales can just use the HOC's chrome. Pass `showAxes` on `CustomChart` / `OrdinalCustomChart` and the frame will render the same x/y or o/r axes the built-in HOCs do — useful for custom XY layouts that overlay points/lines on regular axes. The recipe-managed chrome is for the cases where standard axes can't help (variable-width bars under a band scale, per-row independent scales, etc.).
+Layouts that draw *within* the frame's standard scales can just use the HOC's chrome. Pass `showAxes` on `XYCustomChart` / `OrdinalCustomChart` and the frame will render the same x/y or o/r axes the built-in HOCs do — useful for custom XY layouts that overlay points/lines on regular axes. The recipe-managed chrome is for the cases where standard axes can't help (variable-width bars under a band scale, per-row independent scales, etc.).
 
 **Notes:**
 - Coords are plot-relative (the frame translates the canvas/SVG group by `margin`). Read `ctx.dimensions.plot` for the drawing rect. Radial ordinal projection is the one exception: `plot.x = -width/2`, `plot.y = -height/2` because the canvas ctx is center-translated.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -105,19 +105,19 @@ Not supported: Tree, Treemap, CirclePack, Orbit, ChoroplethMap, FlowMap, Scatter
 
 When the catalog doesn't fit, three HOCs let you supply a layout function that emits scene primitives directly. The frame still owns hit testing, transitions, decay, theme cascade, and SSR — your layout owns geometry only.
 
-- **`CustomChart`** (`semiotic/xy`) — XY layouts: waffle, calendar heatmap, custom point/line/area arrangements
+- **`XYCustomChart`** (`semiotic/xy`) — XY layouts: waffle, calendar heatmap, custom point/line/area arrangements
 - **`OrdinalCustomChart`** (`semiotic/ordinal`) — category × value layouts: marimekko, parallel coordinates, bullet, fan chart, slope graph
 - **`NetworkCustomChart`** (`semiotic/network`) — graph layouts: flextree, dagre, custom force/radial
 
 All three accept `layout` and `layoutConfig` (your own typed config), but the layout context and return shape differ by chart family:
 
-- **`CustomChart` / `OrdinalCustomChart`** — `layout: (ctx) => { nodes, overlays? }`. Context exposes `data`, `scales`, `dimensions` (with plot rect — center-anchored for radial ordinal, top-left otherwise), `theme` (semantic + categorical), `resolveColor(key)`, and `config`. XY scales: `{ x, y }` (linear). Ordinal scales: `{ o, r, projection }` (band + linear).
+- **`XYCustomChart` / `OrdinalCustomChart`** — `layout: (ctx) => { nodes, overlays? }`. Context exposes `data`, `scales`, `dimensions` (with plot rect — center-anchored for radial ordinal, top-left otherwise), `theme` (semantic + categorical), `resolveColor(key)`, and `config`. XY scales: `{ x, y }` (linear). Ordinal scales: `{ o, r, projection }` (band + linear).
 - **`NetworkCustomChart`** — `layout: (ctx) => { sceneNodes?, sceneEdges?, labels?, overlays? }`. Context exposes `nodes`, `edges`, `dimensions`, `theme`, `resolveColor(key)`, and `config` — graph data, no `data`/`scales`. Network layouts often run an external positioner (`d3-flextree`, `dagre`) on nodes/edges, then emit network scene primitives (`circle`, `rect`, `arc` for nodes; `line`, `bezier`, `curved` for edges).
 
 XY/ordinal frames render whatever you put in `nodes` (rect, point, area, line, wedge, connector, etc.). Network frames split node-shaped scenes from edge-shaped scenes — give them `sceneNodes` for the round/rect/arc visuals and `sceneEdges` for the connecting paths. All three frames handle painting, hit testing, accessibility, transitions, decay, and SSR for you.
 
 ```tsx
-import { CustomChart } from "semiotic/xy"
+import { XYCustomChart } from "semiotic/xy"
 import { OrdinalCustomChart } from "semiotic/ordinal"
 import { NetworkCustomChart } from "semiotic/network"
 import {
@@ -126,7 +126,7 @@ import {
   flextreeLayout, dagreLayout,             // network
 } from "semiotic/recipes"
 
-<CustomChart data={cells} layout={waffleLayout} layoutConfig={{ rows: 10, columns: 10, ... }} />
+<XYCustomChart data={cells} layout={waffleLayout} layoutConfig={{ rows: 10, columns: 10, ... }} />
 <OrdinalCustomChart data={revenue} layout={marimekkoLayout} layoutConfig={{ ... }} />
 <NetworkCustomChart nodes={nodes} edges={edges} layout={flextreeLayout} layoutConfig={{ ... }} />
 ```
@@ -152,7 +152,7 @@ Writing your own recipe: prefer `showXxx` boolean toggles for chrome opt-out, `x
 
 ### Interaction (hover, brush, selection): the parent component owns it
 
-Recipes are pure functions, so they can't carry interactive state (hover, brush ranges, selection). The pattern: recipes accept a **predicate prop** (e.g. `parallelCoordinatesLayout`'s `highlightFn?: (d) => boolean`) and the parent component manages state. Wire `onObservation` (`{ type: "hover" | "hover-end" | ... }`) on `OrdinalCustomChart` / `CustomChart` / `NetworkCustomChart` to update parent state, then feed a derived predicate back into `layoutConfig`. Matching rows render at full opacity; non-matching dim. Highlighted rows z-order on top so neighbors don't cover them.
+Recipes are pure functions, so they can't carry interactive state (hover, brush ranges, selection). The pattern: recipes accept a **predicate prop** (e.g. `parallelCoordinatesLayout`'s `highlightFn?: (d) => boolean`) and the parent component manages state. Wire `onObservation` (`{ type: "hover" | "hover-end" | ... }`) on `OrdinalCustomChart` / `XYCustomChart` / `NetworkCustomChart` to update parent state, then feed a derived predicate back into `layoutConfig`. Matching rows render at full opacity; non-matching dim. Highlighted rows z-order on top so neighbors don't cover them.
 
 ```tsx
 const [hovered, setHovered] = useState(null)
@@ -174,7 +174,7 @@ The same predicate hook is the integration point for richer interactions on the 
 
 ### Built-in chrome works when the layout uses standard scales
 
-Layouts that draw *within* the frame's standard scales can just use the HOC's chrome. Pass `showAxes` on `CustomChart` / `OrdinalCustomChart` and the frame will render the same x/y or o/r axes the built-in HOCs do — useful for custom XY layouts that overlay points/lines on regular axes. The recipe-managed chrome is for the cases where standard axes can't help (variable-width bars under a band scale, per-row independent scales, etc.).
+Layouts that draw *within* the frame's standard scales can just use the HOC's chrome. Pass `showAxes` on `XYCustomChart` / `OrdinalCustomChart` and the frame will render the same x/y or o/r axes the built-in HOCs do — useful for custom XY layouts that overlay points/lines on regular axes. The recipe-managed chrome is for the cases where standard axes can't help (variable-width bars under a band scale, per-row independent scales, etc.).
 
 **Notes:**
 - Coords are plot-relative (the frame translates the canvas/SVG group by `margin`). Read `ctx.dimensions.plot` for the drawing rect. Radial ordinal projection is the one exception: `plot.x = -width/2`, `plot.y = -height/2` because the canvas ctx is center-translated.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -105,19 +105,19 @@ Not supported: Tree, Treemap, CirclePack, Orbit, ChoroplethMap, FlowMap, Scatter
 
 When the catalog doesn't fit, three HOCs let you supply a layout function that emits scene primitives directly. The frame still owns hit testing, transitions, decay, theme cascade, and SSR — your layout owns geometry only.
 
-- **`CustomChart`** (`semiotic/xy`) — XY layouts: waffle, calendar heatmap, custom point/line/area arrangements
+- **`XYCustomChart`** (`semiotic/xy`) — XY layouts: waffle, calendar heatmap, custom point/line/area arrangements
 - **`OrdinalCustomChart`** (`semiotic/ordinal`) — category × value layouts: marimekko, parallel coordinates, bullet, fan chart, slope graph
 - **`NetworkCustomChart`** (`semiotic/network`) — graph layouts: flextree, dagre, custom force/radial
 
 All three accept `layout` and `layoutConfig` (your own typed config), but the layout context and return shape differ by chart family:
 
-- **`CustomChart` / `OrdinalCustomChart`** — `layout: (ctx) => { nodes, overlays? }`. Context exposes `data`, `scales`, `dimensions` (with plot rect — center-anchored for radial ordinal, top-left otherwise), `theme` (semantic + categorical), `resolveColor(key)`, and `config`. XY scales: `{ x, y }` (linear). Ordinal scales: `{ o, r, projection }` (band + linear).
+- **`XYCustomChart` / `OrdinalCustomChart`** — `layout: (ctx) => { nodes, overlays? }`. Context exposes `data`, `scales`, `dimensions` (with plot rect — center-anchored for radial ordinal, top-left otherwise), `theme` (semantic + categorical), `resolveColor(key)`, and `config`. XY scales: `{ x, y }` (linear). Ordinal scales: `{ o, r, projection }` (band + linear).
 - **`NetworkCustomChart`** — `layout: (ctx) => { sceneNodes?, sceneEdges?, labels?, overlays? }`. Context exposes `nodes`, `edges`, `dimensions`, `theme`, `resolveColor(key)`, and `config` — graph data, no `data`/`scales`. Network layouts often run an external positioner (`d3-flextree`, `dagre`) on nodes/edges, then emit network scene primitives (`circle`, `rect`, `arc` for nodes; `line`, `bezier`, `curved` for edges).
 
 XY/ordinal frames render whatever you put in `nodes` (rect, point, area, line, wedge, connector, etc.). Network frames split node-shaped scenes from edge-shaped scenes — give them `sceneNodes` for the round/rect/arc visuals and `sceneEdges` for the connecting paths. All three frames handle painting, hit testing, accessibility, transitions, decay, and SSR for you.
 
 ```tsx
-import { CustomChart } from "semiotic/xy"
+import { XYCustomChart } from "semiotic/xy"
 import { OrdinalCustomChart } from "semiotic/ordinal"
 import { NetworkCustomChart } from "semiotic/network"
 import {
@@ -126,7 +126,7 @@ import {
   flextreeLayout, dagreLayout,             // network
 } from "semiotic/recipes"
 
-<CustomChart data={cells} layout={waffleLayout} layoutConfig={{ rows: 10, columns: 10, ... }} />
+<XYCustomChart data={cells} layout={waffleLayout} layoutConfig={{ rows: 10, columns: 10, ... }} />
 <OrdinalCustomChart data={revenue} layout={marimekkoLayout} layoutConfig={{ ... }} />
 <NetworkCustomChart nodes={nodes} edges={edges} layout={flextreeLayout} layoutConfig={{ ... }} />
 ```
@@ -152,7 +152,7 @@ Writing your own recipe: prefer `showXxx` boolean toggles for chrome opt-out, `x
 
 ### Interaction (hover, brush, selection): the parent component owns it
 
-Recipes are pure functions, so they can't carry interactive state (hover, brush ranges, selection). The pattern: recipes accept a **predicate prop** (e.g. `parallelCoordinatesLayout`'s `highlightFn?: (d) => boolean`) and the parent component manages state. Wire `onObservation` (`{ type: "hover" | "hover-end" | ... }`) on `OrdinalCustomChart` / `CustomChart` / `NetworkCustomChart` to update parent state, then feed a derived predicate back into `layoutConfig`. Matching rows render at full opacity; non-matching dim. Highlighted rows z-order on top so neighbors don't cover them.
+Recipes are pure functions, so they can't carry interactive state (hover, brush ranges, selection). The pattern: recipes accept a **predicate prop** (e.g. `parallelCoordinatesLayout`'s `highlightFn?: (d) => boolean`) and the parent component manages state. Wire `onObservation` (`{ type: "hover" | "hover-end" | ... }`) on `OrdinalCustomChart` / `XYCustomChart` / `NetworkCustomChart` to update parent state, then feed a derived predicate back into `layoutConfig`. Matching rows render at full opacity; non-matching dim. Highlighted rows z-order on top so neighbors don't cover them.
 
 ```tsx
 const [hovered, setHovered] = useState(null)
@@ -174,7 +174,7 @@ The same predicate hook is the integration point for richer interactions on the 
 
 ### Built-in chrome works when the layout uses standard scales
 
-Layouts that draw *within* the frame's standard scales can just use the HOC's chrome. Pass `showAxes` on `CustomChart` / `OrdinalCustomChart` and the frame will render the same x/y or o/r axes the built-in HOCs do — useful for custom XY layouts that overlay points/lines on regular axes. The recipe-managed chrome is for the cases where standard axes can't help (variable-width bars under a band scale, per-row independent scales, etc.).
+Layouts that draw *within* the frame's standard scales can just use the HOC's chrome. Pass `showAxes` on `XYCustomChart` / `OrdinalCustomChart` and the frame will render the same x/y or o/r axes the built-in HOCs do — useful for custom XY layouts that overlay points/lines on regular axes. The recipe-managed chrome is for the cases where standard axes can't help (variable-width bars under a band scale, per-row independent scales, etc.).
 
 **Notes:**
 - Coords are plot-relative (the frame translates the canvas/SVG group by `margin`). Read `ctx.dimensions.plot` for the drawing rect. Radial ordinal projection is the one exception: `plot.x = -width/2`, `plot.y = -height/2` because the canvas ctx is center-translated.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,19 +105,19 @@ Not supported: Tree, Treemap, CirclePack, Orbit, ChoroplethMap, FlowMap, Scatter
 
 When the catalog doesn't fit, three HOCs let you supply a layout function that emits scene primitives directly. The frame still owns hit testing, transitions, decay, theme cascade, and SSR — your layout owns geometry only.
 
-- **`CustomChart`** (`semiotic/xy`) — XY layouts: waffle, calendar heatmap, custom point/line/area arrangements
+- **`XYCustomChart`** (`semiotic/xy`) — XY layouts: waffle, calendar heatmap, custom point/line/area arrangements
 - **`OrdinalCustomChart`** (`semiotic/ordinal`) — category × value layouts: marimekko, parallel coordinates, bullet, fan chart, slope graph
 - **`NetworkCustomChart`** (`semiotic/network`) — graph layouts: flextree, dagre, custom force/radial
 
 All three accept `layout` and `layoutConfig` (your own typed config), but the layout context and return shape differ by chart family:
 
-- **`CustomChart` / `OrdinalCustomChart`** — `layout: (ctx) => { nodes, overlays? }`. Context exposes `data`, `scales`, `dimensions` (with plot rect — center-anchored for radial ordinal, top-left otherwise), `theme` (semantic + categorical), `resolveColor(key)`, and `config`. XY scales: `{ x, y }` (linear). Ordinal scales: `{ o, r, projection }` (band + linear).
+- **`XYCustomChart` / `OrdinalCustomChart`** — `layout: (ctx) => { nodes, overlays? }`. Context exposes `data`, `scales`, `dimensions` (with plot rect — center-anchored for radial ordinal, top-left otherwise), `theme` (semantic + categorical), `resolveColor(key)`, and `config`. XY scales: `{ x, y }` (linear). Ordinal scales: `{ o, r, projection }` (band + linear).
 - **`NetworkCustomChart`** — `layout: (ctx) => { sceneNodes?, sceneEdges?, labels?, overlays? }`. Context exposes `nodes`, `edges`, `dimensions`, `theme`, `resolveColor(key)`, and `config` — graph data, no `data`/`scales`. Network layouts often run an external positioner (`d3-flextree`, `dagre`) on nodes/edges, then emit network scene primitives (`circle`, `rect`, `arc` for nodes; `line`, `bezier`, `curved` for edges).
 
 XY/ordinal frames render whatever you put in `nodes` (rect, point, area, line, wedge, connector, etc.). Network frames split node-shaped scenes from edge-shaped scenes — give them `sceneNodes` for the round/rect/arc visuals and `sceneEdges` for the connecting paths. All three frames handle painting, hit testing, accessibility, transitions, decay, and SSR for you.
 
 ```tsx
-import { CustomChart } from "semiotic/xy"
+import { XYCustomChart } from "semiotic/xy"
 import { OrdinalCustomChart } from "semiotic/ordinal"
 import { NetworkCustomChart } from "semiotic/network"
 import {
@@ -126,7 +126,7 @@ import {
   flextreeLayout, dagreLayout,             // network
 } from "semiotic/recipes"
 
-<CustomChart data={cells} layout={waffleLayout} layoutConfig={{ rows: 10, columns: 10, ... }} />
+<XYCustomChart data={cells} layout={waffleLayout} layoutConfig={{ rows: 10, columns: 10, ... }} />
 <OrdinalCustomChart data={revenue} layout={marimekkoLayout} layoutConfig={{ ... }} />
 <NetworkCustomChart nodes={nodes} edges={edges} layout={flextreeLayout} layoutConfig={{ ... }} />
 ```
@@ -152,7 +152,7 @@ Writing your own recipe: prefer `showXxx` boolean toggles for chrome opt-out, `x
 
 ### Interaction (hover, brush, selection): the parent component owns it
 
-Recipes are pure functions, so they can't carry interactive state (hover, brush ranges, selection). The pattern: recipes accept a **predicate prop** (e.g. `parallelCoordinatesLayout`'s `highlightFn?: (d) => boolean`) and the parent component manages state. Wire `onObservation` (`{ type: "hover" | "hover-end" | ... }`) on `OrdinalCustomChart` / `CustomChart` / `NetworkCustomChart` to update parent state, then feed a derived predicate back into `layoutConfig`. Matching rows render at full opacity; non-matching dim. Highlighted rows z-order on top so neighbors don't cover them.
+Recipes are pure functions, so they can't carry interactive state (hover, brush ranges, selection). The pattern: recipes accept a **predicate prop** (e.g. `parallelCoordinatesLayout`'s `highlightFn?: (d) => boolean`) and the parent component manages state. Wire `onObservation` (`{ type: "hover" | "hover-end" | ... }`) on `OrdinalCustomChart` / `XYCustomChart` / `NetworkCustomChart` to update parent state, then feed a derived predicate back into `layoutConfig`. Matching rows render at full opacity; non-matching dim. Highlighted rows z-order on top so neighbors don't cover them.
 
 ```tsx
 const [hovered, setHovered] = useState(null)
@@ -174,7 +174,7 @@ The same predicate hook is the integration point for richer interactions on the 
 
 ### Built-in chrome works when the layout uses standard scales
 
-Layouts that draw *within* the frame's standard scales can just use the HOC's chrome. Pass `showAxes` on `CustomChart` / `OrdinalCustomChart` and the frame will render the same x/y or o/r axes the built-in HOCs do — useful for custom XY layouts that overlay points/lines on regular axes. The recipe-managed chrome is for the cases where standard axes can't help (variable-width bars under a band scale, per-row independent scales, etc.).
+Layouts that draw *within* the frame's standard scales can just use the HOC's chrome. Pass `showAxes` on `XYCustomChart` / `OrdinalCustomChart` and the frame will render the same x/y or o/r axes the built-in HOCs do — useful for custom XY layouts that overlay points/lines on regular axes. The recipe-managed chrome is for the cases where standard axes can't help (variable-width bars under a band scale, per-row independent scales, etc.).
 
 **Notes:**
 - Coords are plot-relative (the frame translates the canvas/SVG group by `margin`). Read `ctx.dimensions.plot` for the drawing rect. Radial ordinal projection is the one exception: `plot.x = -width/2`, `plot.y = -height/2` because the canvas ctx is center-translated.

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -105,19 +105,19 @@ Not supported: Tree, Treemap, CirclePack, Orbit, ChoroplethMap, FlowMap, Scatter
 
 When the catalog doesn't fit, three HOCs let you supply a layout function that emits scene primitives directly. The frame still owns hit testing, transitions, decay, theme cascade, and SSR — your layout owns geometry only.
 
-- **`CustomChart`** (`semiotic/xy`) — XY layouts: waffle, calendar heatmap, custom point/line/area arrangements
+- **`XYCustomChart`** (`semiotic/xy`) — XY layouts: waffle, calendar heatmap, custom point/line/area arrangements
 - **`OrdinalCustomChart`** (`semiotic/ordinal`) — category × value layouts: marimekko, parallel coordinates, bullet, fan chart, slope graph
 - **`NetworkCustomChart`** (`semiotic/network`) — graph layouts: flextree, dagre, custom force/radial
 
 All three accept `layout` and `layoutConfig` (your own typed config), but the layout context and return shape differ by chart family:
 
-- **`CustomChart` / `OrdinalCustomChart`** — `layout: (ctx) => { nodes, overlays? }`. Context exposes `data`, `scales`, `dimensions` (with plot rect — center-anchored for radial ordinal, top-left otherwise), `theme` (semantic + categorical), `resolveColor(key)`, and `config`. XY scales: `{ x, y }` (linear). Ordinal scales: `{ o, r, projection }` (band + linear).
+- **`XYCustomChart` / `OrdinalCustomChart`** — `layout: (ctx) => { nodes, overlays? }`. Context exposes `data`, `scales`, `dimensions` (with plot rect — center-anchored for radial ordinal, top-left otherwise), `theme` (semantic + categorical), `resolveColor(key)`, and `config`. XY scales: `{ x, y }` (linear). Ordinal scales: `{ o, r, projection }` (band + linear).
 - **`NetworkCustomChart`** — `layout: (ctx) => { sceneNodes?, sceneEdges?, labels?, overlays? }`. Context exposes `nodes`, `edges`, `dimensions`, `theme`, `resolveColor(key)`, and `config` — graph data, no `data`/`scales`. Network layouts often run an external positioner (`d3-flextree`, `dagre`) on nodes/edges, then emit network scene primitives (`circle`, `rect`, `arc` for nodes; `line`, `bezier`, `curved` for edges).
 
 XY/ordinal frames render whatever you put in `nodes` (rect, point, area, line, wedge, connector, etc.). Network frames split node-shaped scenes from edge-shaped scenes — give them `sceneNodes` for the round/rect/arc visuals and `sceneEdges` for the connecting paths. All three frames handle painting, hit testing, accessibility, transitions, decay, and SSR for you.
 
 ```tsx
-import { CustomChart } from "semiotic/xy"
+import { XYCustomChart } from "semiotic/xy"
 import { OrdinalCustomChart } from "semiotic/ordinal"
 import { NetworkCustomChart } from "semiotic/network"
 import {
@@ -126,7 +126,7 @@ import {
   flextreeLayout, dagreLayout,             // network
 } from "semiotic/recipes"
 
-<CustomChart data={cells} layout={waffleLayout} layoutConfig={{ rows: 10, columns: 10, ... }} />
+<XYCustomChart data={cells} layout={waffleLayout} layoutConfig={{ rows: 10, columns: 10, ... }} />
 <OrdinalCustomChart data={revenue} layout={marimekkoLayout} layoutConfig={{ ... }} />
 <NetworkCustomChart nodes={nodes} edges={edges} layout={flextreeLayout} layoutConfig={{ ... }} />
 ```
@@ -152,7 +152,7 @@ Writing your own recipe: prefer `showXxx` boolean toggles for chrome opt-out, `x
 
 ### Interaction (hover, brush, selection): the parent component owns it
 
-Recipes are pure functions, so they can't carry interactive state (hover, brush ranges, selection). The pattern: recipes accept a **predicate prop** (e.g. `parallelCoordinatesLayout`'s `highlightFn?: (d) => boolean`) and the parent component manages state. Wire `onObservation` (`{ type: "hover" | "hover-end" | ... }`) on `OrdinalCustomChart` / `CustomChart` / `NetworkCustomChart` to update parent state, then feed a derived predicate back into `layoutConfig`. Matching rows render at full opacity; non-matching dim. Highlighted rows z-order on top so neighbors don't cover them.
+Recipes are pure functions, so they can't carry interactive state (hover, brush ranges, selection). The pattern: recipes accept a **predicate prop** (e.g. `parallelCoordinatesLayout`'s `highlightFn?: (d) => boolean`) and the parent component manages state. Wire `onObservation` (`{ type: "hover" | "hover-end" | ... }`) on `OrdinalCustomChart` / `XYCustomChart` / `NetworkCustomChart` to update parent state, then feed a derived predicate back into `layoutConfig`. Matching rows render at full opacity; non-matching dim. Highlighted rows z-order on top so neighbors don't cover them.
 
 ```tsx
 const [hovered, setHovered] = useState(null)
@@ -174,7 +174,7 @@ The same predicate hook is the integration point for richer interactions on the 
 
 ### Built-in chrome works when the layout uses standard scales
 
-Layouts that draw *within* the frame's standard scales can just use the HOC's chrome. Pass `showAxes` on `CustomChart` / `OrdinalCustomChart` and the frame will render the same x/y or o/r axes the built-in HOCs do — useful for custom XY layouts that overlay points/lines on regular axes. The recipe-managed chrome is for the cases where standard axes can't help (variable-width bars under a band scale, per-row independent scales, etc.).
+Layouts that draw *within* the frame's standard scales can just use the HOC's chrome. Pass `showAxes` on `XYCustomChart` / `OrdinalCustomChart` and the frame will render the same x/y or o/r axes the built-in HOCs do — useful for custom XY layouts that overlay points/lines on regular axes. The recipe-managed chrome is for the cases where standard axes can't help (variable-width bars under a band scale, per-row independent scales, etc.).
 
 **Notes:**
 - Coords are plot-relative (the frame translates the canvas/SVG group by `margin`). Read `ctx.dimensions.plot` for the drawing rect. Radial ordinal projection is the one exception: `plot.x = -width/2`, `plot.y = -height/2` because the canvas ctx is center-translated.

--- a/docs/src/pages/features/CustomChartsPage.js
+++ b/docs/src/pages/features/CustomChartsPage.js
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useCallback } from "react"
-import { CustomChart } from "../../../../src/components/charts/custom/CustomChart"
+import { XYCustomChart } from "../../../../src/components/charts/custom/XYCustomChart"
 import { NetworkCustomChart } from "../../../../src/components/charts/custom/NetworkCustomChart"
 import { OrdinalCustomChart } from "../../../../src/components/charts/custom/OrdinalCustomChart"
 import { StackedAreaChart } from "../../../../src/components/charts/xy/StackedAreaChart"
@@ -230,7 +230,7 @@ export default function CustomChartsPage() {
     <PageLayout title="Custom Charts" subtitle="Bespoke geometry on top of the built-in pipeline">
       <section>
         <p>
-          When the catalog doesn't fit, <code>CustomChart</code> lets you supply a layout
+          When the catalog doesn't fit, <code>XYCustomChart</code> lets you supply a layout
           function that emits scene nodes directly. The frame still owns scales, theme,
           hit testing, transitions, decay, accessibility, and SSR — your layout owns the
           geometry. Most novel chart types (waffle, calendar, streamgraph,
@@ -251,7 +251,7 @@ export default function CustomChartsPage() {
           theme, hover, and selection feature works without extra wiring.
         </p>
         <div style={{ background: "var(--surface-2, #f8f8f8)", borderRadius: 8, padding: 16, border: "1px solid var(--border-color, #e0e0e0)" }}>
-          <CustomChart
+          <XYCustomChart
             data={waffleData}
             layout={waffleLayout}
             layoutConfig={{
@@ -267,10 +267,10 @@ export default function CustomChartsPage() {
             colorScheme={["#4e79a7", "#f28e2c", "#59a14f", "#e15759"]}
           />
         </div>
-        <CodeBlock language="jsx">{`import { CustomChart } from "semiotic/xy"
+        <CodeBlock language="jsx">{`import { XYCustomChart } from "semiotic/xy"
 import { waffleLayout } from "semiotic/recipes"
 
-<CustomChart
+<XYCustomChart
   data={[
     { region: "AMER",  share: 42 },
     { region: "EMEA",  share: 28 },
@@ -297,7 +297,7 @@ import { waffleLayout } from "semiotic/recipes"
           <code>colorRamp</code> for non-default ramps.
         </p>
         <div style={{ background: "var(--surface-2, #f8f8f8)", borderRadius: 8, padding: 16, border: "1px solid var(--border-color, #e0e0e0)" }}>
-          <CustomChart
+          <XYCustomChart
             data={calendarData}
             layout={calendarLayout}
             layoutConfig={{
@@ -313,7 +313,7 @@ import { waffleLayout } from "semiotic/recipes"
         </div>
         <CodeBlock language="jsx">{`import { calendarLayout } from "semiotic/recipes"
 
-<CustomChart
+<XYCustomChart
   data={dailyEvents}
   layout={calendarLayout}
   layoutConfig={{
@@ -691,7 +691,7 @@ export const myLayout: CustomLayout<MyConfig> = (ctx) => {
         <h2>Sub-path import</h2>
         <p>
           Each frame's escape-hatch HOC ships from its own sub-path:{" "}
-          <code>CustomChart</code> from <code>semiotic/xy</code>,{" "}
+          <code>XYCustomChart</code> from <code>semiotic/xy</code>,{" "}
           <code>NetworkCustomChart</code> from <code>semiotic/network</code>,{" "}
           <code>OrdinalCustomChart</code> from <code>semiotic/ordinal</code>.
           Layout recipes live on <code>semiotic/recipes</code> as a separate
@@ -699,7 +699,7 @@ export const myLayout: CustomLayout<MyConfig> = (ctx) => {
           BYO deps (<code>d3-flextree</code>, <code>dagre</code>) are imported by
           your code, not Semiotic — keeps the library small.
         </p>
-        <CodeBlock language="jsx">{`import { CustomChart } from "semiotic/xy"
+        <CodeBlock language="jsx">{`import { XYCustomChart } from "semiotic/xy"
 import { NetworkCustomChart } from "semiotic/network"
 import { OrdinalCustomChart } from "semiotic/ordinal"
 import {
@@ -714,7 +714,7 @@ import {
         <ul>
           <li><strong>Plot-relative coordinates.</strong> Scene-node positions are in plot space — the frame already translates by the resolved <code>margin</code>. Use <code>ctx.dimensions.plot</code> for the drawing rect.</li>
           <li><strong>Renderer dispatch.</strong> When <code>customLayout</code> is provided, the frame uses a renderer set that handles every node type, so your layout can emit any mix of rects, areas, lines, etc. regardless of <code>chartType</code>.</li>
-          <li><strong>Extents.</strong> If your layout uses scales, pass <code>xExtent</code> / <code>yExtent</code> on <code>CustomChart</code> to lock the domain. Layouts that don't use scales (waffle, calendar) ignore them.</li>
+          <li><strong>Extents.</strong> If your layout uses scales, pass <code>xExtent</code> / <code>yExtent</code> on <code>XYCustomChart</code> to lock the domain. Layouts that don't use scales (waffle, calendar) ignore them.</li>
           <li>
             For richer composition examples, see <Link to="/recipes/benchmark-dashboard">recipes pages</Link>.
             Streamgraph baseline lives on <Link to="/charts/stacked-area-chart">StackedAreaChart</Link>.

--- a/etc/api-surface/semiotic-xy.api.md
+++ b/etc/api-surface/semiotic-xy.api.md
@@ -8,7 +8,6 @@ function AreaChart
 function BubbleChart
 function CandlestickChart
 function ConnectedScatterplot
-function CustomChart
 function Heatmap
 function LineChart
 function MinimapChart
@@ -18,11 +17,11 @@ function Scatterplot
 function ScatterplotMatrix
 function StackedAreaChart
 function StreamXYFrame
+function XYCustomChart
 interface AreaChartProps
 interface BubbleChartProps
 interface CandlestickChartProps
 interface ConnectedScatterplotProps
-interface CustomChartProps
 interface HeatmapProps
 interface LayoutContext
 interface LayoutResult
@@ -33,5 +32,6 @@ interface ScatterplotProps
 interface StackedAreaChartProps
 interface StreamXYFrameHandle
 interface StreamXYFrameProps
+interface XYCustomChartProps
 type CustomLayout
 ```

--- a/etc/api-surface/semiotic.api.md
+++ b/etc/api-surface/semiotic.api.md
@@ -26,7 +26,6 @@ function ChordDiagram
 function CirclePack
 function ConnectedScatterplot
 function ContextLayout
-function CustomChart
 function DetailsPanel
 function DonutChart
 function DotPlot
@@ -69,6 +68,7 @@ function Tooltip
 function TreeDiagram
 function Treemap
 function ViolinPlot
+function XYCustomChart
 function adaptiveTimeTicks
 function configToJSX
 function copyConfig

--- a/src/components/charts/custom/CustomChart.tsx
+++ b/src/components/charts/custom/CustomChart.tsx
@@ -1,17 +1,14 @@
 "use client"
 import * as React from "react"
-import { forwardRef, useRef } from "react"
+import { forwardRef } from "react"
 import StreamXYFrame from "../../stream/StreamXYFrame"
 import type { StreamXYFrameProps, StreamXYFrameHandle } from "../../stream/types"
 import type { RealtimeFrameHandle } from "../../realtime/types"
 import type { CustomLayout } from "../../stream/customLayout"
 import type { Datum } from "../shared/datumTypes"
 import type { BaseChartProps, AxisConfig } from "../shared/types"
-import { useChartMode } from "../shared/hooks"
 import { SafeRender } from "../shared/withChartWrapper"
-import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
-import { filterSparseArray } from "../shared/sparseArray"
-import { useChartSetup } from "../shared/useChartSetup"
+import { useCustomChartSetup } from "../shared/useCustomChartSetup"
 import { buildBaseMetadataProps, buildCustomBehaviorProps } from "../shared/streamPropsHelpers"
 import type { TooltipProp } from "../../Tooltip/Tooltip"
 
@@ -71,20 +68,6 @@ export const CustomChart = forwardRef(function CustomChart<
   TDatum extends Datum = Datum,
   TConfig extends object = Record<string, unknown>
 >(props: CustomChartProps<TDatum, TConfig>, ref: React.Ref<RealtimeFrameHandle>) {
-  const frameRef = useRef<StreamXYFrameHandle>(null)
-  useFrameImperativeHandle(ref, { variant: "xy", frameRef })
-
-  const resolved = useChartMode(props.mode, {
-    width: props.width,
-    height: props.height,
-    showGrid: props.showGrid,
-    enableHover: props.enableHover,
-    showLegend: props.showLegend,
-    title: props.title,
-    xLabel: props.xLabel,
-    yLabel: props.yLabel,
-  })
-
   const {
     data,
     layout,
@@ -106,46 +89,35 @@ export const CustomChart = forwardRef(function CustomChart<
     frameProps = {},
   } = props
 
-  const {
-    width,
-    height,
-    enableHover,
-    showGrid,
-    showLegend,
-    title,
-    description,
-    summary,
-    accessibleTable,
-    xLabel,
-    yLabel,
-  } = resolved
-
-  const safeData = React.useMemo(() => filterSparseArray(data ?? []), [data])
-
-  const setup = useChartSetup({
-    data: safeData,
-    rawData: data,
-    colorBy: undefined,
+  const { frameRef, resolved, safeData, setup, earlyReturn } = useCustomChartSetup<StreamXYFrameHandle>({
+    imperativeRef: ref,
+    imperativeVariant: "xy",
+    chartTypeLabel: "CustomChart",
+    unwrapData: false,
+    data,
     colorScheme,
-    legendInteraction: undefined,
     selection,
     linkedHover,
-    fallbackFields: [],
-    unwrapData: false,
     onObservation,
     onClick,
-    chartType: "CustomChart",
     chartId,
-    showLegend,
-    userMargin,
-    marginDefaults: resolved.marginDefaults,
     loading,
     emptyContent,
-    width,
-    height,
+    margin: userMargin,
+    width: props.width,
+    height: props.height,
+    showGrid: props.showGrid,
+    enableHover: props.enableHover,
+    showLegend: props.showLegend,
+    title: props.title,
+    mode: props.mode,
+    xLabel: props.xLabel,
+    yLabel: props.yLabel,
   })
 
-  if (setup.earlyReturn) return setup.earlyReturn
+  if (earlyReturn) return earlyReturn
+
+  const { width, height, enableHover, showGrid, title, description, summary, accessibleTable, xLabel, yLabel } = resolved
 
   const streamProps: StreamXYFrameProps = {
     chartType: "custom",

--- a/src/components/charts/custom/NetworkCustomChart.tsx
+++ b/src/components/charts/custom/NetworkCustomChart.tsx
@@ -1,6 +1,6 @@
 "use client"
 import * as React from "react"
-import { forwardRef, useMemo, useRef } from "react"
+import { forwardRef, useMemo } from "react"
 import StreamNetworkFrame from "../../stream/StreamNetworkFrame"
 import type {
   StreamNetworkFrameProps,
@@ -10,9 +10,8 @@ import type { RealtimeFrameHandle } from "../../realtime/types"
 import type { NetworkCustomLayout } from "../../stream/networkCustomLayout"
 import type { Datum } from "../shared/datumTypes"
 import type { BaseChartProps } from "../shared/types"
-import { useChartMode } from "../shared/hooks"
 import { SafeRender } from "../shared/withChartWrapper"
-import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
+import { useCustomChartScaffold } from "../shared/useCustomChartSetup"
 import { filterSparseArray } from "../shared/sparseArray"
 
 export interface NetworkCustomChartProps<
@@ -81,20 +80,6 @@ export const NetworkCustomChart = forwardRef(function NetworkCustomChart<
   TEdge extends Datum = Datum,
   TConfig extends object = Record<string, unknown>
 >(props: NetworkCustomChartProps<TNode, TEdge, TConfig>, ref: React.Ref<RealtimeFrameHandle>) {
-  const frameRef = useRef<StreamNetworkFrameHandle>(null)
-  useFrameImperativeHandle(ref, { variant: "network", frameRef })
-
-  const resolved = useChartMode(props.mode, {
-    width: props.width,
-    height: props.height,
-    showGrid: false,
-    enableHover: props.enableHover,
-    showLegend: undefined,
-    title: props.title,
-    xLabel: undefined,
-    yLabel: undefined,
-  })
-
   const {
     nodes,
     edges,
@@ -103,33 +88,27 @@ export const NetworkCustomChart = forwardRef(function NetworkCustomChart<
     nodeIDAccessor = "id",
     sourceAccessor = "source",
     targetAccessor = "target",
-    margin: userMarginRaw,
+    margin: userMargin,
     className,
     colorScheme,
     frameProps = {},
   } = props
 
-  // PartialMargin allows a number shorthand; StreamNetworkFrame's margin
-  // only accepts the sided object form.
-  const userMargin = useMemo(() => {
-    if (typeof userMarginRaw === "number") {
-      return { top: userMarginRaw, right: userMarginRaw, bottom: userMarginRaw, left: userMarginRaw }
-    }
-    return userMarginRaw
-  }, [userMarginRaw])
-
-  const {
-    width,
-    height,
-    enableHover,
-    title,
-    description,
-    summary,
-    accessibleTable,
-  } = resolved
+  const { frameRef, resolved, normalizedMargin } = useCustomChartScaffold<StreamNetworkFrameHandle>({
+    imperativeRef: ref,
+    imperativeVariant: "network",
+    margin: userMargin,
+    width: props.width,
+    height: props.height,
+    enableHover: props.enableHover,
+    title: props.title,
+    mode: props.mode,
+  })
 
   const safeNodes = useMemo(() => filterSparseArray(nodes ?? []), [nodes])
   const safeEdges = useMemo(() => filterSparseArray(edges ?? []), [edges])
+
+  const { width, height, enableHover, title, description, summary, accessibleTable } = resolved
 
   const streamProps: StreamNetworkFrameProps = {
     chartType: "force",
@@ -144,7 +123,7 @@ export const NetworkCustomChart = forwardRef(function NetworkCustomChart<
     size: [width, height],
     responsiveWidth: props.responsiveWidth,
     responsiveHeight: props.responsiveHeight,
-    margin: userMargin,
+    margin: normalizedMargin,
     className,
     title,
     description,

--- a/src/components/charts/custom/OrdinalCustomChart.tsx
+++ b/src/components/charts/custom/OrdinalCustomChart.tsx
@@ -1,6 +1,6 @@
 "use client"
 import * as React from "react"
-import { forwardRef, useMemo, useRef } from "react"
+import { forwardRef } from "react"
 import StreamOrdinalFrame from "../../stream/StreamOrdinalFrame"
 import type {
   StreamOrdinalFrameProps,
@@ -10,12 +10,9 @@ import type { RealtimeFrameHandle } from "../../realtime/types"
 import type { OrdinalCustomLayout } from "../../stream/ordinalCustomLayout"
 import type { Datum } from "../shared/datumTypes"
 import type { BaseChartProps } from "../shared/types"
-import { useChartMode } from "../shared/hooks"
 import { SafeRender } from "../shared/withChartWrapper"
-import { filterSparseArray } from "../shared/sparseArray"
-import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
 import { buildBaseMetadataProps, buildCustomBehaviorProps } from "../shared/streamPropsHelpers"
-import { useChartSetup } from "../shared/useChartSetup"
+import { useCustomChartSetup } from "../shared/useCustomChartSetup"
 
 export interface OrdinalCustomChartProps<
   TDatum extends Datum = Datum,
@@ -88,24 +85,6 @@ export const OrdinalCustomChart = forwardRef(function OrdinalCustomChart<
   TDatum extends Datum = Datum,
   TConfig extends object = Record<string, unknown>
 >(props: OrdinalCustomChartProps<TDatum, TConfig>, ref: React.Ref<RealtimeFrameHandle>) {
-  const frameRef = useRef<StreamOrdinalFrameHandle>(null)
-
-  // Forward push/pushMany/clear/getData to the inner frame via the shared
-  // helper. The "xy" variant's expected shape (XYOrdinalFrameLike) matches
-  // StreamOrdinalFrameHandle exactly — same shape both frames use.
-  useFrameImperativeHandle(ref, { variant: "xy", frameRef })
-
-  const resolved = useChartMode(props.mode, {
-    width: props.width,
-    height: props.height,
-    showGrid: props.showGrid,
-    enableHover: props.enableHover,
-    showLegend: undefined,
-    title: props.title,
-    xLabel: undefined,
-    yLabel: undefined,
-  })
-
   const {
     data,
     layout,
@@ -115,7 +94,7 @@ export const OrdinalCustomChart = forwardRef(function OrdinalCustomChart<
     oExtent,
     rExtent,
     projection = "vertical",
-    margin: userMarginRaw,
+    margin: userMargin,
     className,
     colorScheme,
     showAxes = false,
@@ -130,60 +109,39 @@ export const OrdinalCustomChart = forwardRef(function OrdinalCustomChart<
     frameProps = {},
   } = props
 
-  // PartialMargin allows a number shorthand; StreamOrdinalFrame's margin
-  // only accepts the sided object form.
-  const userMargin = useMemo(() => {
-    if (typeof userMarginRaw === "number") {
-      return { top: userMarginRaw, right: userMarginRaw, bottom: userMarginRaw, left: userMarginRaw }
-    }
-    return userMarginRaw
-  }, [userMarginRaw])
-
-  const {
-    width,
-    height,
-    enableHover,
-    showGrid,
-    title,
-    description,
-    summary,
-    accessibleTable,
-  } = resolved
-
-  const safeData = useMemo(() => filterSparseArray(data ?? []), [data])
-
   // Shared setup pipeline — same one BarChart/SwarmPlot/etc. use. Provides:
-  //   - setup.earlyReturn: loading skeleton or empty-state element to short-
-  //     circuit the render (so loading/emptyContent props actually do something)
+  //   - earlyReturn: loading skeleton or empty-state element to short-circuit
   //   - setup.customHoverBehavior / customClickBehavior: wraps onObservation,
-  //     onClick, selection, and linkedHover into the customHoverBehavior/
+  //     onClick, selection, and linkedHover into the customHoverBehavior /
   //     customClickBehavior fields the frame consumes (the bare props don't
   //     exist on StreamOrdinalFrameProps)
   //   - setup.margin: merged user margin + chart-mode default
-  const setup = useChartSetup({
-    data: safeData,
-    rawData: data,
-    colorBy: undefined,
+  const { frameRef, resolved, safeData, setup, earlyReturn } = useCustomChartSetup<StreamOrdinalFrameHandle>({
+    imperativeRef: ref,
+    imperativeVariant: "xy",
+    chartTypeLabel: "OrdinalCustomChart",
+    unwrapData: true,
+    data,
     colorScheme,
-    legendInteraction: undefined,
     selection,
     linkedHover,
-    fallbackFields: [],
-    unwrapData: true,
     onObservation,
     onClick,
-    chartType: "OrdinalCustomChart",
     chartId,
-    showLegend: undefined,
-    userMargin,
-    marginDefaults: resolved.marginDefaults,
     loading,
     emptyContent,
-    width,
-    height,
+    margin: userMargin,
+    width: props.width,
+    height: props.height,
+    showGrid: props.showGrid,
+    enableHover: props.enableHover,
+    title: props.title,
+    mode: props.mode,
   })
 
-  if (setup.earlyReturn) return setup.earlyReturn
+  if (earlyReturn) return earlyReturn
+
+  const { width, height, enableHover, showGrid, title, description, summary, accessibleTable } = resolved
 
   const streamProps: StreamOrdinalFrameProps = {
     chartType: "custom",

--- a/src/components/charts/custom/XYCustomChart.test.tsx
+++ b/src/components/charts/custom/XYCustomChart.test.tsx
@@ -1,13 +1,13 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest"
 import React from "react"
 import { render } from "@testing-library/react"
-import { CustomChart } from "./CustomChart"
+import { XYCustomChart } from "./XYCustomChart"
 import type { CustomLayout } from "../../stream/customLayout"
 import type { RectSceneNode } from "../../stream/types"
 import { TooltipProvider } from "../../store/TooltipStore"
 import { setupCanvasMock } from "../../../test-utils/canvasMock"
 
-// Mock StreamXYFrame to inspect the props CustomChart forwards.
+// Mock StreamXYFrame to inspect the props XYCustomChart forwards.
 let lastXYFrameProps: { customLayout?: CustomLayout; layoutConfig?: Record<string, unknown>; chartType?: string } | null = null
 vi.mock("../../stream/StreamXYFrame", () => {
   return {
@@ -19,7 +19,7 @@ vi.mock("../../stream/StreamXYFrame", () => {
   }
 })
 
-describe("CustomChart", () => {
+describe("XYCustomChart", () => {
   let cleanup: () => void
   beforeEach(() => {
     lastXYFrameProps = null
@@ -43,7 +43,7 @@ describe("CustomChart", () => {
   it("forwards customLayout and chartType=custom to the frame", () => {
     render(
       <TooltipProvider>
-        <CustomChart
+        <XYCustomChart
           data={[{ value: 1 }]}
           layout={trivialLayout}
           width={400}
@@ -58,7 +58,7 @@ describe("CustomChart", () => {
   it("forwards layoutConfig", () => {
     render(
       <TooltipProvider>
-        <CustomChart
+        <XYCustomChart
           data={[{ value: 1 }]}
           layout={trivialLayout}
           layoutConfig={{ rows: 5, columns: 5 }}

--- a/src/components/charts/custom/XYCustomChart.tsx
+++ b/src/components/charts/custom/XYCustomChart.tsx
@@ -12,7 +12,7 @@ import { useCustomChartSetup } from "../shared/useCustomChartSetup"
 import { buildBaseMetadataProps, buildCustomBehaviorProps } from "../shared/streamPropsHelpers"
 import type { TooltipProp } from "../../Tooltip/Tooltip"
 
-export interface CustomChartProps<
+export interface XYCustomChartProps<
   TDatum extends Datum = Datum,
   TConfig extends object = Record<string, unknown>
 > extends BaseChartProps, AxisConfig {
@@ -37,37 +37,37 @@ export interface CustomChartProps<
   annotations?: Datum[]
   colorScheme?: string | string[]
   tooltip?: TooltipProp
-  /** Additional StreamXYFrame props for advanced customization, excluding CustomChart-controlled fields. */
+  /** Additional StreamXYFrame props for advanced customization, excluding XYCustomChart-controlled fields. */
   frameProps?: Partial<Omit<StreamXYFrameProps, "chartType" | "data" | "size" | "customLayout" | "layoutConfig">>
 }
 
 /**
- * CustomChart — escape hatch for bespoke chart geometry.
+ * XYCustomChart — escape hatch for bespoke chart geometry.
  *
  * Wraps StreamXYFrame and threads a user-supplied layout function into the
  * scene-building pipeline. The layout receives scales, dimensions, theme,
  * and a resolveColor helper, and returns scene nodes + optional overlays.
  *
- * Built-in chart types should always be preferred. Reach for CustomChart
+ * Built-in chart types should always be preferred. Reach for XYCustomChart
  * when no HOC fits — waffle grids, calendar heatmaps, horizon bands,
  * bespoke composites. See `semiotic/recipes` for reference layouts.
  *
  * @example
  * ```tsx
- * import { CustomChart } from "semiotic/xy"
+ * import { XYCustomChart } from "semiotic/xy"
  * import { waffleLayout } from "semiotic/recipes"
  *
- * <CustomChart
+ * <XYCustomChart
  *   data={cells}
  *   layout={waffleLayout}
  *   layoutConfig={{ rows: 10, columns: 10, gutter: 2, valueAccessor: "value" }}
  * />
  * ```
  */
-export const CustomChart = forwardRef(function CustomChart<
+export const XYCustomChart = forwardRef(function XYCustomChart<
   TDatum extends Datum = Datum,
   TConfig extends object = Record<string, unknown>
->(props: CustomChartProps<TDatum, TConfig>, ref: React.Ref<RealtimeFrameHandle>) {
+>(props: XYCustomChartProps<TDatum, TConfig>, ref: React.Ref<RealtimeFrameHandle>) {
   const {
     data,
     layout,
@@ -92,7 +92,7 @@ export const CustomChart = forwardRef(function CustomChart<
   const { frameRef, resolved, safeData, setup, earlyReturn } = useCustomChartSetup<StreamXYFrameHandle>({
     imperativeRef: ref,
     imperativeVariant: "xy",
-    chartTypeLabel: "CustomChart",
+    chartTypeLabel: "XYCustomChart",
     unwrapData: false,
     data,
     colorScheme,
@@ -155,7 +155,7 @@ export const CustomChart = forwardRef(function CustomChart<
   }
 
   return (
-    <SafeRender componentName="CustomChart" width={width} height={height}>
+    <SafeRender componentName="XYCustomChart" width={width} height={height}>
       <StreamXYFrame ref={frameRef} {...streamProps} />
     </SafeRender>
   )
@@ -164,9 +164,9 @@ export const CustomChart = forwardRef(function CustomChart<
     TDatum extends Datum = Datum,
     TConfig extends object = Record<string, unknown>
   >(
-    props: CustomChartProps<TDatum, TConfig> & React.RefAttributes<RealtimeFrameHandle>
+    props: XYCustomChartProps<TDatum, TConfig> & React.RefAttributes<RealtimeFrameHandle>
   ): React.ReactElement | null
   displayName?: string
 }
 
-;(CustomChart as { displayName?: string }).displayName = "CustomChart"
+;(XYCustomChart as { displayName?: string }).displayName = "XYCustomChart"

--- a/src/components/charts/index.ts
+++ b/src/components/charts/index.ts
@@ -50,8 +50,8 @@ export type { CandlestickChartProps } from "./xy/CandlestickChart"
 // Custom Chart (escape hatch for bespoke layouts)
 // ============================================================================
 
-export { CustomChart } from "./custom/CustomChart"
-export type { CustomChartProps } from "./custom/CustomChart"
+export { XYCustomChart } from "./custom/XYCustomChart"
+export type { XYCustomChartProps } from "./custom/XYCustomChart"
 
 export { NetworkCustomChart } from "./custom/NetworkCustomChart"
 export type { NetworkCustomChartProps } from "./custom/NetworkCustomChart"

--- a/src/components/charts/shared/useCustomChartSetup.ts
+++ b/src/components/charts/shared/useCustomChartSetup.ts
@@ -29,7 +29,6 @@ import type { PartialMargin, MarginType } from "../../types/marginType"
 import type { Datum } from "./datumTypes"
 import type { RealtimeFrameHandle } from "../../realtime/types"
 import { useFrameImperativeHandle } from "./useFrameImperativeHandle"
-import { filterSparseArray } from "./sparseArray"
 
 /**
  * Margin shorthand → sided form. The Stream*Frame margin props only
@@ -145,14 +144,14 @@ export function useCustomChartSetup<TFrameHandle>(
   const scaffold = useCustomChartScaffold<TFrameHandle>(options)
   const { resolved, normalizedMargin } = scaffold
 
-  // `useChartSetup` filters sparse data internally, but HOCs that want
-  // to forward `safeData` directly into their frame's `data` prop need
-  // a parallel reference here. `filterSparseArray` returns the original
-  // reference when nothing was dropped so memo identity is preserved.
-  const safeData = useMemo(() => filterSparseArray(options.data ?? []), [options.data])
-
+  // `useChartSetup` filters sparse data internally and returns the
+  // result as `setup.data`. Forward the raw prop in and reuse that
+  // sparse-filtered output below — one pass per data change instead of
+  // two. `filterSparseArray` preserves identity when nothing's dropped,
+  // so memo cache hits in the (overwhelmingly common) clean-input case
+  // are unchanged.
   const setup = useChartSetup({
-    data: safeData,
+    data: options.data ?? [],
     rawData: options.data,
     colorBy: undefined,
     colorScheme: options.colorScheme,
@@ -176,7 +175,7 @@ export function useCustomChartSetup<TFrameHandle>(
 
   return {
     ...scaffold,
-    safeData,
+    safeData: setup.data,
     setup,
     earlyReturn: setup.earlyReturn,
   }

--- a/src/components/charts/shared/useCustomChartSetup.ts
+++ b/src/components/charts/shared/useCustomChartSetup.ts
@@ -1,0 +1,183 @@
+/**
+ * useCustomChartScaffold / useCustomChartSetup — shared scaffolding for
+ * the three custom-layout HOCs.
+ *
+ * `CustomChart`, `OrdinalCustomChart`, and `NetworkCustomChart` all
+ * repeat the same orchestration pipeline: bind the imperative ref, run
+ * `useChartMode`, normalize the user margin shorthand, filter the
+ * sparse data array, and (for the data-shaped HOCs) call
+ * `useChartSetup` for selection / legend / loading / empty plumbing.
+ *
+ * The split:
+ *   - `useCustomChartScaffold`  — chart-mode + margin + imperative
+ *      handle. Used by all three HOCs (network calls this directly).
+ *   - `useCustomChartSetup`     — the scaffold *plus* `useChartSetup`
+ *      wiring for the data-shaped HOCs (CustomChart, OrdinalCustomChart).
+ *
+ * Two separate hooks rather than one conditional hook so React's
+ * rules-of-hooks aren't on the line — each call site pins exactly one
+ * shape.
+ */
+"use client"
+import { useMemo, useRef } from "react"
+import type { Ref, RefObject, ReactElement, ReactNode } from "react"
+import { useChartMode } from "./hooks"
+import { useChartSetup, type ChartSetupResult } from "./useChartSetup"
+import type { ChartMode, SelectionConfig, LinkedHoverProp } from "./types"
+import type { OnObservationCallback } from "../../store/ObservationStore"
+import type { PartialMargin, MarginType } from "../../types/marginType"
+import type { Datum } from "./datumTypes"
+import type { RealtimeFrameHandle } from "../../realtime/types"
+import { useFrameImperativeHandle } from "./useFrameImperativeHandle"
+import { filterSparseArray } from "./sparseArray"
+
+/**
+ * Margin shorthand → sided form. The Stream*Frame margin props only
+ * accept the sided object form, so HOCs that expose the user-friendly
+ * number shorthand have to expand it themselves. Centralized here so
+ * every custom-layout HOC normalizes consistently.
+ */
+export function normalizeUserMargin(m: PartialMargin | undefined): Partial<MarginType> | undefined {
+  if (m == null) return undefined
+  if (typeof m === "number") return { top: m, right: m, bottom: m, left: m }
+  return m
+}
+
+interface ScaffoldOptions<TFrameHandle> {
+  /** Ref forwarded by the HOC. The hook binds the imperative handle internally. */
+  imperativeRef: Ref<RealtimeFrameHandle> | undefined
+  /** Which `useFrameImperativeHandle` variant to bind. XY/ordinal frames share "xy". */
+  imperativeVariant: "xy" | "network"
+  /** Margin shorthand or sided form from the HOC's `margin` prop. */
+  margin: PartialMargin | undefined
+  // Common chart-mode inputs
+  width?: number
+  height?: number
+  showGrid?: boolean
+  enableHover?: boolean
+  showLegend?: boolean
+  title?: string
+  mode?: ChartMode
+  xLabel?: string
+  yLabel?: string
+}
+
+interface ScaffoldResult<TFrameHandle> {
+  /** Ref to attach to the inner Stream*Frame component. */
+  frameRef: RefObject<TFrameHandle | null>
+  /** Result of `useChartMode` — width/height/showGrid/etc. with mode defaults applied. */
+  resolved: ReturnType<typeof useChartMode>
+  /** User margin normalized to the sided form, or undefined if not supplied. */
+  normalizedMargin: Partial<MarginType> | undefined
+}
+
+/**
+ * Scaffold shared by all three custom-layout HOCs: imperative-handle
+ * binding, chart-mode resolution, margin normalization. Network HOCs
+ * stop here; data-shaped HOCs layer `useChartSetup` on top via
+ * `useCustomChartSetup`.
+ */
+export function useCustomChartScaffold<TFrameHandle>(
+  options: ScaffoldOptions<TFrameHandle>
+): ScaffoldResult<TFrameHandle> {
+  const frameRef = useRef<TFrameHandle | null>(null)
+  useFrameImperativeHandle(options.imperativeRef, {
+    variant: options.imperativeVariant,
+    frameRef: frameRef as RefObject<unknown>,
+  })
+
+  const resolved = useChartMode(options.mode, {
+    width: options.width,
+    height: options.height,
+    showGrid: options.showGrid,
+    enableHover: options.enableHover,
+    showLegend: options.showLegend,
+    title: options.title,
+    xLabel: options.xLabel,
+    yLabel: options.yLabel,
+  })
+
+  const normalizedMargin = useMemo(
+    () => normalizeUserMargin(options.margin),
+    [options.margin],
+  )
+
+  return { frameRef, resolved, normalizedMargin }
+}
+
+interface DataSetupOptions<TFrameHandle> extends ScaffoldOptions<TFrameHandle> {
+  /** Raw `data` prop from the HOC (may be undefined in push mode). */
+  data: Datum[] | undefined
+  /** Label used by useChartSetup for observation events ("CustomChart", "OrdinalCustomChart"). */
+  chartTypeLabel: string
+  /** Whether the hover callback should unwrap the datum (ordinal/network = true, XY = false). */
+  unwrapData: boolean
+  /** Color scheme threaded into useChartSetup's color resolution. */
+  colorScheme?: string | string[]
+  /** Pass-through chart-setup inputs. */
+  selection?: SelectionConfig
+  linkedHover?: LinkedHoverProp
+  onObservation?: OnObservationCallback
+  onClick?: (datum: any, ev: { x: number; y: number }) => void
+  chartId?: string
+  loading?: boolean
+  emptyContent?: ReactNode
+}
+
+interface DataSetupResult<TFrameHandle> extends ScaffoldResult<TFrameHandle> {
+  /** Sparse-filtered copy of the input data array. */
+  safeData: Datum[]
+  /** Full `useChartSetup` result — selection/legend/behavior wiring for the streamProps. */
+  setup: ChartSetupResult
+  /** If non-null, the HOC should render this immediately (loading skeleton or empty state). */
+  earlyReturn: ReactElement | null
+}
+
+/**
+ * Scaffold + `useChartSetup` wiring for the data-shaped custom-layout
+ * HOCs (`CustomChart`, `OrdinalCustomChart`). Each HOC stays in charge
+ * of its own frame-specific streamProps; the hook only owns the
+ * orchestration that is genuinely identical.
+ */
+export function useCustomChartSetup<TFrameHandle>(
+  options: DataSetupOptions<TFrameHandle>
+): DataSetupResult<TFrameHandle> {
+  const scaffold = useCustomChartScaffold<TFrameHandle>(options)
+  const { resolved, normalizedMargin } = scaffold
+
+  // `useChartSetup` filters sparse data internally, but HOCs that want
+  // to forward `safeData` directly into their frame's `data` prop need
+  // a parallel reference here. `filterSparseArray` returns the original
+  // reference when nothing was dropped so memo identity is preserved.
+  const safeData = useMemo(() => filterSparseArray(options.data ?? []), [options.data])
+
+  const setup = useChartSetup({
+    data: safeData,
+    rawData: options.data,
+    colorBy: undefined,
+    colorScheme: options.colorScheme,
+    legendInteraction: undefined,
+    selection: options.selection,
+    linkedHover: options.linkedHover,
+    fallbackFields: [],
+    unwrapData: options.unwrapData,
+    onObservation: options.onObservation,
+    onClick: options.onClick,
+    chartType: options.chartTypeLabel,
+    chartId: options.chartId,
+    showLegend: resolved.showLegend,
+    userMargin: normalizedMargin,
+    marginDefaults: resolved.marginDefaults,
+    loading: options.loading,
+    emptyContent: options.emptyContent,
+    width: resolved.width,
+    height: resolved.height,
+  })
+
+  return {
+    ...scaffold,
+    safeData,
+    setup,
+    earlyReturn: setup.earlyReturn,
+  }
+}

--- a/src/components/charts/shared/useCustomChartSetup.ts
+++ b/src/components/charts/shared/useCustomChartSetup.ts
@@ -2,7 +2,7 @@
  * useCustomChartScaffold / useCustomChartSetup — shared scaffolding for
  * the three custom-layout HOCs.
  *
- * `CustomChart`, `OrdinalCustomChart`, and `NetworkCustomChart` all
+ * `XYCustomChart`, `OrdinalCustomChart`, and `NetworkCustomChart` all
  * repeat the same orchestration pipeline: bind the imperative ref, run
  * `useChartMode`, normalize the user margin shorthand, filter the
  * sparse data array, and (for the data-shaped HOCs) call
@@ -12,7 +12,7 @@
  *   - `useCustomChartScaffold`  — chart-mode + margin + imperative
  *      handle. Used by all three HOCs (network calls this directly).
  *   - `useCustomChartSetup`     — the scaffold *plus* `useChartSetup`
- *      wiring for the data-shaped HOCs (CustomChart, OrdinalCustomChart).
+ *      wiring for the data-shaped HOCs (XYCustomChart, OrdinalCustomChart).
  *
  * Two separate hooks rather than one conditional hook so React's
  * rules-of-hooks aren't on the line — each call site pins exactly one
@@ -108,7 +108,7 @@ export function useCustomChartScaffold<TFrameHandle>(
 interface DataSetupOptions<TFrameHandle> extends ScaffoldOptions<TFrameHandle> {
   /** Raw `data` prop from the HOC (may be undefined in push mode). */
   data: Datum[] | undefined
-  /** Label used by useChartSetup for observation events ("CustomChart", "OrdinalCustomChart"). */
+  /** Label used by useChartSetup for observation events ("XYCustomChart", "OrdinalCustomChart"). */
   chartTypeLabel: string
   /** Whether the hover callback should unwrap the datum (ordinal/network = true, XY = false). */
   unwrapData: boolean
@@ -135,7 +135,7 @@ interface DataSetupResult<TFrameHandle> extends ScaffoldResult<TFrameHandle> {
 
 /**
  * Scaffold + `useChartSetup` wiring for the data-shaped custom-layout
- * HOCs (`CustomChart`, `OrdinalCustomChart`). Each HOC stays in charge
+ * HOCs (`XYCustomChart`, `OrdinalCustomChart`). Each HOC stays in charge
  * of its own frame-specific streamProps; the hook only owns the
  * orchestration that is genuinely identical.
  */

--- a/src/components/recipes/bullet.ts
+++ b/src/components/recipes/bullet.ts
@@ -184,11 +184,20 @@ export const bulletLayout: OrdinalCustomLayout<BulletConfig> = (ctx) => {
     const xToPx = (v: number) => bulletX + (v / maxVal) * bulletW
     const cat = getCategory(d)
 
-    const makeDatum = (extras: Record<string, unknown>): Datum => {
-      const entries: Record<string, unknown> = { metric: cat, ...extras }
-      if (categoryKey !== "metric") entries[categoryKey] = cat
-      return createSafeDatum(entries)
-    }
+    // makeDatum runs every assignment through createSafeDatum's
+    // null-prototype writer — including user-supplied accessor names.
+    // Building an intermediate object literal first would let
+    // `__proto__` invoke the setter on a normal object before we ever
+    // reach the safe target, silently dropping the field. Each call site
+    // hands the recipe-fixed keys (kind/value/range/...) and any
+    // user-controlled accessor (categoryKey/valueKey/targetKey) through
+    // the `set` writer.
+    const makeDatum = (build: (set: (k: string, v: unknown) => void) => void): Datum =>
+      createSafeDatum((set) => {
+        set("metric", cat)
+        if (categoryKey !== "metric") set(categoryKey, cat)
+        build(set)
+      })
 
     // Background range bars — full row height, successively darker.
     let lastEnd = bulletX
@@ -203,7 +212,11 @@ export const bulletLayout: OrdinalCustomLayout<BulletConfig> = (ctx) => {
           w,
           h: rowH,
           style: { fill: rangeColors[Math.min(r, rangeColors.length - 1)], stroke: "none" },
-          datum: makeDatum({ range: r, rangeValue: ranges[r], kind: "range" }),
+          datum: makeDatum((set) => {
+            set("range", r)
+            set("rangeValue", ranges[r])
+            set("kind", "range")
+          }),
           group: `range-${r}`,
         })
       }
@@ -212,8 +225,6 @@ export const bulletLayout: OrdinalCustomLayout<BulletConfig> = (ctx) => {
 
     // Actual value bar — thinner, centered vertically inside the row.
     const actualH = Math.max(6, Math.floor(rowH * 0.45))
-    const actualExtras: Record<string, unknown> = { value: actual, kind: "actual" }
-    if (valueKey !== "value") actualExtras[valueKey] = actual
     nodes.push({
       type: "rect",
       x: bulletX,
@@ -221,15 +232,17 @@ export const bulletLayout: OrdinalCustomLayout<BulletConfig> = (ctx) => {
       w: xToPx(actual) - bulletX,
       h: actualH,
       style: { fill: baseColor, stroke: "none" },
-      datum: makeDatum(actualExtras),
+      datum: makeDatum((set) => {
+        set("value", actual)
+        set("kind", "actual")
+        if (valueKey !== "value") set(valueKey, actual)
+      }),
       group: "actual",
     })
 
     // Target tick — narrow vertical mark spanning ~80% of row height.
     const tickW = 3
     const tickH = Math.floor(rowH * 0.8)
-    const targetExtras: Record<string, unknown> = { target, kind: "target" }
-    if (targetKey !== "target") targetExtras[targetKey] = target
     nodes.push({
       type: "rect",
       x: xToPx(target) - tickW / 2,
@@ -237,7 +250,11 @@ export const bulletLayout: OrdinalCustomLayout<BulletConfig> = (ctx) => {
       w: tickW,
       h: tickH,
       style: { fill: targetColor, stroke: "none" },
-      datum: makeDatum(targetExtras),
+      datum: makeDatum((set) => {
+        set("target", target)
+        set("kind", "target")
+        if (targetKey !== "target") set(targetKey, target)
+      }),
       group: "target",
     })
   }

--- a/src/components/recipes/bullet.ts
+++ b/src/components/recipes/bullet.ts
@@ -2,6 +2,7 @@ import * as React from "react"
 import type { OrdinalCustomLayout } from "../stream/ordinalCustomLayout"
 import type { Datum } from "../charts/shared/datumTypes"
 import type { RectSceneNode } from "../stream/types"
+import { resolveAccessor, createSafeDatum } from "./recipeUtils"
 
 export interface BulletConfig {
   /** Field (or function) yielding the row label per datum. Each row is one bullet. */
@@ -183,17 +184,10 @@ export const bulletLayout: OrdinalCustomLayout<BulletConfig> = (ctx) => {
     const xToPx = (v: number) => bulletX + (v / maxVal) * bulletW
     const cat = getCategory(d)
 
-    // `Object.create(null)` produces a prototype-less object so
-    // assigning a user-supplied key like `__proto__`, `constructor`, or
-    // `prototype` just sets a normal own-property instead of mutating
-    // the prototype chain. Defends against accidental prototype
-    // pollution when callers pass adversarial accessor names.
     const makeDatum = (extras: Record<string, unknown>): Datum => {
-      const out = Object.create(null) as Datum
-      out.metric = cat
-      if (categoryKey !== "metric") out[categoryKey] = cat
-      for (const k of Object.keys(extras)) out[k] = extras[k]
-      return out
+      const entries: Record<string, unknown> = { metric: cat, ...extras }
+      if (categoryKey !== "metric") entries[categoryKey] = cat
+      return createSafeDatum(entries)
     }
 
     // Background range bars — full row height, successively darker.
@@ -302,7 +296,3 @@ export const bulletLayout: OrdinalCustomLayout<BulletConfig> = (ctx) => {
   return { nodes, overlays }
 }
 
-function resolveAccessor<T = unknown>(a: string | ((d: Datum) => T)): (d: Datum) => T {
-  if (typeof a === "function") return a
-  return (d: Datum) => d[a] as T
-}

--- a/src/components/recipes/calendar.ts
+++ b/src/components/recipes/calendar.ts
@@ -16,7 +16,7 @@ export interface CalendarConfig {
   colorRamp?: [string, string]
   /**
    * Calendar year to render. If omitted, infers the year from the first datum.
-   * For multi-year series, render one CustomChart per year.
+   * For multi-year series, render one XYCustomChart per year.
    */
   year?: number
   /** Pixel gap between cells. @default 2 */
@@ -33,7 +33,7 @@ const DAY_MS = 86_400_000
  *
  * @example
  * ```tsx
- * <CustomChart
+ * <XYCustomChart
  *   data={dailyEvents}
  *   layout={calendarLayout}
  *   layoutConfig={{

--- a/src/components/recipes/marimekko.ts
+++ b/src/components/recipes/marimekko.ts
@@ -2,6 +2,7 @@ import * as React from "react"
 import type { OrdinalCustomLayout } from "../stream/ordinalCustomLayout"
 import type { Datum } from "../charts/shared/datumTypes"
 import type { RectSceneNode } from "../stream/types"
+import { resolveAccessor, createSafeDatum } from "./recipeUtils"
 
 export interface MarimekkoConfig {
   /** Field (or function) yielding the category for each datum. Categories become x-axis bars. */
@@ -81,19 +82,11 @@ export const marimekkoLayout: OrdinalCustomLayout<MarimekkoConfig> = (ctx) => {
   const stackKey = typeof cfg.stackBy === "string" ? cfg.stackBy : "stack"
   const valueKey = typeof cfg.valueAccessor === "string" ? cfg.valueAccessor : "value"
   const buildDatum = (cat: string, st: string, cellVal: number): Datum => {
-    // `Object.create(null)` produces an object with no prototype, so
-    // assigning a user-supplied key like `__proto__`, `constructor`, or
-    // `prototype` just sets a normal own-property instead of mutating
-    // the object's prototype chain. Defends against accidental
-    // prototype pollution when callers pass adversarial accessor names.
-    const out = Object.create(null) as Datum
-    out.category = cat
-    out.stack = st
-    out.value = cellVal
-    if (categoryKey !== "category") out[categoryKey] = cat
-    if (stackKey !== "stack") out[stackKey] = st
-    if (valueKey !== "value") out[valueKey] = cellVal
-    return out
+    const entries: Record<string, unknown> = { category: cat, stack: st, value: cellVal }
+    if (categoryKey !== "category") entries[categoryKey] = cat
+    if (stackKey !== "stack") entries[stackKey] = st
+    if (valueKey !== "value") entries[valueKey] = cellVal
+    return createSafeDatum(entries)
   }
 
   const showLabels = cfg.showCategoryLabels !== false
@@ -207,11 +200,6 @@ function renderCategoryLabels(
     }, slot.cat)
   })
   return React.createElement(React.Fragment, null, ...elements)
-}
-
-function resolveAccessor<T = unknown>(a: string | ((d: Datum) => T)): (d: Datum) => T {
-  if (typeof a === "function") return a
-  return (d: Datum) => d[a] as T
 }
 
 function mergeOrder(hint: string[], fallback: string[], existsInData: (k: string) => boolean): string[] {

--- a/src/components/recipes/marimekko.ts
+++ b/src/components/recipes/marimekko.ts
@@ -81,13 +81,15 @@ export const marimekkoLayout: OrdinalCustomLayout<MarimekkoConfig> = (ctx) => {
   const categoryKey = typeof cfg.categoryAccessor === "string" ? cfg.categoryAccessor : "category"
   const stackKey = typeof cfg.stackBy === "string" ? cfg.stackBy : "stack"
   const valueKey = typeof cfg.valueAccessor === "string" ? cfg.valueAccessor : "value"
-  const buildDatum = (cat: string, st: string, cellVal: number): Datum => {
-    const entries: Record<string, unknown> = { category: cat, stack: st, value: cellVal }
-    if (categoryKey !== "category") entries[categoryKey] = cat
-    if (stackKey !== "stack") entries[stackKey] = st
-    if (valueKey !== "value") entries[valueKey] = cellVal
-    return createSafeDatum(entries)
-  }
+  const buildDatum = (cat: string, st: string, cellVal: number): Datum =>
+    createSafeDatum((set) => {
+      set("category", cat)
+      set("stack", st)
+      set("value", cellVal)
+      if (categoryKey !== "category") set(categoryKey, cat)
+      if (stackKey !== "stack") set(stackKey, st)
+      if (valueKey !== "value") set(valueKey, cellVal)
+    })
 
   const showLabels = cfg.showCategoryLabels !== false
   const labelPad = cfg.labelPadding ?? (showLabels ? 22 : 0)

--- a/src/components/recipes/ordinalRecipes.test.ts
+++ b/src/components/recipes/ordinalRecipes.test.ts
@@ -149,13 +149,16 @@ describe("marimekkoLayout", () => {
 
   it("does not pollute Object.prototype when accessor names are adversarial", () => {
     // Regression: assigning user-supplied keys like "__proto__" onto a
-    // plain object literal can mutate the prototype chain. Recipe uses
-    // Object.create(null) so the assignment becomes a normal own-property.
+    // plain object literal mutates the prototype chain (or silently no-ops
+    // on the setter, dropping the field). The recipe routes every assignment
+    // through createSafeDatum's null-prototype writer so adversarial keys
+    // become normal own-properties on the datum and the global prototype is
+    // untouched.
     const before = Object.getOwnPropertyNames(Object.prototype).length
     const adversarial = [
       { region: "AMER", product: "Hardware", revenue: 50, polluted: "no" },
     ]
-    marimekkoLayout(makeCtx({
+    const result = marimekkoLayout(makeCtx({
       categoryAccessor: "__proto__" as string,
       stackBy: "constructor" as string,
       valueAccessor: "revenue",
@@ -163,6 +166,12 @@ describe("marimekkoLayout", () => {
     const after = Object.getOwnPropertyNames(Object.prototype).length
     expect(after).toBe(before)
     expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+    // The user-supplied "__proto__" accessor must round-trip as an
+    // *own-property* on the datum — not be silently dropped by the
+    // __proto__ setter on a non-null prototype intermediate.
+    const rect = (result.nodes! as RectSceneNode[])[0]
+    expect(Object.prototype.hasOwnProperty.call(rect.datum, "__proto__")).toBe(true)
+    expect(Object.prototype.hasOwnProperty.call(rect.datum, "constructor")).toBe(true)
   })
 })
 
@@ -309,10 +318,11 @@ describe("bulletLayout", () => {
 
   it("does not pollute Object.prototype when accessor names are adversarial", () => {
     // Regression: bullet emits datum objects keyed by user-supplied
-    // accessor names. Object.create(null) keeps "__proto__" assignments
-    // as own-properties instead of mutating the prototype chain.
+    // accessor names. createSafeDatum's null-prototype writer keeps
+    // "__proto__" assignments as own-properties instead of routing them
+    // through the prototype setter on an intermediate object.
     const before = Object.getOwnPropertyNames(Object.prototype).length
-    bulletLayout(makeCtx({
+    const result = bulletLayout(makeCtx({
       categoryAccessor: "__proto__" as string,
       valueAccessor: "constructor" as string,
       targetAccessor: "prototype" as string,
@@ -320,6 +330,14 @@ describe("bulletLayout", () => {
     }, [{ metric: "X", actual: 50, target: 60, ranges: [10, 50, 100] }]))
     const after = Object.getOwnPropertyNames(Object.prototype).length
     expect(after).toBe(before)
+    // Each rect's datum must surface the user-supplied accessor name as
+    // an own-property, not silently lose it to the __proto__ setter.
+    const rects = result.nodes! as RectSceneNode[]
+    const actualRect = rects.find((r) => r.datum?.kind === "actual")!
+    const targetRect = rects.find((r) => r.datum?.kind === "target")!
+    expect(Object.prototype.hasOwnProperty.call(actualRect.datum, "__proto__")).toBe(true)
+    expect(Object.prototype.hasOwnProperty.call(actualRect.datum, "constructor")).toBe(true)
+    expect(Object.prototype.hasOwnProperty.call(targetRect.datum, "prototype")).toBe(true)
   })
 })
 

--- a/src/components/recipes/recipeUtils.ts
+++ b/src/components/recipes/recipeUtils.ts
@@ -15,14 +15,22 @@ export function resolveAccessor<T = unknown>(a: string | ((d: Datum) => T)): (d:
  * user-supplied accessor names. `Object.create(null)` produces a
  * prototype-less object so adversarial keys like `__proto__`,
  * `constructor`, or `prototype` become normal own-properties instead of
- * mutating the prototype chain.
+ * invoking the prototype setter on a normal object literal (which
+ * silently drops the assignment).
+ *
+ * The builder takes a callback that receives a `set(key, value)` writer
+ * bound to the null-prototype object. This API forces every assignment
+ * through the safe target — passing a plain `Record<string, unknown>`
+ * instead would be unsafe, since constructing that intermediate via an
+ * object literal lets `__proto__` hit the setter before we ever reach
+ * the helper.
  *
  * Recipes funnel every datum-emit through this helper so the
  * prototype-pollution invariant is enforced in one place rather than
  * scattered across each recipe's inner loops.
  */
-export function createSafeDatum(entries: Record<string, unknown>): Datum {
+export function createSafeDatum(populate: (set: (key: string, value: unknown) => void) => void): Datum {
   const out = Object.create(null) as Datum
-  for (const k of Object.keys(entries)) out[k] = entries[k]
+  populate((key, value) => { out[key] = value })
   return out
 }

--- a/src/components/recipes/recipeUtils.ts
+++ b/src/components/recipes/recipeUtils.ts
@@ -1,0 +1,28 @@
+import type { Datum } from "../charts/shared/datumTypes"
+
+/**
+ * Normalize a string-or-function accessor into a function. Recipes
+ * consistently accept either form, so this collapses the type-check at
+ * the boundary and lets the layout body call a single function.
+ */
+export function resolveAccessor<T = unknown>(a: string | ((d: Datum) => T)): (d: Datum) => T {
+  if (typeof a === "function") return a
+  return (d: Datum) => d[a] as T
+}
+
+/**
+ * Build a datum object whose own-properties are safe to set from
+ * user-supplied accessor names. `Object.create(null)` produces a
+ * prototype-less object so adversarial keys like `__proto__`,
+ * `constructor`, or `prototype` become normal own-properties instead of
+ * mutating the prototype chain.
+ *
+ * Recipes funnel every datum-emit through this helper so the
+ * prototype-pollution invariant is enforced in one place rather than
+ * scattered across each recipe's inner loops.
+ */
+export function createSafeDatum(entries: Record<string, unknown>): Datum {
+  const out = Object.create(null) as Datum
+  for (const k of Object.keys(entries)) out[k] = entries[k]
+  return out
+}

--- a/src/components/recipes/waffle.ts
+++ b/src/components/recipes/waffle.ts
@@ -32,10 +32,10 @@ export interface WaffleConfig {
  *
  * @example
  * ```tsx
- * import { CustomChart } from "semiotic/xy"
+ * import { XYCustomChart } from "semiotic/xy"
  * import { waffleLayout } from "semiotic/recipes"
  *
- * <CustomChart
+ * <XYCustomChart
  *   data={[
  *     { region: "AMER", value: 42 },
  *     { region: "EMEA", value: 33 },

--- a/src/components/semiotic-recipes.ts
+++ b/src/components/semiotic-recipes.ts
@@ -1,5 +1,5 @@
 /**
- * Recipes entry point — curated layout functions for use with `CustomChart`.
+ * Recipes entry point — curated layout functions for use with `XYCustomChart`.
  *
  * Import from "semiotic/recipes" instead of the full bundle. Recipes are
  * pure CustomLayout functions that emit standard SceneNodes; they get hit

--- a/src/components/semiotic-xy.ts
+++ b/src/components/semiotic-xy.ts
@@ -20,7 +20,7 @@ export { MinimapChart } from "./charts/xy/MinimapChart"
 export { QuadrantChart } from "./charts/xy/QuadrantChart"
 export { MultiAxisLineChart } from "./charts/xy/MultiAxisLineChart"
 export { CandlestickChart } from "./charts/xy/CandlestickChart"
-export { CustomChart } from "./charts/custom/CustomChart"
+export { XYCustomChart } from "./charts/custom/XYCustomChart"
 
 // Stream Frame types
 export type {
@@ -46,4 +46,4 @@ export type { HeatmapProps } from "./charts/xy/Heatmap"
 export type { QuadrantChartProps } from "./charts/xy/QuadrantChart"
 export type { MultiAxisLineChartProps } from "./charts/xy/MultiAxisLineChart"
 export type { CandlestickChartProps } from "./charts/xy/CandlestickChart"
-export type { CustomChartProps } from "./charts/custom/CustomChart"
+export type { XYCustomChartProps } from "./charts/custom/XYCustomChart"

--- a/src/components/semiotic.ts
+++ b/src/components/semiotic.ts
@@ -4,7 +4,7 @@ import StreamOrdinalFrame from "./stream/StreamOrdinalFrame"
 import StreamNetworkFrame from "./stream/StreamNetworkFrame"
 
 // ── Chart HOCs ─────────────────────────────────────────────────────────
-import { Scatterplot, ConnectedScatterplot, LineChart, AreaChart, StackedAreaChart, Heatmap, BubbleChart, BarChart, StackedBarChart, LikertChart, SwarmPlot, BoxPlot, Histogram, ViolinPlot, RidgelinePlot, DotPlot, PieChart, DonutChart, GaugeChart, GroupedBarChart, FunnelChart, SwimlaneChart, ForceDirectedGraph, ChordDiagram, SankeyDiagram, TreeDiagram, Treemap, CirclePack, OrbitDiagram, ScatterplotMatrix, MinimapChart, QuadrantChart, MultiAxisLineChart, CandlestickChart, CustomChart, NetworkCustomChart, OrdinalCustomChart } from "./charts"
+import { Scatterplot, ConnectedScatterplot, LineChart, AreaChart, StackedAreaChart, Heatmap, BubbleChart, BarChart, StackedBarChart, LikertChart, SwarmPlot, BoxPlot, Histogram, ViolinPlot, RidgelinePlot, DotPlot, PieChart, DonutChart, GaugeChart, GroupedBarChart, FunnelChart, SwimlaneChart, ForceDirectedGraph, ChordDiagram, SankeyDiagram, TreeDiagram, Treemap, CirclePack, OrbitDiagram, ScatterplotMatrix, MinimapChart, QuadrantChart, MultiAxisLineChart, CandlestickChart, XYCustomChart, NetworkCustomChart, OrdinalCustomChart } from "./charts"
 
 // ── Coordinated views ──────────────────────────────────────────────────
 import { LinkedCharts } from "./LinkedCharts"
@@ -89,7 +89,7 @@ export {
   QuadrantChart,
   MultiAxisLineChart,
   CandlestickChart,
-  CustomChart,
+  XYCustomChart,
   NetworkCustomChart,
   OrdinalCustomChart,
   // Coordinated views

--- a/src/components/stream/StreamNetworkFrame.tsx
+++ b/src/components/stream/StreamNetworkFrame.tsx
@@ -1419,9 +1419,7 @@ const StreamNetworkFrame = forwardRef<
         legendHighlightedCategory={legendHighlightedCategory}
         legendIsolatedCategories={legendIsolatedCategories}
         foregroundGraphics={
-          customOverlays != null
-            ? <>{resolvedForeground}{customOverlays}</>
-            : resolvedForeground
+          composeOverlays(resolvedForeground, customOverlays)
         }
         annotations={annotations}
         svgAnnotationRules={svgAnnotationRules}

--- a/src/components/stream/StreamNetworkFrame.tsx
+++ b/src/components/stream/StreamNetworkFrame.tsx
@@ -26,6 +26,7 @@ import {
   DEFAULT_PARTICLE_STYLE
 } from "./networkTypes"
 import { NetworkPipelineStore } from "./NetworkPipelineStore"
+import { composeOverlays } from "./composeOverlays"
 import { findNearestNetworkNode } from "./NetworkCanvasHitTester"
 import { extractNetworkNavPoints, buildNavGraph, resolvePosition, nextNetworkIndex, type NavGraph } from "./keyboardNav"
 import { FocusRing } from "./FocusRing"
@@ -1332,9 +1333,7 @@ const StreamNetworkFrame = forwardRef<
           legendHighlightedCategory={legendHighlightedCategory}
           legendIsolatedCategories={legendIsolatedCategories}
           foregroundGraphics={
-            storeRef.current?.customLayoutOverlays != null
-              ? <>{resolvedForeground}{storeRef.current.customLayoutOverlays}</>
-              : resolvedForeground
+            composeOverlays(resolvedForeground, storeRef.current?.customLayoutOverlays)
           }
           annotations={annotations}
           svgAnnotationRules={svgAnnotationRules}

--- a/src/components/stream/StreamOrdinalFrame.tsx
+++ b/src/components/stream/StreamOrdinalFrame.tsx
@@ -1133,9 +1133,7 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
           legendIsolatedCategories={legendIsolatedCategories}
           legendPosition={legendPosition}
           foregroundGraphics={
-            customOverlays != null
-              ? <>{resolvedForeground}{customOverlays}</>
-              : resolvedForeground
+            composeOverlays(resolvedForeground, customOverlays)
           }
           annotations={annotations}
           svgAnnotationRules={svgAnnotationRules}

--- a/src/components/stream/StreamOrdinalFrame.tsx
+++ b/src/components/stream/StreamOrdinalFrame.tsx
@@ -42,6 +42,7 @@ import type {
 } from "./ordinalTypes"
 import { DataSourceAdapter } from "./DataSourceAdapter"
 import { OrdinalPipelineStore } from "./OrdinalPipelineStore"
+import { composeOverlays } from "./composeOverlays"
 import { findNearestOrdinalNode } from "./OrdinalCanvasHitTester"
 import { extractOrdinalNavPoints, buildNavGraph, resolvePosition, nextGraphIndex, navPointToHover, type NavGraph } from "./keyboardNav"
 import { useStalenessCheck } from "./useStalenessCheck"
@@ -1011,9 +1012,7 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
             legendIsolatedCategories={legendIsolatedCategories}
             legendPosition={legendPosition}
             foregroundGraphics={
-              storeRef.current?.customLayoutOverlays != null
-                ? <>{resolvedForeground}{storeRef.current.customLayoutOverlays}</>
-                : resolvedForeground
+              composeOverlays(resolvedForeground, storeRef.current?.customLayoutOverlays)
             }
             annotations={annotations}
             svgAnnotationRules={svgAnnotationRules}

--- a/src/components/stream/StreamXYFrame.tsx
+++ b/src/components/stream/StreamXYFrame.tsx
@@ -25,6 +25,7 @@ import { XYBrushOverlay } from "./XYBrushOverlay"
 import { DataSourceAdapter } from "./DataSourceAdapter"
 import { resolveThemeSemanticColors } from "../store/ThemeStore"
 import { PipelineStore, type PipelineConfig } from "./PipelineStore"
+import { composeOverlays } from "./composeOverlays"
 import { findNearestNode, findAllNodesAtX } from "./CanvasHitTester"
 import { extractXYNavPoints, buildNavGraph, resolvePosition, nextGraphIndex, navPointToHover, type NavGraph } from "./keyboardNav"
 import { useStalenessCheck } from "./useStalenessCheck"
@@ -1375,9 +1376,7 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
             legendIsolatedCategories={legendIsolatedCategories}
             legendPosition={legendPosition}
             foregroundGraphics={
-            storeRef.current?.customLayoutOverlays != null
-              ? <>{resolvedForeground}{storeRef.current.customLayoutOverlays}</>
-              : resolvedForeground
+            composeOverlays(resolvedForeground, storeRef.current?.customLayoutOverlays)
           }
             marginalGraphics={marginalGraphics}
             xValues={[]}
@@ -1501,9 +1500,7 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
           legendIsolatedCategories={legendIsolatedCategories}
           legendPosition={legendPosition}
           foregroundGraphics={
-            storeRef.current?.customLayoutOverlays != null
-              ? <>{resolvedForeground}{storeRef.current.customLayoutOverlays}</>
-              : resolvedForeground
+            composeOverlays(resolvedForeground, storeRef.current?.customLayoutOverlays)
           }
           marginalGraphics={marginalGraphics}
           xValues={marginalXValues}

--- a/src/components/stream/composeOverlays.test.ts
+++ b/src/components/stream/composeOverlays.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest"
+import * as React from "react"
+import { composeOverlays } from "./composeOverlays"
+
+describe("composeOverlays", () => {
+  it("returns null when every source is null/undefined", () => {
+    expect(composeOverlays()).toBeNull()
+    expect(composeOverlays(null, undefined)).toBeNull()
+  })
+
+  it("returns the single source unwrapped (no fragment) when only one is present", () => {
+    const node = React.createElement("g", { key: "a" })
+    expect(composeOverlays(null, node, undefined)).toBe(node)
+  })
+
+  it("wraps multiple sources in a single fragment, in order", () => {
+    const a = React.createElement("g", { key: "a" })
+    const b = React.createElement("g", { key: "b" })
+    const result = composeOverlays(a, null, b) as React.ReactElement<{ children: React.ReactNode[] }>
+    expect(result.type).toBe(React.Fragment)
+    // React clones children passed via createElement spreads, so identity
+    // doesn't survive — compare on the keys we set instead.
+    const childKeys = (result.props.children as React.ReactElement[]).map((c) => c.key)
+    expect(childKeys).toEqual(["a", "b"])
+  })
+
+  it("drops null/undefined gaps between real sources (so a future overlay can opt out cleanly)", () => {
+    const a = React.createElement("g", { key: "a" })
+    const c = React.createElement("g", { key: "c" })
+    const result = composeOverlays(a, undefined, null, c) as React.ReactElement<{ children: React.ReactNode[] }>
+    const childKeys = (result.props.children as React.ReactElement[]).map((ch) => ch.key)
+    expect(childKeys).toEqual(["a", "c"])
+  })
+})

--- a/src/components/stream/composeOverlays.tsx
+++ b/src/components/stream/composeOverlays.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+/**
+ * Compose a stack of overlay ReactNodes into a single fragment, dropping
+ * null/undefined sources. Each frame paints its `resolvedForeground`
+ * (axes, legends, annotations, react overlay) and may layer additional
+ * sources on top — currently `customLayoutOverlays` from recipe-managed
+ * chrome, with brush UIs and recipe-owned legends planned. Centralising
+ * the merge here keeps SSR and client branches in sync and gives future
+ * overlay sources one obvious place to plug in.
+ *
+ * Returns the single non-null source as-is when only one is present
+ * (avoids an unnecessary fragment); returns `null` when every source is
+ * absent so callers can skip the overlay subtree entirely.
+ */
+export function composeOverlays(...sources: Array<React.ReactNode | null | undefined>): React.ReactNode {
+  const present = sources.filter((s): s is React.ReactNode => s != null)
+  if (present.length === 0) return null
+  if (present.length === 1) return present[0]
+  return React.createElement(React.Fragment, null, ...present)
+}


### PR DESCRIPTION
Introduce shared scaffolding and utilities for custom-layout charts and overlay composition. Add useCustomChartScaffold/useCustomChartSetup to centralize imperative ref binding, chart-mode resolution, margin normalization, sparse-data filtering, and useChartSetup wiring; expose normalizeUserMargin. Refactor CustomChart, OrdinalCustomChart, and NetworkCustomChart to use the new hooks and remove duplicated imperative/margin/Mode logic. Add composeOverlays to merge resolvedForeground with optional customLayoutOverlays and wire it into StreamXYFrame, StreamOrdinalFrame, and StreamNetworkFrame; include unit tests for composeOverlays. Extract recipeUtils (resolveAccessor, createSafeDatum) and update bullet and marimekko recipes to use them, consolidating safe-datum creation and accessor resolution.

This pull request refactors the custom chart components to centralize and streamline their setup logic. The main change is the introduction of new shared hooks (`useCustomChartScaffold` and `useCustomChartSetup`) that handle repetitive orchestration tasks such as ref binding, chart mode resolution, margin normalization, and data preparation. This reduces code duplication and improves maintainability across `CustomChart`, `OrdinalCustomChart`, and `NetworkCustomChart`. Additionally, the bullet chart recipe now uses a safer utility for datum creation.

**Refactoring and shared logic extraction:**

* Introduced `useCustomChartScaffold` and `useCustomChartSetup` in `useCustomChartSetup.ts` to centralize imperative ref binding, chart mode resolution, margin normalization, and (for data-shaped charts) selection/legend/loading setup. All three custom chart components now use these hooks instead of duplicating this logic.

* Updated `CustomChart.tsx`, `OrdinalCustomChart.tsx`, and `NetworkCustomChart.tsx` to use the new hooks, removing local state and memoization related to chart setup, margin normalization, and imperative handle wiring. [[1]](diffhunk://#diff-5658f80f8a0783a2f8b8431113c4a285e396248a1c53436a1eba2364786f7e3cL3-R11) [[2]](diffhunk://#diff-5658f80f8a0783a2f8b8431113c4a285e396248a1c53436a1eba2364786f7e3cL74-L87) [[3]](diffhunk://#diff-5658f80f8a0783a2f8b8431113c4a285e396248a1c53436a1eba2364786f7e3cL109-R120) [[4]](diffhunk://#diff-15c4e325a43e48295d4b58bd90de81c7114e5716a6b3b840f049db8de76e4097L3-R3) [[5]](diffhunk://#diff-15c4e325a43e48295d4b58bd90de81c7114e5716a6b3b840f049db8de76e4097L13-R14) [[6]](diffhunk://#diff-15c4e325a43e48295d4b58bd90de81c7114e5716a6b3b840f049db8de76e4097L84-L97) [[7]](diffhunk://#diff-15c4e325a43e48295d4b58bd90de81c7114e5716a6b3b840f049db8de76e4097L106-R112) [[8]](diffhunk://#diff-15c4e325a43e48295d4b58bd90de81c7114e5716a6b3b840f049db8de76e4097L147-R126) [[9]](diffhunk://#diff-6f9174c17315b981364f6703c72e89f8d685d0382fe56141ed86fa71ac71922cL3-R3) [[10]](diffhunk://#diff-6f9174c17315b981364f6703c72e89f8d685d0382fe56141ed86fa71ac71922cL13-R15) [[11]](diffhunk://#diff-6f9174c17315b981364f6703c72e89f8d685d0382fe56141ed86fa71ac71922cL91-L108) [[12]](diffhunk://#diff-6f9174c17315b981364f6703c72e89f8d685d0382fe56141ed86fa71ac71922cL118-R97) [[13]](diffhunk://#diff-6f9174c17315b981364f6703c72e89f8d685d0382fe56141ed86fa71ac71922cL133-R144)

**Data safety and utility improvements:**

* Modified the bullet chart recipe to use a new `createSafeDatum` utility for constructing datums, improving safety against prototype pollution, and moved `resolveAccessor` to a shared utility module. [[1]](diffhunk://#diff-fb6b9d9175ef11fc78edc10a305e5f0ed9f0ddc8633b1903ebc0df2ad30d1dd6R5) [[2]](diffhunk://#diff-fb6b9d9175ef11fc78edc10a305e5f0ed9f0ddc8633b1903ebc0df2ad30d1dd6L186-R190) [[3]](diffhunk://#diff-fb6b9d9175ef11fc78edc10a305e5f0ed9f0ddc8633b1903ebc0df2ad30d1dd6L305-L308)

Also renames CustomChart to XYCustomChart to match the other two.