### PR TITLE
cheap ssr improvement

### DIFF
--- a/OUTSTANDING_WORK.md
+++ b/OUTSTANDING_WORK.md
@@ -1,6 +1,6 @@
 # Outstanding Work
 
-Last updated 2026-05-01.
+Last updated 2026-05-01 (cheap-fix SSR landed mid-day).
 
 This file is the active backlog only. Completed work belongs in `CHANGELOG.md`, not here.
 
@@ -18,22 +18,21 @@ This file is the active backlog only. Completed work belongs in `CHANGELOG.md`, 
 
 ### Isomorphic SSR + Hydration for Interactive Charts (Next.js style)
 
-The current SSR path (`semiotic/server` and the in-frame `isServerEnvironment` branch) emits SVG, but it isn't wired into a hydration boundary — on client mount the canvas pipeline rebuilds the scene from scratch and replaces the server output. There's no rehydration today; consumers either render server-side as static SVG (no interaction) or render client-only.
+The current SSR path (`semiotic/server` and the in-frame `isServerEnvironment` branch) emits SVG, but it isn't wired into a hydration boundary — on client mount the canvas pipeline rebuilds the scene from scratch and replaces the server output. There's no rehydration today.
 
-Real isomorphic charts (server-rendered for SEO + a11y + first-paint, then progressively interactive after hydration) need three pieces:
+**Cheap interim — landed 2026-05-01.** `UsingSSRPage` now documents the `next/dynamic({ ssr: false })` + `semiotic/server` `renderChart` placeholder pattern. Server emits the static SVG inline, client lazy-mounts the interactive chart on hydration. No rehydration, but no warnings either; SEO/a11y/first-paint story works. SSR-safety audit complete: `useResponsiveSize`, `useStalenessCheck`, and the rAF call sites already gate on `useEffect`/interaction handlers; `resolveCSSColor` already has `typeof window` guards. Only real defect was `createStore.tsx`'s `new CustomEvent("update")` (Node 19+ only) — replaced with plain `Event`. Two-way-door verified: nothing about the docs pattern or the `Event` swap blocks future real-rehydration work.
+
+**Real fix (deferred).** True isomorphic charts (server-rendered for SEO + a11y + first-paint, then progressively interactive after hydration) need three pieces:
 
 1. **Hydration-stable first paint.** The first client render must produce byte-identical SVG to the server output, then canvas activates *underneath* without unmounting. Today `<canvas>` exists on client but not server, which trips React's hydration check. Likely shape: dual-layer mode where SVG is the canonical paint surface, canvas overlays on `useEffect` for hit-testing/animation.
-2. **Server-safe stores and hooks.** `createStore.tsx` (EventTarget on Node <19), `useResponsiveSize` (ResizeObserver), and the staleness/animation hooks need explicit `typeof window` guards. The `isServerEnvironment` branch in StreamFrames covers paint, but not the surrounding hooks the HOCs call.
-3. **Datum identity round-trip.** For hover/click to work after hydration, the server-emitted scene nodes have to be reconstructable on the client — currently rebuilt from scratch on mount, which is fine for paint but means the first interaction has to wait on a full pipeline pass.
+2. **Datum identity round-trip.** For hover/click to work after hydration, the server-emitted scene nodes have to be reconstructable on the client — currently rebuilt from scratch on mount, which is fine for paint but means the first interaction has to wait on a full pipeline pass.
+3. **Decay/transition state.** Animations and decay schedules can't trivially resume from a server-painted snapshot; either snapshot the schedule too or accept a one-frame discontinuity on hydration.
 
-**Cheap interim**: `next/dynamic({ ssr: false })` with a `semiotic/server` `renderChart` placeholder. Server emits static SVG, client lazy-mounts the interactive chart on hydration. No rehydration, but no warnings either, and the SEO/a11y/first-paint story works.
-
-**Real fix**: multi-week refactor of the paint pipeline. Main tradeoff is SVG-first hydration is slower for big datasets (canvas wins past ~5k marks) but indexable and a11y-clean. Worth scoping against actual Next.js consumer demand before committing.
+Multi-week refactor of the paint pipeline. Main tradeoff: SVG-first hydration is slower for big datasets (canvas wins past ~5k marks) but indexable and a11y-clean. Worth scoping against actual Next.js consumer demand before committing.
 
 Next work:
-- Decide on cheap-interim vs. real-fix based on consumer pull.
-- If real-fix: prototype the dual-layer SVG-canvas mode on one chart family (likely XY) before generalizing.
-- Either way: audit `createStore.tsx` / `useResponsiveSize` / staleness hooks for SSR safety and add `typeof window` guards (cheap, independent of the larger decision).
+- Watch consumer pull. The cheap interim covers the static / build-time path; do consumers report needing more?
+- If pulled: prototype the dual-layer SVG-canvas mode on one chart family (likely XY) before generalizing.
 
 ---
 

