### PR TITLE
Update for 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.5.0] - 2026-05-02
 
 ### Added
 

--- a/ai/schema.json
+++ b/ai/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "semiotic",
-  "version": "3.4.2",
+  "version": "3.5.0",
   "description": "React data visualization library for charts, networks, and beyond",
   "tools": [
     {

--- a/docs/src/pages/charts/SankeyDiagramPage.js
+++ b/docs/src/pages/charts/SankeyDiagramPage.js
@@ -215,6 +215,17 @@ function StreamingSankey() {
   )
 }`
 
+// Hoisted out of the component so the `frameProps` reference passed to
+// SankeyDiagram is stable. Inline `frameProps={{ pulse: {...}, staleness: {...} }}`
+// gives `pulse` and `staleness` new identities on every parent render, which
+// invalidates `StreamNetworkFrame.pipelineConfig` and pushes the rAF render
+// loop into a setState cycle that React 19 catches as a max-update-depth
+// violation.
+const STREAMING_SANKEY_FRAME_PROPS = {
+  pulse: { duration: 600, color: "rgba(255,200,50,0.7)", glowRadius: 5 },
+  staleness: { threshold: 5000, dimOpacity: 0.4, showBadge: true },
+}
+
 function StreamingSankeyDemo({ width }) {
   const chartRef = useRef()
   const [pushed, setPushed] = useState(false)
@@ -248,10 +259,7 @@ function StreamingSankeyDemo({ width }) {
         showParticles
         edgeOpacity={0.4}
         colorScheme={pastelColors}
-        frameProps={{
-          pulse: { duration: 600, color: "rgba(255,200,50,0.7)", glowRadius: 5 },
-          staleness: { threshold: 5000, dimOpacity: 0.4, showBadge: true },
-        }}
+        frameProps={STREAMING_SANKEY_FRAME_PROPS}
       />
     </div>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "semiotic",
-  "version": "3.4.2",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "semiotic",
-      "version": "3.4.2",
+      "version": "3.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "d3-array": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semiotic",
-  "version": "3.4.2",
+  "version": "3.5.0",
   "mcpName": "io.github.nteract/semiotic",
   "description": "React data visualization library with built-in MCP server for AI-assisted chart generation",
   "main": "dist/semiotic.min.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/nteract/semiotic",
     "source": "github"
   },
-  "version": "3.4.2",
+  "version": "3.5.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "semiotic",
-      "version": "3.4.2",
+      "version": "3.5.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/components/LinkedCharts.tsx
+++ b/src/components/LinkedCharts.tsx
@@ -167,9 +167,14 @@ function LinkedLegend({
   selectionName: string
   field: string
 }) {
+  // All hooks must run unconditionally on every render — when
+  // `categoryColors` starts empty (e.g. a streaming chart hasn't pushed
+  // any rows yet) and later populates, an early return before the hook
+  // calls would change the static-flag profile of the fiber and trip
+  // React 19's "Internal React error: Expected static flag was missing"
+  // on the first non-empty render. The empty-state early return lives
+  // *after* every hook below.
   const entries = Object.entries(categoryColors)
-  if (entries.length === 0) return null
-
   const allCategories = entries.map(([label]) => label)
   const items = entries.map(([label, color]) => ({ label, color }))
   const legendGroups: LegendGroup[] = [{
@@ -267,6 +272,11 @@ function LinkedLegend({
     [entries, measuredWidth]
   )
   const svgHeight = Math.max(30, rowCount * 22 + 8)
+
+  // Empty-state guard lives here, after every hook above, so the hook
+  // count and static-flag profile stay constant across renders — see
+  // the comment near `entries` for why an earlier return would crash.
+  if (entries.length === 0) return null
 
   return (
     <div ref={containerRef} style={{ width: "100%", display: "block" }}>

--- a/src/components/stream/StreamGeoFrame.tsx
+++ b/src/components/stream/StreamGeoFrame.tsx
@@ -331,9 +331,10 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
       projectionTransform, decay, pulse, transition?.duration, transition?.easing, introEnabled, annotations, pointIdAccessor, currentTheme
     ])
 
-    // Stabilize the config reference so inline-object props don't shed
-    // a fresh identity every parent render. See StreamNetworkFrame for
-    // the full incident write-up; the same loop applies here.
+    // Stabilize the config reference so inline-object / inline-array
+    // props don't shed identity every parent render. See
+    // StreamNetworkFrame for the full incident write-up; the same loop
+    // applies here.
     const stablePipelineConfig = useStableShallow(pipelineConfig)
 
     // ── Store ─────────────────────────────────────────────────────────

--- a/src/components/stream/StreamGeoFrame.tsx
+++ b/src/components/stream/StreamGeoFrame.tsx
@@ -30,6 +30,7 @@ import { useStalenessCheck } from "./useStalenessCheck"
 import { SVGOverlay } from "./SVGOverlay"
 import { isServerEnvironment, geoSceneNodeToSVG } from "./SceneToSVG"
 import { useHydration, useWasHydratingFromSSR, useHydrationLifecycle } from "./useHydration"
+import { useStableShallow } from "./useStableShallow"
 import { AccessibleDataTable, AriaLiveTooltip, ScreenReaderSummary, SkipToTableLink, computeCanvasAriaLabel } from "./AccessibleDataTable"
 import { extractCategoryDomain, sameCategoryDomain } from "./categoryDomain"
 import { filterSparseArray } from "../charts/shared/sparseArray"
@@ -330,11 +331,16 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
       projectionTransform, decay, pulse, transition?.duration, transition?.easing, introEnabled, annotations, pointIdAccessor, currentTheme
     ])
 
+    // Stabilize the config reference so inline-object props don't shed
+    // a fresh identity every parent render. See StreamNetworkFrame for
+    // the full incident write-up; the same loop applies here.
+    const stablePipelineConfig = useStableShallow(pipelineConfig)
+
     // ── Store ─────────────────────────────────────────────────────────
 
     const storeRef = useRef<GeoPipelineStore | null>(null)
     if (!storeRef.current) {
-      storeRef.current = new GeoPipelineStore(pipelineConfig)
+      storeRef.current = new GeoPipelineStore(stablePipelineConfig)
     }
 
     // ── Refs ──────────────────────────────────────────────────────────
@@ -424,10 +430,10 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
     // ── Sync config ───────────────────────────────────────────────────
 
     useEffect(() => {
-      storeRef.current?.updateConfig(pipelineConfig)
+      storeRef.current?.updateConfig(stablePipelineConfig)
       dirtyRef.current = true
       scheduleRender()
-    }, [pipelineConfig, scheduleRender])
+    }, [stablePipelineConfig, scheduleRender])
 
     // ── Sync bounded data ─────────────────────────────────────────────
 

--- a/src/components/stream/StreamNetworkFrame.tsx
+++ b/src/components/stream/StreamNetworkFrame.tsx
@@ -37,6 +37,7 @@ import { useStalenessCheck } from "./useStalenessCheck"
 import { NetworkSVGOverlay } from "./NetworkSVGOverlay"
 import { networkSceneNodeToSVG, networkSceneEdgeToSVG, networkLabelToSVG, isServerEnvironment } from "./SceneToSVG"
 import { useHydration, useWasHydratingFromSSR, useHydrationLifecycle } from "./useHydration"
+import { useStableShallow } from "./useStableShallow"
 import { NetworkAccessibleDataTable, AriaLiveTooltip, ScreenReaderSummary, SkipToTableLink, computeNetworkAriaLabel } from "./AccessibleDataTable"
 import { filterSparseArray } from "../charts/shared/sparseArray"
 
@@ -447,6 +448,20 @@ const StreamNetworkFrame = forwardRef<
     ]
   )
 
+  // Stabilize the config reference so inline-object props (e.g.
+  // `pulse={{ duration: 600, ... }}`, `staleness={{ ... }}`,
+  // `frameProps={{ pulse: ..., staleness: ... }}`) don't shed a fresh
+  // identity on every parent render. Without this, the effect at line
+  // ~590 — `useEffect(() => updateConfig(pipelineConfig), [pipelineConfig])` —
+  // re-fires every render, dirties the scene, and the rAF render loop's
+  // `setAnnotationFrame((f) => f + 1)` triggers another re-render with
+  // yet another fresh inline ref, which React 19 catches as
+  // "Maximum update depth exceeded" after ~50 cycles. The hook returns
+  // the previous reference whenever the value is shallow-equal at one
+  // level deep, which covers the typical config shape (primitives plus
+  // a few sub-objects of primitives).
+  const stablePipelineConfig = useStableShallow(pipelineConfig)
+
   // ── Refs ─────────────────────────────────────────────────────────────
 
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -463,7 +478,7 @@ const StreamNetworkFrame = forwardRef<
 
   const storeRef = useRef<NetworkPipelineStore | null>(null)
   if (!storeRef.current) {
-    storeRef.current = new NetworkPipelineStore(pipelineConfig)
+    storeRef.current = new NetworkPipelineStore(stablePipelineConfig)
   }
 
   // ── State ────────────────────────────────────────────────────────────
@@ -582,10 +597,10 @@ const StreamNetworkFrame = forwardRef<
 
   // Update config when props change
   useEffect(() => {
-    storeRef.current?.updateConfig(pipelineConfig)
+    storeRef.current?.updateConfig(stablePipelineConfig)
     dirtyRef.current = true
     scheduleRender()
-  }, [pipelineConfig, scheduleRender])
+  }, [stablePipelineConfig, scheduleRender])
 
   // Sync the customLayout overlay output to React state. Called after every
   // data-change `buildScene` so the overlay re-renders when topology or
@@ -859,7 +874,7 @@ const StreamNetworkFrame = forwardRef<
       dirtyRef.current = true
       scheduleRender()
     }
-  }, [safeNodes, safeEdges, dataProp, hierarchyRoot, isHierarchical, adjustedWidth, adjustedHeight, pipelineConfig, scheduleRender, colorScheme, syncCustomOverlays])
+  }, [safeNodes, safeEdges, dataProp, hierarchyRoot, isHierarchical, adjustedWidth, adjustedHeight, stablePipelineConfig, scheduleRender, colorScheme, syncCustomOverlays])
 
   // ── Initial streaming data ───────────────────────────────────────────
 

--- a/src/components/stream/StreamNetworkFrame.tsx
+++ b/src/components/stream/StreamNetworkFrame.tsx
@@ -448,18 +448,18 @@ const StreamNetworkFrame = forwardRef<
     ]
   )
 
-  // Stabilize the config reference so inline-object props (e.g.
-  // `pulse={{ duration: 600, ... }}`, `staleness={{ ... }}`,
+  // Stabilize the config reference so inline-object / inline-array
+  // props (e.g. `pulse={{ duration: 600, ... }}`, `staleness={{ ... }}`,
   // `frameProps={{ pulse: ..., staleness: ... }}`) don't shed a fresh
-  // identity on every parent render. Without this, the effect at line
-  // ~590 — `useEffect(() => updateConfig(pipelineConfig), [pipelineConfig])` —
-  // re-fires every render, dirties the scene, and the rAF render loop's
-  // `setAnnotationFrame((f) => f + 1)` triggers another re-render with
-  // yet another fresh inline ref, which React 19 catches as
-  // "Maximum update depth exceeded" after ~50 cycles. The hook returns
-  // the previous reference whenever the value is shallow-equal at one
-  // level deep, which covers the typical config shape (primitives plus
-  // a few sub-objects of primitives).
+  // identity on every parent render. Without this stabilization, the
+  // `updateConfig` effect would depend on raw `pipelineConfig` and
+  // re-fire on every render, dirtying the scene; the rAF render loop's
+  // `setAnnotationFrame((f) => f + 1)` would then trigger another
+  // re-render with yet another fresh inline ref, which React 19
+  // catches as "Maximum update depth exceeded" after ~50 cycles. The
+  // hook returns the previous reference whenever the value is
+  // shallow-equal at one level deep — which covers the typical config
+  // shape (primitives, sub-objects of primitives, primitive arrays).
   const stablePipelineConfig = useStableShallow(pipelineConfig)
 
   // ── Refs ─────────────────────────────────────────────────────────────

--- a/src/components/stream/StreamOrdinalFrame.tsx
+++ b/src/components/stream/StreamOrdinalFrame.tsx
@@ -474,9 +474,10 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
       customLayout, layoutConfig, margin,
     ])
 
-    // Stabilize the config reference so inline-object props don't shed
-    // a fresh identity every parent render. See StreamNetworkFrame for
-    // the full incident write-up; the same loop applies here.
+    // Stabilize the config reference so inline-object / inline-array
+    // props don't shed identity every parent render. See
+    // StreamNetworkFrame for the full incident write-up; the same loop
+    // applies here.
     const stablePipelineConfig = useStableShallow(pipelineConfig)
 
     const storeRef = useRef<OrdinalPipelineStore | null>(null)

--- a/src/components/stream/StreamOrdinalFrame.tsx
+++ b/src/components/stream/StreamOrdinalFrame.tsx
@@ -50,6 +50,7 @@ import { OrdinalSVGOverlay, OrdinalSVGUnderlay } from "./OrdinalSVGOverlay"
 import { OrdinalBrushOverlay } from "./OrdinalBrushOverlay"
 import { ordinalSceneNodeToSVG, isServerEnvironment } from "./SceneToSVG"
 import { useHydration, useWasHydratingFromSSR, useHydrationLifecycle } from "./useHydration"
+import { useStableShallow } from "./useStableShallow"
 import { AccessibleDataTable, AriaLiveTooltip, ScreenReaderSummary, SkipToTableLink, computeCanvasAriaLabel } from "./AccessibleDataTable"
 import { FocusRing } from "./FocusRing"
 import { FlippingTooltip } from "../Tooltip/FlippingTooltip"
@@ -473,9 +474,14 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
       customLayout, layoutConfig, margin,
     ])
 
+    // Stabilize the config reference so inline-object props don't shed
+    // a fresh identity every parent render. See StreamNetworkFrame for
+    // the full incident write-up; the same loop applies here.
+    const stablePipelineConfig = useStableShallow(pipelineConfig)
+
     const storeRef = useRef<OrdinalPipelineStore | null>(null)
     if (!storeRef.current) {
-      storeRef.current = new OrdinalPipelineStore(pipelineConfig)
+      storeRef.current = new OrdinalPipelineStore(stablePipelineConfig)
     }
 
     // scheduleRender comes from useFrame above.
@@ -492,10 +498,10 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
 
     // Update config when it changes
     useEffect(() => {
-      storeRef.current?.updateConfig(pipelineConfig)
+      storeRef.current?.updateConfig(stablePipelineConfig)
       dirtyRef.current = true
       scheduleRender()
-    }, [pipelineConfig, scheduleRender])
+    }, [stablePipelineConfig, scheduleRender])
 
     // Theme-change repaint (clearCSSColorCache + dirty + scheduleRender)
     // is handled by useFrame above when themeDirtyRef is provided.

--- a/src/components/stream/StreamXYFrame.tsx
+++ b/src/components/stream/StreamXYFrame.tsx
@@ -32,6 +32,7 @@ import { useStalenessCheck } from "./useStalenessCheck"
 import { SVGOverlay, SVGUnderlay } from "./SVGOverlay"
 import { xySceneNodeToSVG, isServerEnvironment } from "./SceneToSVG"
 import { useHydration, useWasHydratingFromSSR, useHydrationLifecycle } from "./useHydration"
+import { useStableShallow } from "./useStableShallow"
 import { AccessibleDataTable, AriaLiveTooltip, ScreenReaderSummary, SkipToTableLink, computeCanvasAriaLabel } from "./AccessibleDataTable"
 import { FocusRing } from "./FocusRing"
 import { FlippingTooltip } from "../Tooltip/FlippingTooltip"
@@ -672,9 +673,21 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
       customLayout, layoutConfig, margin
     ])
 
+    // Stabilize the config reference so inline-object props (e.g.
+    // `pulse={{ duration: 600, ... }}`, `staleness={{ ... }}`,
+    // `frameProps={{ pulse: ..., staleness: ... }}`) don't shed a fresh
+    // identity every parent render. Without this the `updateConfig`
+    // effect below re-fires every render → dirty + scheduleRender →
+    // rAF render loop fires `setAnnotationFrame((f) => f + 1)` → React
+    // re-renders → pipelineConfig recomputes (inline ref again) → the
+    // cycle trips React 19's "Maximum update depth exceeded" guard
+    // after ~50 frames. See `useStableShallow.ts` for why a one-level
+    // shallow compare is enough for the typical config shape.
+    const stablePipelineConfig = useStableShallow(pipelineConfig)
+
     const storeRef = useRef<PipelineStore | null>(null)
     if (!storeRef.current) {
-      storeRef.current = new PipelineStore(pipelineConfig)
+      storeRef.current = new PipelineStore(stablePipelineConfig)
     }
 
     // scheduleRender comes from useFrame above.
@@ -692,10 +705,10 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
     // Update config when it changes — also schedule re-render since style
     // callbacks (pointStyle, areaStyle, etc.) may have changed.
     useEffect(() => {
-      storeRef.current?.updateConfig(pipelineConfig)
+      storeRef.current?.updateConfig(stablePipelineConfig)
       dirtyRef.current = true
       scheduleRender()
-    }, [pipelineConfig, scheduleRender])
+    }, [stablePipelineConfig, scheduleRender])
 
     // Theme-change repaint (clearCSSColorCache + dirty + scheduleRender)
     // is handled by useFrame above when themeDirtyRef is provided.

--- a/src/components/stream/StreamXYFrame.tsx
+++ b/src/components/stream/StreamXYFrame.tsx
@@ -673,16 +673,16 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
       customLayout, layoutConfig, margin
     ])
 
-    // Stabilize the config reference so inline-object props (e.g.
-    // `pulse={{ duration: 600, ... }}`, `staleness={{ ... }}`,
-    // `frameProps={{ pulse: ..., staleness: ... }}`) don't shed a fresh
-    // identity every parent render. Without this the `updateConfig`
-    // effect below re-fires every render → dirty + scheduleRender →
-    // rAF render loop fires `setAnnotationFrame((f) => f + 1)` → React
-    // re-renders → pipelineConfig recomputes (inline ref again) → the
-    // cycle trips React 19's "Maximum update depth exceeded" guard
-    // after ~50 frames. See `useStableShallow.ts` for why a one-level
-    // shallow compare is enough for the typical config shape.
+    // Stabilize the config reference so inline-object / inline-array
+    // props don't shed identity on every parent render. Without this
+    // the `updateConfig` effect would depend on raw `pipelineConfig`
+    // and re-fire every render → dirty + scheduleRender → rAF render
+    // loop fires `setAnnotationFrame((f) => f + 1)` → React re-renders
+    // → pipelineConfig recomputes (inline ref again) → the cycle trips
+    // React 19's "Maximum update depth exceeded" guard. See
+    // `useStableShallow.ts` for why a one-level shallow compare is
+    // enough for the typical config shape (primitives, sub-objects of
+    // primitives, primitive arrays).
     const stablePipelineConfig = useStableShallow(pipelineConfig)
 
     const storeRef = useRef<PipelineStore | null>(null)

--- a/src/components/stream/renderers/barFunnelCanvasRenderer.ts
+++ b/src/components/stream/renderers/barFunnelCanvasRenderer.ts
@@ -77,7 +77,15 @@ export const barFunnelHatchRenderer = (
  *  - Bold percentage (of first step)
  *  - Raw value below it
  *
- * Labels appear on a white rounded-rect background (matching the reference images).
+ * Light/dark mode is decided per-frame from the luminance of the
+ * resolved `--semiotic-text` value: if body text is light, we're in
+ * dark mode and pair a dark surface with light text; otherwise light
+ * mode (white surface, dark text). Pairing the background to whatever
+ * text color the consumer's theme actually emits is more robust than
+ * sourcing both from independent CSS variables — many sites set
+ * `--semiotic-text` and `--semiotic-bg` without setting
+ * `--semiotic-tooltip-bg`, which would otherwise leave the label box
+ * stuck on its fallback regardless of theme.
  */
 export const barFunnelLabelRenderer = (
   ctx: CanvasRenderingContext2D,
@@ -105,9 +113,18 @@ export const barFunnelLabelRenderer = (
   // Minimum bar width (px) before label is suppressed entirely
   const MIN_LABEL_BAR_WIDTH = 25
 
-  // Resolve once per frame — theme text colors for label primary/secondary text.
-  const primaryTextColor = resolveCSSColor(ctx, "var(--semiotic-text, #333)")!
-  const secondaryTextColor = resolveCSSColor(ctx, "var(--semiotic-text-secondary, #666)")!
+  // Decide light vs dark mode from the body text luminance, then pair
+  // the floating-label surface against that. Both pct and val use the
+  // same primary text color so the value stays high-contrast on the
+  // chosen surface — the previous secondary-text branch failed in dark
+  // mode where `--semiotic-text-secondary` (a mid-grey) collapsed into
+  // the surface color.
+  const bodyTextColor = resolveCSSColor(ctx, "var(--semiotic-text, #333)")!
+  const isDarkMode = isLightColor(bodyTextColor)
+  const labelBackground = isDarkMode ? "#1f2937" : "#ffffff"
+  const labelBorder = isDarkMode ? "rgba(255,255,255,0.18)" : "rgba(0,0,0,0.12)"
+  const primaryTextColor = isDarkMode ? "#f3f4f6" : "#1a1a1a"
+  const secondaryTextColor = primaryTextColor
 
   for (const node of labelRects) {
     const d = node.datum
@@ -146,19 +163,19 @@ export const barFunnelLabelRenderer = (
     const boxX = lx - labelW / 2
     const boxY = ly - labelH - 4
 
-    // White background with subtle shadow
+    // Theme-aware background with subtle shadow
     ctx.save()
     ctx.shadowColor = "rgba(0,0,0,0.15)"
     ctx.shadowBlur = 4
     ctx.shadowOffsetY = 1
-    ctx.fillStyle = "rgba(255,255,255,0.95)"
+    ctx.fillStyle = labelBackground
     ctx.beginPath()
     roundedRect(ctx, boxX, boxY, labelW, labelH, cornerRadius)
     ctx.fill()
     ctx.restore()
 
-    // Subtle border
-    ctx.strokeStyle = "rgba(0,0,0,0.12)"
+    // Subtle border (theme-aware)
+    ctx.strokeStyle = labelBorder
     ctx.lineWidth = 0.5
     ctx.beginPath()
     roundedRect(ctx, boxX, boxY, labelW, labelH, cornerRadius)
@@ -205,6 +222,48 @@ function roundedRect(
   ctx.lineTo(x, y + r)
   ctx.quadraticCurveTo(x, y, x + r, y)
   ctx.closePath()
+}
+
+/**
+ * Approximate WCAG-style relative luminance check. Parses `#rgb`,
+ * `#rrggbb`, `rgb(...)`, and `rgba(...)` — the forms `resolveCSSColor`
+ * is going to produce after going through `getComputedStyle` (which
+ * normalizes everything to `rgb(...)` / `rgba(...)`). Anything we can't
+ * parse defaults to "not light" so the label conservatively stays in
+ * light-mode shape, which is the historic visual contract.
+ */
+function isLightColor(color: string): boolean {
+  const rgb = parseRGB(color)
+  if (!rgb) return false
+  // Rec. 709 luma — close enough for the dark-vs-light split, and
+  // cheaper than full WCAG sRGB linearization.
+  const luma = (0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]) / 255
+  return luma > 0.6
+}
+
+function parseRGB(color: string): [number, number, number] | null {
+  const trimmed = color.trim()
+  if (trimmed.startsWith("#")) {
+    const hex = trimmed.slice(1)
+    if (hex.length === 3) {
+      return [
+        parseInt(hex[0] + hex[0], 16),
+        parseInt(hex[1] + hex[1], 16),
+        parseInt(hex[2] + hex[2], 16),
+      ]
+    }
+    if (hex.length === 6) {
+      return [
+        parseInt(hex.slice(0, 2), 16),
+        parseInt(hex.slice(2, 4), 16),
+        parseInt(hex.slice(4, 6), 16),
+      ]
+    }
+    return null
+  }
+  const m = /^rgba?\(\s*([\d.]+)\s*[,\s]\s*([\d.]+)\s*[,\s]\s*([\d.]+)/.exec(trimmed)
+  if (!m) return null
+  return [Number(m[1]), Number(m[2]), Number(m[3])]
 }
 
 function formatNumber(n: number): string {

--- a/src/components/stream/renderers/barFunnelCanvasRenderer.ts
+++ b/src/components/stream/renderers/barFunnelCanvasRenderer.ts
@@ -1,6 +1,7 @@
 import type { RectSceneNode, OrdinalLayout, OrdinalScales, OrdinalSceneNode } from "../ordinalTypes"
 import { createHatchPattern } from "../../charts/shared/hatchPattern"
 import { resolveCSSColor } from "./resolveCSSColor"
+import { parseCanvasColor } from "./colorUtils"
 
 /**
  * Canvas renderer that applies diagonal-line hatching to bar-funnel dropoff bars.
@@ -120,7 +121,7 @@ export const barFunnelLabelRenderer = (
   // mode where `--semiotic-text-secondary` (a mid-grey) collapsed into
   // the surface color.
   const bodyTextColor = resolveCSSColor(ctx, "var(--semiotic-text, #333)")!
-  const isDarkMode = isLightColor(bodyTextColor)
+  const isDarkMode = isLightColor(ctx, bodyTextColor)
   const labelBackground = isDarkMode ? "#1f2937" : "#ffffff"
   const labelBorder = isDarkMode ? "rgba(255,255,255,0.18)" : "rgba(0,0,0,0.12)"
   const primaryTextColor = isDarkMode ? "#f3f4f6" : "#1a1a1a"
@@ -225,45 +226,22 @@ function roundedRect(
 }
 
 /**
- * Approximate WCAG-style relative luminance check. Parses `#rgb`,
- * `#rrggbb`, `rgb(...)`, and `rgba(...)` — the forms `resolveCSSColor`
- * is going to produce after going through `getComputedStyle` (which
- * normalizes everything to `rgb(...)` / `rgba(...)`). Anything we can't
- * parse defaults to "not light" so the label conservatively stays in
- * light-mode shape, which is the historic visual contract.
+ * Approximate WCAG-style relative luminance check. Routes through
+ * `parseCanvasColor`, which round-trips the input through the canvas's
+ * own `fillStyle` to normalize any valid CSS color — named, hex, hsl,
+ * legacy/modern rgb(), space-separated rgb syntax, etc. — into an
+ * `[r, g, b]` triple. That matters because `resolveCSSColor` returns
+ * the raw CSS variable token, and `getComputedStyle` is allowed to
+ * yield any of those forms; a hand-rolled hex/rgb regex would silently
+ * mis-classify hsl tokens as "not light" and leave dark-mode labels in
+ * light-mode shape.
  */
-function isLightColor(color: string): boolean {
-  const rgb = parseRGB(color)
-  if (!rgb) return false
+function isLightColor(ctx: CanvasRenderingContext2D, color: string): boolean {
+  const [r, g, b] = parseCanvasColor(ctx, color)
   // Rec. 709 luma — close enough for the dark-vs-light split, and
   // cheaper than full WCAG sRGB linearization.
-  const luma = (0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]) / 255
+  const luma = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255
   return luma > 0.6
-}
-
-function parseRGB(color: string): [number, number, number] | null {
-  const trimmed = color.trim()
-  if (trimmed.startsWith("#")) {
-    const hex = trimmed.slice(1)
-    if (hex.length === 3) {
-      return [
-        parseInt(hex[0] + hex[0], 16),
-        parseInt(hex[1] + hex[1], 16),
-        parseInt(hex[2] + hex[2], 16),
-      ]
-    }
-    if (hex.length === 6) {
-      return [
-        parseInt(hex.slice(0, 2), 16),
-        parseInt(hex.slice(2, 4), 16),
-        parseInt(hex.slice(4, 6), 16),
-      ]
-    }
-    return null
-  }
-  const m = /^rgba?\(\s*([\d.]+)\s*[,\s]\s*([\d.]+)\s*[,\s]\s*([\d.]+)/.exec(trimmed)
-  if (!m) return null
-  return [Number(m[1]), Number(m[2]), Number(m[3])]
 }
 
 function formatNumber(n: number): string {

--- a/src/components/stream/useStableShallow.test.tsx
+++ b/src/components/stream/useStableShallow.test.tsx
@@ -94,6 +94,54 @@ describe("useStableShallow", () => {
     expect(result.current).toBe(b)
   })
 
+  it("stabilizes equal top-level arrays (extent / colorScheme shape)", () => {
+    // Stream pipeline configs commonly carry primitive arrays — xExtent,
+    // yExtent, sizeRange, colorScheme, etc. — all of which a consumer
+    // is just as likely to inline as object props.
+    const initial = [0, 100] as [number, number]
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableShallow(value),
+      { initialProps: { value: initial } },
+    )
+    expect(result.current).toBe(initial)
+    rerender({ value: [0, 100] as [number, number] })
+    expect(result.current).toBe(initial)
+  })
+
+  it("returns the new array reference when an element changes", () => {
+    const a = [0, 100] as [number, number]
+    const b = [0, 200] as [number, number]
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableShallow(value),
+      { initialProps: { value: a } },
+    )
+    rerender({ value: b })
+    expect(result.current).toBe(b)
+  })
+
+  it("stabilizes nested arrays inside config objects", () => {
+    // `pipelineConfig.colorScheme = ["#a", "#b"]` is the realistic case.
+    const a = { colorScheme: ["#abc", "#def"], n: 1 }
+    const b = { colorScheme: ["#abc", "#def"], n: 1 }
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableShallow(value),
+      { initialProps: { value: a } },
+    )
+    rerender({ value: b })
+    expect(result.current).toBe(a)
+  })
+
+  it("does not falsely stabilize when nested arrays differ in length", () => {
+    const a = { colorScheme: ["#abc", "#def"] }
+    const b = { colorScheme: ["#abc", "#def", "#fed"] }
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableShallow(value),
+      { initialProps: { value: a } },
+    )
+    rerender({ value: b })
+    expect(result.current).toBe(b)
+  })
+
   it("does not falsely stabilize when nested key sets differ", () => {
     const a = { pulse: { duration: 600 } }
     const b = { pulse: { color: "#abc" } } // single key, but different name

--- a/src/components/stream/useStableShallow.test.tsx
+++ b/src/components/stream/useStableShallow.test.tsx
@@ -14,107 +14,94 @@
  * level deep — which is the typical config shape — so the effect no
  * longer fires on inline-object churn.
  */
-import * as React from "react"
-import { renderToString } from "react-dom/server"
 import { describe, it, expect } from "vitest"
+import { renderHook } from "@testing-library/react"
 import { useStableShallow } from "./useStableShallow"
 
 describe("useStableShallow", () => {
-  function harness<T>(values: T[]): { results: T[] } {
-    const results: T[] = []
-    function Probe({ value }: { value: T }) {
-      const stable = useStableShallow(value)
-      results.push(stable)
-      return null
-    }
-    // Repeated single-render passes simulate a parent re-rendering with
-    // a fresh value reference each time. We can't drive successive
-    // commits through `renderToString`, so the test uses a direct
-    // dispatcher harness via React's state-machine: render the Probe
-    // once per value into the SAME tree by using a thin Switcher.
-    function Switcher() {
-      const [step, setStep] = React.useState(0)
-      // Synchronously advance through every value before painting.
-      React.useLayoutEffect(() => {
-        if (step < values.length - 1) setStep(step + 1)
-      }, [step])
-      return <Probe value={values[step]} />
-    }
-    renderToString(<Switcher />)
-    return { results }
-  }
-
-  it("returns the same reference when the value is shallow-equal at one level", () => {
-    const a = { duration: 600, color: "#abc" }
-    const b = { duration: 600, color: "#abc" } // value-equal, ref-different
-    const { results } = harness([a, b])
-    // renderToString doesn't loop the layout effect, so we test via
-    // direct invocation pattern below instead.
-    expect(results.length).toBeGreaterThanOrEqual(1)
-    expect(results[0]).toBe(a)
+  it("returns the same reference across renders when shallow-equal at one level", () => {
+    const initial = { duration: 600, color: "#abc" }
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableShallow(value),
+      { initialProps: { value: initial } },
+    )
+    expect(result.current).toBe(initial)
+    // Value-equal but ref-different — the inline-object render pattern.
+    rerender({ value: { duration: 600, color: "#abc" } })
+    expect(result.current).toBe(initial)
   })
 
-  it("returns a new reference when a top-level primitive changes", () => {
-    // Inline two-call replication of the hook's contract — sufficient
-    // because the hook only inspects `value` and a `useRef` cell.
-    const captures: unknown[] = []
-    function Probe({ value }: { value: { duration: number; color: string } }) {
-      captures.push(useStableShallow(value))
-      return null
-    }
+  it("returns the new reference when a top-level primitive changes", () => {
     const a = { duration: 600, color: "#abc" }
     const b = { duration: 700, color: "#abc" }
-    function Tree({ which }: { which: "a" | "b" }) {
-      return <Probe value={which === "a" ? a : b} />
-    }
-    renderToString(<Tree which="a" />)
-    renderToString(<Tree which="b" />)
-    // Each renderToString invocation creates a fresh `useRef` cell, so
-    // the cross-render stabilization isn't observable from server
-    // render alone. The contract we assert here is that the returned
-    // reference equals the input reference on first observation in a
-    // fresh tree — anything else would mean the hook mutated the
-    // input or returned an unrelated value.
-    expect(captures[0]).toBe(a)
-    expect(captures[1]).toBe(b)
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableShallow(value),
+      { initialProps: { value: a } },
+    )
+    expect(result.current).toBe(a)
+    rerender({ value: b })
+    expect(result.current).toBe(b)
   })
 
-  it("treats a nested object swap with equal keys as equal", () => {
-    // Direct unit-style call to the comparison logic via a tiny harness:
-    // mount once with `a`, simulate a re-render with `b` by reusing the
-    // ref cell. Drives the same fiber across two renders.
-    let captured: unknown
-    let setValue: (v: unknown) => void = () => {}
-    function Probe({ initial }: { initial: { pulse: { duration: number; color: string } } }) {
-      const [v, setV] = React.useState(initial)
-      setValue = setV
-      captured = useStableShallow(v)
-      return null
-    }
+  it("treats a nested sub-object as equal when its keys are pairwise identical", () => {
+    const a = { pulse: { duration: 600, color: "#abc" }, n: 1 }
+    const b = { pulse: { duration: 600, color: "#abc" }, n: 1 }
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableShallow(value),
+      { initialProps: { value: a } },
+    )
+    expect(result.current).toBe(a)
+    rerender({ value: b })
+    expect(result.current).toBe(a)
+  })
+
+  it("returns a new reference when a nested sub-object value changes", () => {
     const a = { pulse: { duration: 600, color: "#abc" } }
-    const b = { pulse: { duration: 600, color: "#abc" } } // value-equal nested, ref-different
-    // Use act() through React's test-renderer surface to drive a
-    // re-render. The repository pulls in `react` 19 but no test
-    // renderer in dependencies; substitute by rendering twice through
-    // hydrateRoot is overkill for this test. Instead, directly verify
-    // the comparison is equality-correct by calling the hook twice
-    // through a controlled state update.
-    const root = document.createElement("div")
-    document.body.appendChild(root)
-    try {
-      const { createRoot } = require("react-dom/client") as typeof import("react-dom/client")
-      const reactRoot = createRoot(root)
-      // First render: captured === a
-      ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
-      const { act } = require("react") as typeof import("react")
-      act(() => { reactRoot.render(<Probe initial={a} />) })
-      expect(captured).toBe(a)
-      // Second render with shallow-equal nested object: should remain `a`
-      act(() => { setValue(b) })
-      expect(captured).toBe(a)
-      reactRoot.unmount()
-    } finally {
-      document.body.removeChild(root)
-    }
+    const b = { pulse: { duration: 700, color: "#abc" } }
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableShallow(value),
+      { initialProps: { value: a } },
+    )
+    rerender({ value: b })
+    expect(result.current).toBe(b)
+  })
+
+  it("does not falsely stabilize across class instances (Set, Map, Date)", () => {
+    // StreamXYFrame stuffs `new Set(areaGroups)` into its pipelineConfig.
+    // Two distinct Sets must compare as not-equal so the `updateConfig`
+    // effect re-fires and the area-group filter stays current.
+    const a = { areaGroups: new Set(["x", "y"]) }
+    const b = { areaGroups: new Set(["x", "z"]) }
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableShallow(value),
+      { initialProps: { value: a } },
+    )
+    rerender({ value: b })
+    expect(result.current).toBe(b)
+  })
+
+  it("does not falsely stabilize when key sets differ but value-counts match", () => {
+    // `{ a: undefined }` and `{ b: undefined }` both have one own key
+    // and both look up `undefined` for any missing key. Without an
+    // explicit key-presence check the two would falsely compare equal.
+    const a = { a: undefined as unknown as number }
+    const b = { b: undefined as unknown as number }
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableShallow(value),
+      { initialProps: { value: a } },
+    )
+    rerender({ value: b })
+    expect(result.current).toBe(b)
+  })
+
+  it("does not falsely stabilize when nested key sets differ", () => {
+    const a = { pulse: { duration: 600 } }
+    const b = { pulse: { color: "#abc" } } // single key, but different name
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableShallow(value),
+      { initialProps: { value: a } },
+    )
+    rerender({ value: b })
+    expect(result.current).toBe(b)
   })
 })

--- a/src/components/stream/useStableShallow.test.tsx
+++ b/src/components/stream/useStableShallow.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Regression coverage for `useStableShallow` — the seam that breaks the
+ * inline-object-props render loop in the four Stream Frames. The
+ * canonical incident: passing `frameProps={{ pulse: { ... }, staleness:
+ * { ... } }}` to a HOC produced a fresh `pulse`/`staleness` reference
+ * on every parent render. The Stream Frame's `pipelineConfig` useMemo
+ * listed those refs in its deps, so it recomputed every render. The
+ * `updateConfig` effect re-fired every render, dirtying the scene and
+ * scheduling a paint; the rAF render loop's `setAnnotationFrame` call
+ * fed back into a re-render. React 19 caught the cycle as
+ * "Maximum update depth exceeded" after ~50 frames.
+ *
+ * The hook stabilises the reference whenever values are equal at one
+ * level deep — which is the typical config shape — so the effect no
+ * longer fires on inline-object churn.
+ */
+import * as React from "react"
+import { renderToString } from "react-dom/server"
+import { describe, it, expect } from "vitest"
+import { useStableShallow } from "./useStableShallow"
+
+describe("useStableShallow", () => {
+  function harness<T>(values: T[]): { results: T[] } {
+    const results: T[] = []
+    function Probe({ value }: { value: T }) {
+      const stable = useStableShallow(value)
+      results.push(stable)
+      return null
+    }
+    // Repeated single-render passes simulate a parent re-rendering with
+    // a fresh value reference each time. We can't drive successive
+    // commits through `renderToString`, so the test uses a direct
+    // dispatcher harness via React's state-machine: render the Probe
+    // once per value into the SAME tree by using a thin Switcher.
+    function Switcher() {
+      const [step, setStep] = React.useState(0)
+      // Synchronously advance through every value before painting.
+      React.useLayoutEffect(() => {
+        if (step < values.length - 1) setStep(step + 1)
+      }, [step])
+      return <Probe value={values[step]} />
+    }
+    renderToString(<Switcher />)
+    return { results }
+  }
+
+  it("returns the same reference when the value is shallow-equal at one level", () => {
+    const a = { duration: 600, color: "#abc" }
+    const b = { duration: 600, color: "#abc" } // value-equal, ref-different
+    const { results } = harness([a, b])
+    // renderToString doesn't loop the layout effect, so we test via
+    // direct invocation pattern below instead.
+    expect(results.length).toBeGreaterThanOrEqual(1)
+    expect(results[0]).toBe(a)
+  })
+
+  it("returns a new reference when a top-level primitive changes", () => {
+    // Inline two-call replication of the hook's contract — sufficient
+    // because the hook only inspects `value` and a `useRef` cell.
+    const captures: unknown[] = []
+    function Probe({ value }: { value: { duration: number; color: string } }) {
+      captures.push(useStableShallow(value))
+      return null
+    }
+    const a = { duration: 600, color: "#abc" }
+    const b = { duration: 700, color: "#abc" }
+    function Tree({ which }: { which: "a" | "b" }) {
+      return <Probe value={which === "a" ? a : b} />
+    }
+    renderToString(<Tree which="a" />)
+    renderToString(<Tree which="b" />)
+    // Each renderToString invocation creates a fresh `useRef` cell, so
+    // the cross-render stabilization isn't observable from server
+    // render alone. The contract we assert here is that the returned
+    // reference equals the input reference on first observation in a
+    // fresh tree — anything else would mean the hook mutated the
+    // input or returned an unrelated value.
+    expect(captures[0]).toBe(a)
+    expect(captures[1]).toBe(b)
+  })
+
+  it("treats a nested object swap with equal keys as equal", () => {
+    // Direct unit-style call to the comparison logic via a tiny harness:
+    // mount once with `a`, simulate a re-render with `b` by reusing the
+    // ref cell. Drives the same fiber across two renders.
+    let captured: unknown
+    let setValue: (v: unknown) => void = () => {}
+    function Probe({ initial }: { initial: { pulse: { duration: number; color: string } } }) {
+      const [v, setV] = React.useState(initial)
+      setValue = setV
+      captured = useStableShallow(v)
+      return null
+    }
+    const a = { pulse: { duration: 600, color: "#abc" } }
+    const b = { pulse: { duration: 600, color: "#abc" } } // value-equal nested, ref-different
+    // Use act() through React's test-renderer surface to drive a
+    // re-render. The repository pulls in `react` 19 but no test
+    // renderer in dependencies; substitute by rendering twice through
+    // hydrateRoot is overkill for this test. Instead, directly verify
+    // the comparison is equality-correct by calling the hook twice
+    // through a controlled state update.
+    const root = document.createElement("div")
+    document.body.appendChild(root)
+    try {
+      const { createRoot } = require("react-dom/client") as typeof import("react-dom/client")
+      const reactRoot = createRoot(root)
+      // First render: captured === a
+      ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+      const { act } = require("react") as typeof import("react")
+      act(() => { reactRoot.render(<Probe initial={a} />) })
+      expect(captured).toBe(a)
+      // Second render with shallow-equal nested object: should remain `a`
+      act(() => { setValue(b) })
+      expect(captured).toBe(a)
+      reactRoot.unmount()
+    } finally {
+      document.body.removeChild(root)
+    }
+  })
+})

--- a/src/components/stream/useStableShallow.ts
+++ b/src/components/stream/useStableShallow.ts
@@ -36,6 +36,7 @@ export function useStableShallow<T>(value: T): T {
 
 function shallowEqualTwoLevel(a: unknown, b: unknown): boolean {
   if (Object.is(a, b)) return true
+  if (Array.isArray(a) && Array.isArray(b)) return shallowEqualArray(a, b)
   if (!isPlainObject(a) || !isPlainObject(b)) return false
   const ak = Object.keys(a)
   const bk = Object.keys(b)
@@ -48,6 +49,10 @@ function shallowEqualTwoLevel(a: unknown, b: unknown): boolean {
     const va = (a as Record<string, unknown>)[k]
     const vb = (b as Record<string, unknown>)[k]
     if (Object.is(va, vb)) continue
+    if (Array.isArray(va) && Array.isArray(vb)) {
+      if (!shallowEqualArray(va, vb)) return false
+      continue
+    }
     if (!isPlainObject(va) || !isPlainObject(vb)) return false
     if (!shallowEqualKeys(va, vb)) return false
   }
@@ -64,6 +69,23 @@ function shallowEqualKeys(
   for (const k of ak) {
     if (!Object.prototype.hasOwnProperty.call(b, k)) return false
     if (!Object.is(a[k], b[k])) return false
+  }
+  return true
+}
+
+/**
+ * Per-index `Object.is` for arrays. Inline array literals (xExtent,
+ * yExtent, sizeRange, colorScheme, areaGroups, etc.) shed identity
+ * every render the same way inline objects do, and the pipelineConfig
+ * memo deps include them, so without array-aware comparison the
+ * stabilizer would still let the loop reform on those props. We don't
+ * recurse into array elements — the typical shape is arrays of
+ * primitives (numbers, strings) where `Object.is` is the right test.
+ */
+function shallowEqualArray(a: unknown[], b: unknown[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (!Object.is(a[i], b[i])) return false
   }
   return true
 }

--- a/src/components/stream/useStableShallow.ts
+++ b/src/components/stream/useStableShallow.ts
@@ -41,6 +41,10 @@ function shallowEqualTwoLevel(a: unknown, b: unknown): boolean {
   const bk = Object.keys(b)
   if (ak.length !== bk.length) return false
   for (const k of ak) {
+    // Confirm `b` actually has this own key — `{ a: undefined }` and
+    // `{ b: undefined }` share key counts but the values would both
+    // read as `undefined` without an explicit hasOwnProperty guard.
+    if (!Object.prototype.hasOwnProperty.call(b, k)) return false
     const va = (a as Record<string, unknown>)[k]
     const vb = (b as Record<string, unknown>)[k]
     if (Object.is(va, vb)) continue
@@ -58,13 +62,29 @@ function shallowEqualKeys(
   const bk = Object.keys(b)
   if (ak.length !== bk.length) return false
   for (const k of ak) {
+    if (!Object.prototype.hasOwnProperty.call(b, k)) return false
     if (!Object.is(a[k], b[k])) return false
   }
   return true
 }
 
+/**
+ * Strict plain-object check. We only want to recurse into bag-style
+ * objects (`{ pulse: { duration: 600 } }`) — not class instances like
+ * `Set`/`Map`/`Date`/etc. that would expose zero own enumerable keys
+ * and falsely compare equal across distinct instances. The most
+ * reliable signal is the prototype: literal objects and
+ * `Object.create(null)` are the only legitimate "config bag" shapes.
+ *
+ * Concrete consequence: StreamXYFrame's `pipelineConfig.areaGroups` is
+ * `new Set(areaGroups)`. Without this guard, two distinct Sets would
+ * be compared as `Object.keys(set).length === 0` on both sides and
+ * incorrectly stabilize, suppressing the `updateConfig` effect and
+ * leaving the area-group filter stale.
+ */
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   if (v === null || typeof v !== "object") return false
   if (Array.isArray(v)) return false
-  return true
+  const proto = Object.getPrototypeOf(v)
+  return proto === Object.prototype || proto === null
 }

--- a/src/components/stream/useStableShallow.ts
+++ b/src/components/stream/useStableShallow.ts
@@ -1,0 +1,70 @@
+/**
+ * useStableShallow — return a stable reference for a value as long as it
+ * remains shallow-equal to the previous render's value.
+ *
+ * Why: pipeline configs in the Stream Frames are large objects whose
+ * fields are typically primitives plus a few nested config sub-objects
+ * (`pulse`, `staleness`, `transition`, `particleStyle`, etc.). When a
+ * consumer constructs those sub-objects inline on the JSX —
+ * `frameProps={{ pulse: { duration: 600, ... } }}` is the canonical
+ * shape — every parent render produces a new top-level config object
+ * even though no value actually changed. Effects that list the config
+ * in their dep array then re-fire every render, dirty the scene, and
+ * schedule a paint; the rAF render loop fires `setAnnotationFrame`,
+ * which re-renders, which produces a fresh inline ref, which re-fires
+ * the effect. React 19 catches this as "Maximum update depth exceeded"
+ * after roughly fifty cycles.
+ *
+ * The hook performs a one-level-deep shallow compare: top-level keys
+ * are compared with `===`, and any object-typed value is compared by
+ * its own keys with `===`. That's enough to absorb the inline-config
+ * pattern (objects of primitives) without paying for full deep
+ * equality. Function-valued props are compared by identity — consumers
+ * that pass new function refs every render are still expected to
+ * memoize them, since stable-function semantics require it for hover
+ * callbacks, tooltip renderers, and similar.
+ */
+import { useRef } from "react"
+
+export function useStableShallow<T>(value: T): T {
+  const ref = useRef<T>(value)
+  if (!shallowEqualTwoLevel(ref.current, value)) {
+    ref.current = value
+  }
+  return ref.current
+}
+
+function shallowEqualTwoLevel(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true
+  if (!isPlainObject(a) || !isPlainObject(b)) return false
+  const ak = Object.keys(a)
+  const bk = Object.keys(b)
+  if (ak.length !== bk.length) return false
+  for (const k of ak) {
+    const va = (a as Record<string, unknown>)[k]
+    const vb = (b as Record<string, unknown>)[k]
+    if (Object.is(va, vb)) continue
+    if (!isPlainObject(va) || !isPlainObject(vb)) return false
+    if (!shallowEqualKeys(va, vb)) return false
+  }
+  return true
+}
+
+function shallowEqualKeys(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+): boolean {
+  const ak = Object.keys(a)
+  const bk = Object.keys(b)
+  if (ak.length !== bk.length) return false
+  for (const k of ak) {
+    if (!Object.is(a[k], b[k])) return false
+  }
+  return true
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  if (v === null || typeof v !== "object") return false
+  if (Array.isArray(v)) return false
+  return true
+}


### PR DESCRIPTION
This pull request updates the project version from 3.4.2 to 3.5.0 across multiple configuration and metadata files to prepare for a new release. No code or feature changes are included; this is a version bump and release documentation update.

Release version update:

* Updated the version to 3.5.0 in `package.json`, `ai/schema.json`, `server.json`, and the changelog (`CHANGELOG.md`). [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-11d73edc35698861bc3e58aa5c3f2e0061aed4a1216352b544d334e92659e575L4-R4) [[3]](diffhunk://#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429L11-R17) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R8)
* 
Introduce useStableShallow to keep pipeline/config objects stable across renders when they are shallow-equal, preventing churn from inline object props. Integrate the hook into StreamGeoFrame, StreamNetworkFrame, StreamOrdinalFrame and StreamXYFrame so stores and update effects use the stabilized config and deps. Add tests for useStableShallow and move a streaming Sankey frameProps object in docs to a hoisted constant to ensure a stable reference. Fix LinkedLegend to run hooks unconditionally and perform its empty-state early return after hooks to avoid React 19 static-flag errors. Make barFunnel label rendering theme-aware (light/dark detection), adjust label colors/borders, and add helper color parsing and luminance check.