--- a/docs/src/pages/UsingSSRPage.js
+++ b/docs/src/pages/UsingSSRPage.js
@@ -135,6 +135,121 @@ import { StreamNetworkFrame } from "semiotic/network"`}
       </p>
 
       {/* -------------------------------------------------------------- */}
+      <h2 id="server-placeholder-pattern">SEO and First-Paint with a Server-Rendered Placeholder</h2>
+
+      <p>
+        The standard <code>"use client"</code> pattern works, but it skips
+        server rendering entirely — the client mount is what produces the
+        first paint. For pages that need indexable chart content, faster
+        first contentful paint, or accessible chart output for non-JS
+        clients, pair <code>next/dynamic</code> with{" "}
+        <code>semiotic/server</code>'s <code>renderChart</code> as the
+        placeholder. The server emits a static SVG that's part of the
+        initial HTML; on hydration, the interactive client chart mounts in
+        place of it.
+      </p>
+
+      <p>
+        This is the cheap, working SSR story today. It's deliberately not
+        rehydration — the placeholder SVG and the client canvas are
+        produced by separate code paths, so the client mount swaps the
+        DOM out rather than picking up where the server left off. That
+        means fast initial paint, indexable static SVG, and zero
+        hydration warnings, with the cost that the first interaction has
+        to wait on client mount + the chart's initial layout pass.
+      </p>
+
+      <CodeBlock
+        code={`// app/dashboard/RevenueChart.tsx — client wrapper
+"use client"
+import dynamic from "next/dynamic"
+import type { ComponentProps } from "react"
+
+// Lazy-load the interactive chart on the client only. The placeholder
+// the server sends down comes from the parent server component below.
+const InteractiveChart = dynamic(
+  () => import("semiotic/xy").then((m) => m.LineChart),
+  { ssr: false },
+)
+
+export default function RevenueChart(props: ComponentProps<typeof InteractiveChart>) {
+  return <InteractiveChart {...props} />
+}`}
+        language="tsx"
+      />
+
+      <CodeBlock
+        code={`// app/dashboard/page.tsx — server component
+import { renderChart } from "semiotic/server"
+import RevenueChart from "./RevenueChart"
+
+export default async function DashboardPage() {
+  const data = await fetchRevenue()
+  const chartProps = { data, xAccessor: "month", yAccessor: "revenue", width: 800, height: 400 }
+
+  // Server-render a static SVG placeholder. Inline it as the initial
+  // markup; the client wrapper above replaces it on hydration.
+  const placeholder = renderChart("LineChart", chartProps)
+
+  return (
+    <main>
+      <h1>Revenue</h1>
+      <div
+        // Same dimensions as the chart so layout doesn't shift on hydration.
+        style={{ width: 800, height: 400 }}
+        // The interactive chart will mount inside this div, replacing the SVG.
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: placeholder }}
+      >
+      </div>
+      {/* Hydrate the interactive version. Pass the same props so the visual
+          continuity is exact. */}
+      <RevenueChart {...chartProps} />
+    </main>
+  )
+}`}
+        language="tsx"
+      />
+
+      <p>
+        A few details worth knowing:
+      </p>
+
+      <ul>
+        <li>
+          <code>suppressHydrationWarning</code> on the placeholder div is
+          load-bearing — without it React complains about the SVG content
+          differing between server and client. Hand-waved away here because
+          the client takes ownership of that subtree on mount.
+        </li>
+        <li>
+          The placeholder div needs the same dimensions as the chart so
+          there's no layout shift when the client component mounts.
+          Match <code>width</code> and <code>height</code>.
+        </li>
+        <li>
+          Pass the same props to both the server <code>renderChart</code>{" "}
+          call and the client <code>InteractiveChart</code>. Mismatch and
+          you'll see the chart "jump" on hydration.
+        </li>
+        <li>
+          For static / build-time pages this gives indexable chart SVG with
+          no interactivity penalty (interactivity attaches on hydration).
+          For dynamically-rendered pages on Node 18 or 19, the server pass
+          runs on every request — fine for moderate traffic, but cache the
+          result if you're rendering the same chart many times.
+        </li>
+      </ul>
+
+      <p>
+        This pattern is a one-piece fit: replace the server-rendered SVG
+        with future Semiotic isomorphic-rehydration support (when it
+        ships) by removing the <code>renderChart</code>{" "}
+        / <code>dangerouslySetInnerHTML</code>{" "}
+        scaffolding. No data shape or prop changes required.
+      </p>
+
+      {/* -------------------------------------------------------------- */}
       <h2 id="static-svg-rendering">Static SVG Rendering on the Server</h2>
 
       <p>

--- a/docs/src/pages/UsingSSRPage.js
+++ b/docs/src/pages/UsingSSRPage.js
@@ -145,8 +145,9 @@ import { StreamNetworkFrame } from "semiotic/network"`}
         clients, pair <code>next/dynamic</code> with{" "}
         <code>semiotic/server</code>'s <code>renderChart</code> as the
         placeholder. The server emits a static SVG that's part of the
-        initial HTML; on hydration, the interactive client chart mounts in
-        place of it.
+        initial HTML; the client wrapper renders the same placeholder
+        until it has mounted, then swaps in the interactive chart in the
+        same slot.
       </p>
 
       <p>
@@ -159,21 +160,48 @@ import { StreamNetworkFrame } from "semiotic/network"`}
         to wait on client mount + the chart's initial layout pass.
       </p>
 
+      <p>
+        The shape is two files: a server component that pre-renders the
+        placeholder SVG and passes it down, and a client wrapper that
+        gates on a <code>mounted</code> flag so the placeholder renders
+        on the server (and on the first client render) and the
+        interactive chart renders thereafter.
+      </p>
+
       <CodeBlock
         code={`// app/dashboard/RevenueChart.tsx — client wrapper
 "use client"
+import { useEffect, useState } from "react"
 import dynamic from "next/dynamic"
-import type { ComponentProps } from "react"
 
-// Lazy-load the interactive chart on the client only. The placeholder
-// the server sends down comes from the parent server component below.
+// Lazy-load the interactive chart on the client only.
 const InteractiveChart = dynamic(
   () => import("semiotic/xy").then((m) => m.LineChart),
   { ssr: false },
 )
 
-export default function RevenueChart(props: ComponentProps<typeof InteractiveChart>) {
-  return <InteractiveChart {...props} />
+interface Props {
+  chartProps: { data: Array<{ month: string; revenue: number }>; xAccessor: string; yAccessor: string; width: number; height: number }
+  placeholderSvg: string
+}
+
+export default function RevenueChart({ chartProps, placeholderSvg }: Props) {
+  // \`mounted\` is false on the server and during the first client
+  // render — the SVG placeholder is what gets emitted in both cases,
+  // so React's hydration sees identical markup. After mount, swap to
+  // the interactive chart in the same slot.
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => { setMounted(true) }, [])
+
+  if (!mounted) {
+    return (
+      <div
+        style={{ width: chartProps.width, height: chartProps.height }}
+        dangerouslySetInnerHTML={{ __html: placeholderSvg }}
+      />
+    )
+  }
+  return <InteractiveChart {...chartProps} />
 }`}
         language="tsx"
       />
@@ -187,24 +215,15 @@ export default async function DashboardPage() {
   const data = await fetchRevenue()
   const chartProps = { data, xAccessor: "month", yAccessor: "revenue", width: 800, height: 400 }
 
-  // Server-render a static SVG placeholder. Inline it as the initial
-  // markup; the client wrapper above replaces it on hydration.
-  const placeholder = renderChart("LineChart", chartProps)
+  // Server-render the static SVG once. The wrapper renders it inline
+  // during SSR and during the first client render, then replaces it
+  // with the interactive chart on mount.
+  const placeholderSvg = renderChart("LineChart", chartProps)
 
   return (
     <main>
       <h1>Revenue</h1>
-      <div
-        // Same dimensions as the chart so layout doesn't shift on hydration.
-        style={{ width: 800, height: 400 }}
-        // The interactive chart will mount inside this div, replacing the SVG.
-        suppressHydrationWarning
-        dangerouslySetInnerHTML={{ __html: placeholder }}
-      >
-      </div>
-      {/* Hydrate the interactive version. Pass the same props so the visual
-          continuity is exact. */}
-      <RevenueChart {...chartProps} />
+      <RevenueChart chartProps={chartProps} placeholderSvg={placeholderSvg} />
     </main>
   )
 }`}
@@ -217,36 +236,37 @@ export default async function DashboardPage() {
 
       <ul>
         <li>
-          <code>suppressHydrationWarning</code> on the placeholder div is
-          load-bearing — without it React complains about the SVG content
-          differing between server and client. Hand-waved away here because
-          the client takes ownership of that subtree on mount.
+          The <code>mounted</code> flag is what gives you in-place
+          replacement. The server bundle and the first client render
+          emit the same SVG markup (so hydration matches), and the
+          post-effect render swaps the subtree to the interactive
+          chart. Only one of the two is in the DOM at any time.
         </li>
         <li>
-          The placeholder div needs the same dimensions as the chart so
-          there's no layout shift when the client component mounts.
-          Match <code>width</code> and <code>height</code>.
+          The placeholder <code>div</code> uses the same{" "}
+          <code>width</code> and <code>height</code> as the chart so the
+          interactive mount doesn't trigger a layout shift.
         </li>
         <li>
-          Pass the same props to both the server <code>renderChart</code>{" "}
-          call and the client <code>InteractiveChart</code>. Mismatch and
-          you'll see the chart "jump" on hydration.
+          Pass identical props to <code>renderChart</code> and{" "}
+          <code>InteractiveChart</code>. Mismatch and the chart "jumps"
+          on swap.
         </li>
         <li>
-          For static / build-time pages this gives indexable chart SVG with
-          no interactivity penalty (interactivity attaches on hydration).
-          For dynamically-rendered pages on Node 18 or 19, the server pass
-          runs on every request — fine for moderate traffic, but cache the
-          result if you're rendering the same chart many times.
+          For static / build-time pages this gives indexable chart SVG
+          with no interactivity penalty. For dynamically-rendered pages
+          the server pass runs on every request — fine for moderate
+          traffic, but cache the SVG output if you're rendering the
+          same chart many times.
         </li>
       </ul>
 
       <p>
         This pattern is a one-piece fit: replace the server-rendered SVG
         with future Semiotic isomorphic-rehydration support (when it
-        ships) by removing the <code>renderChart</code>{" "}
-        / <code>dangerouslySetInnerHTML</code>{" "}
-        scaffolding. No data shape or prop changes required.
+        ships) by removing the <code>placeholderSvg</code>{" "}
+        prop and the <code>mounted</code> gate. No data shape or other
+        prop changes required.
       </p>
 
       {/* -------------------------------------------------------------- */}

--- a/src/components/store/createStore.tsx
+++ b/src/components/store/createStore.tsx
@@ -61,7 +61,11 @@ function createSource<T>(
 
   function set(updater: (current: T) => Partial<T>) {
     state = { ...state, ...updater(state) } as T
-    events.dispatchEvent(new CustomEvent("update"))
+    // Plain `Event`, not `CustomEvent`. CustomEvent landed as a Node
+    // global in v19; using it would crash store updates fired during
+    // SSR on Node 18 (the package's lower bound). The `detail` field is
+    // never read by subscribers, so there's no functional difference.
+    events.dispatchEvent(new Event("update"))
   }
 
   function subscribe(cb: () => void) {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -8,7 +8,12 @@ export default defineConfig({
     exclude: [
       'node_modules',
       'dist',
-      'integration-tests/**'
+      'integration-tests/**',
+      // The `codemod/` directory is a self-contained sibling package
+      // with its own jest test runner. Exclude its test files (and the
+      // nested node_modules vitest auto-walks into) so Semiotic's vitest
+      // doesn't try to run jscodeshift internals.
+      'codemod/**'
     ],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
This pull request documents and implements a "cheap" server-side rendering (SSR) fix for interactive charts, improving SSR safety and developer guidance. It updates documentation to show a practical SSR pattern using a static SVG placeholder with client-side hydration, ensures compatibility with older Node.js versions, and refines test configuration. The real isomorphic SSR/hydration solution is deferred, but the groundwork and documentation are in place for both current and future needs.

**SSR and Hydration Improvements**
- Updated `OUTSTANDING_WORK.md` to clarify that a cheap SSR fix has landed: the documentation now covers using `next/dynamic({ ssr: false })` with `semiotic/server`'s `renderChart` as a placeholder, providing static SVG for SEO/a11y/first-paint while deferring full isomorphic hydration for future work. Also, details the completed SSR-safety audit and the only code change needed (`CustomEvent` → `Event`). [[1]](diffhunk://#diff-fbb4a34cc150f00e9572aa6eb822870894953c8e68dd30e0e7718940ad18e614L3-R3) [[2]](diffhunk://#diff-fbb4a34cc150f00e9572aa6eb822870894953c8e68dd30e0e7718940ad18e614L21-R35)
- Expanded `docs/src/pages/UsingSSRPage.js` with a detailed guide and code samples for implementing the SSR placeholder pattern, including caveats and migration notes for future isomorphic hydration support.

**SSR Safety and Compatibility**
- Changed `src/components/store/createStore.tsx` to use the standard `Event` instead of `CustomEvent` when dispatching updates, ensuring compatibility with Node.js 18 (where `CustomEvent` is not available globally) and preventing SSR crashes.

**Test Configuration**
- Updated `vitest.config.mts` to exclude the `codemod/` directory (and its nested `node_modules`) from test runs, preventing Semiotic's test runner from attempting to run unrelated jscodeshift tests.