### PR TITLE
Add heatmap tooltip and bin center metadata

### DIFF
--- a/src/components/charts/realtime/RealtimeHeatmap.tsx
+++ b/src/components/charts/realtime/RealtimeHeatmap.tsx
@@ -18,7 +18,7 @@ import { useChartSelection, useChartMode } from "../shared/hooks"
 import type { LegendInteractionMode, LegendPosition } from "../shared/hooks"
 import type { ChartMode, ChartAccessor, SelectionConfig } from "../shared/types"
 import type { OnObservationCallback } from "../../store/ObservationStore"
-import { buildDefaultRealtimeTooltip } from "./defaultRealtimeTooltip"
+import { buildHeatmapTooltip } from "./defaultRealtimeTooltip"
 import { renderLoadingState, renderEmptyState } from "../shared/withChartWrapper"
 import { resolveRealtimeWindowSize } from "./resolveWindowSize"
 import type { Datum } from "../shared/datumTypes"
@@ -199,9 +199,14 @@ export const RealtimeHeatmap = forwardRef(
     const enableHover = resolved.enableHover
     const margin = userMargin ?? resolved.marginDefaults
     const resolvedSize: [number, number] = size ?? [resolved.width, resolved.height]
-    // See RealtimeLineChart for the data-space-vs-pixel-space tooltip rationale.
+    // Heatcell datums are aggregated bins, not the user's raw rows — the
+    // generic `x:/y:` tooltip would read undefined off `timeAccessor`/
+    // `valueAccessor` since the cell datum is `{xi, yi, value, count, sum,
+    // xCenter, yCenter, agg}`. The heatmap-specific helper reads the
+    // enriched bin-center coords + aggregation type so users see real
+    // data-space values and the cell's count/sum/mean.
     const resolvedTooltip =
-      tooltipContent ?? tooltip ?? buildDefaultRealtimeTooltip({ timeAccessor, valueAccessor })
+      tooltipContent ?? tooltip ?? buildHeatmapTooltip({ timeAccessor, valueAccessor })
 
     const frameRef = useRef<StreamXYFrameHandle>(null)
 

--- a/src/components/charts/realtime/defaultRealtimeTooltip.test.tsx
+++ b/src/components/charts/realtime/defaultRealtimeTooltip.test.tsx
@@ -181,13 +181,20 @@ describe("buildHeatmapTooltip", () => {
     expect(container.textContent).toMatch(/count:\s*42/)
   })
 
-  it("shows sum only when agg === \"sum\" and the sum differs from count", () => {
+  it("shows sum whenever agg === \"sum\", including the sum-equals-count edge case", () => {
     const Tooltip = buildHeatmapTooltip()
     const sumHover = heatmapHover({ agg: "sum", value: 142, count: 12, sum: 142 })
     const text = render(<>{Tooltip(sumHover)}</>).container.textContent ?? ""
     expect(text).toMatch(/sum:\s*142/)
     expect(text).not.toMatch(/mean:/)
-    // count agg keeps the sum row hidden — value === count there, no extra info.
+    // The metric the heatmap is colored BY when agg="sum" is the sum,
+    // so it's surfaced even when sum coincidentally equals count
+    // (e.g. every value in the bin is 1). Suppressing on equality used
+    // to hide the primary aggregated metric on this realistic case.
+    const onesHover = heatmapHover({ agg: "sum", value: 5, count: 5, sum: 5 })
+    const onesText = render(<>{Tooltip(onesHover)}</>).container.textContent ?? ""
+    expect(onesText).toMatch(/sum:\s*5/)
+    // count agg still keeps the sum row hidden — sum isn't the metric there.
     const countText = render(<>{Tooltip(heatmapHover())}</>).container.textContent ?? ""
     expect(countText).not.toMatch(/sum:/)
     expect(countText).not.toMatch(/mean:/)

--- a/src/components/charts/realtime/defaultRealtimeTooltip.test.tsx
+++ b/src/components/charts/realtime/defaultRealtimeTooltip.test.tsx
@@ -12,7 +12,7 @@
 import * as React from "react"
 import { render } from "@testing-library/react"
 import { describe, it, expect } from "vitest"
-import { buildDefaultRealtimeTooltip, buildWaterfallTooltip } from "./defaultRealtimeTooltip"
+import { buildDefaultRealtimeTooltip, buildWaterfallTooltip, buildHeatmapTooltip } from "./defaultRealtimeTooltip"
 import type { HoverData } from "../../realtime/types"
 
 function fakeHover(overrides: Partial<HoverData> = {}): HoverData {
@@ -145,5 +145,77 @@ describe("buildWaterfallTooltip", () => {
     expect(text).toMatch(/x:\s*100/)
     expect(text).toMatch(/Δ:\s*\+7/)
     expect(text).toMatch(/total:\s*7/)
+  })
+})
+
+describe("buildHeatmapTooltip", () => {
+  // Shape mirrors what `heatmapScene.buildStreamingHeatmapScene` puts on
+  // each cell's datum after the bin-center / agg enrichment pass.
+  function heatmapHover(overrides: Record<string, unknown> = {}): HoverData {
+    return {
+      data: {
+        xi: 3, yi: 7,
+        value: 12, count: 12, sum: 0,
+        xCenter: 14.5, yCenter: 87.25,
+        agg: "count",
+        ...overrides,
+      },
+      x: 240, y: 128,
+    } as HoverData
+  }
+
+  it("prefers xCenter / yCenter from the enriched bin datum over accessor lookup", () => {
+    // timeAccessor / valueAccessor would resolve to "time" / "value" on the
+    // datum (both undefined here) — the helper has to ignore them when the
+    // bin-center fields are present, otherwise the tooltip reads blank.
+    const Tooltip = buildHeatmapTooltip()
+    const { container } = render(<>{Tooltip(heatmapHover())}</>)
+    const text = container.textContent ?? ""
+    expect(text).toMatch(/x:\s*14\.50/)
+    expect(text).toMatch(/y:\s*87\.25/)
+  })
+
+  it("always shows count regardless of aggregation type", () => {
+    const Tooltip = buildHeatmapTooltip()
+    const { container } = render(<>{Tooltip(heatmapHover({ count: 42 }))}</>)
+    expect(container.textContent).toMatch(/count:\s*42/)
+  })
+
+  it("shows sum only when agg === \"sum\" and the sum differs from count", () => {
+    const Tooltip = buildHeatmapTooltip()
+    const sumHover = heatmapHover({ agg: "sum", value: 142, count: 12, sum: 142 })
+    const text = render(<>{Tooltip(sumHover)}</>).container.textContent ?? ""
+    expect(text).toMatch(/sum:\s*142/)
+    expect(text).not.toMatch(/mean:/)
+    // count agg keeps the sum row hidden — value === count there, no extra info.
+    const countText = render(<>{Tooltip(heatmapHover())}</>).container.textContent ?? ""
+    expect(countText).not.toMatch(/sum:/)
+    expect(countText).not.toMatch(/mean:/)
+  })
+
+  it("shows mean only when agg === \"mean\"", () => {
+    const Tooltip = buildHeatmapTooltip()
+    const meanHover = heatmapHover({ agg: "mean", value: 11.83, count: 12, sum: 142 })
+    const text = render(<>{Tooltip(meanHover)}</>).container.textContent ?? ""
+    expect(text).toMatch(/mean:\s*11\.83/)
+    expect(text).not.toMatch(/sum:/)
+  })
+
+  it("falls back to accessor-based x/y when the bin-center fields are absent", () => {
+    // Non-streaming render path (or a custom scene) that doesn't produce
+    // `xCenter` / `yCenter` on the datum should still degrade to the user's
+    // declared accessor fields rather than rendering blank values.
+    const Tooltip = buildHeatmapTooltip({
+      timeAccessor: "t" as unknown as never,
+      valueAccessor: "v" as unknown as never,
+    })
+    const fallbackHover = {
+      data: { t: 5, v: 99, count: 1, agg: "count" },
+      x: 0, y: 0,
+    } as HoverData
+    const text = render(<>{Tooltip(fallbackHover)}</>).container.textContent ?? ""
+    expect(text).toMatch(/x:\s*5/)
+    expect(text).toMatch(/y:\s*99/)
+    expect(text).toMatch(/count:\s*1/)
   })
 })

--- a/src/components/charts/realtime/defaultRealtimeTooltip.tsx
+++ b/src/components/charts/realtime/defaultRealtimeTooltip.tsx
@@ -148,12 +148,16 @@ export function buildWaterfallTooltip<TDatum extends Datum = Datum>(
  * This tooltip surfaces the user-relevant info:
  *   x:     <data-space x-center of the bin>
  *   y:     <data-space y-center of the bin>
- *   count: 12               (always shown)
- *   sum:   142              (when agg === "sum" and differs from count)
+ *   count: 12               (when datum.count is present — streaming path)
+ *   sum:   142              (when agg === "sum")
  *   mean:  11.83            (when agg === "mean")
  *
+ * For `agg === "sum"` we always surface the sum (it's the metric the
+ * heatmap is colored by, even when sum happens to equal count).
+ *
  * Falls back to the canonical x/y shape if the enriched fields are
- * absent (e.g. a non-streaming render path).
+ * absent (e.g. a non-streaming render path); the count/sum/mean rows
+ * only appear when the matching field is present on the datum.
  */
 export function buildHeatmapTooltip<TDatum extends Datum = Datum>(
   options: DefaultRealtimeTooltipOptions<TDatum> = {},
@@ -186,7 +190,7 @@ export function buildHeatmapTooltip<TDatum extends Datum = Datum>(
         {count != null && (
           <div><span style={labelStyle}>count:</span>{format(count)}</div>
         )}
-        {agg === "sum" && sum != null && sum !== count && (
+        {agg === "sum" && sum != null && (
           <div><span style={labelStyle}>sum:</span>{format(sum)}</div>
         )}
         {agg === "mean" && mean != null && (

--- a/src/components/charts/realtime/defaultRealtimeTooltip.tsx
+++ b/src/components/charts/realtime/defaultRealtimeTooltip.tsx
@@ -171,7 +171,13 @@ export function buildHeatmapTooltip<TDatum extends Datum = Datum>(
     const x = datum?.xCenter ?? readField(datum, timeAccessor, "time")
     const y = datum?.yCenter ?? readField(datum, valueAccessor, "value")
     const count = datum?.count
-    const value = datum?.value
+    // Read the dedicated `sum` and `value` fields directly off the datum
+    // contract instead of treating `value` as the sum (it's
+    // aggregation-dependent — equals count for "count", mean for "mean").
+    // Decoupling the display from `value` semantics keeps the tooltip
+    // honest if the scene ever changes how `value` is computed.
+    const sum = datum?.sum
+    const mean = datum?.value
     const agg = datum?.agg ?? "count"
     return (
       <div className="semiotic-tooltip" style={tooltipStyle}>
@@ -180,11 +186,11 @@ export function buildHeatmapTooltip<TDatum extends Datum = Datum>(
         {count != null && (
           <div><span style={labelStyle}>count:</span>{format(count)}</div>
         )}
-        {agg === "sum" && value != null && value !== count && (
-          <div><span style={labelStyle}>sum:</span>{format(value)}</div>
+        {agg === "sum" && sum != null && sum !== count && (
+          <div><span style={labelStyle}>sum:</span>{format(sum)}</div>
         )}
-        {agg === "mean" && value != null && (
-          <div><span style={labelStyle}>mean:</span>{format(value)}</div>
+        {agg === "mean" && mean != null && (
+          <div><span style={labelStyle}>mean:</span>{format(mean)}</div>
         )}
       </div>
     )

--- a/src/components/charts/realtime/defaultRealtimeTooltip.tsx
+++ b/src/components/charts/realtime/defaultRealtimeTooltip.tsx
@@ -135,3 +135,58 @@ export function buildWaterfallTooltip<TDatum extends Datum = Datum>(
     )
   }
 }
+
+/**
+ * Heatmap-specific default tooltip.
+ *
+ * The streaming heatmap aggregates raw points into 2D bins; each cell's
+ * datum is `{ xi, yi, value, count, sum, xCenter, yCenter, agg }`. The
+ * generic `x: <time>, y: <value>` shape is meaningless because the cell
+ * doesn't carry the user's original fields — it carries bin indices and
+ * aggregated counts.
+ *
+ * This tooltip surfaces the user-relevant info:
+ *   x:     <data-space x-center of the bin>
+ *   y:     <data-space y-center of the bin>
+ *   count: 12               (always shown)
+ *   sum:   142              (when agg === "sum" and differs from count)
+ *   mean:  11.83            (when agg === "mean")
+ *
+ * Falls back to the canonical x/y shape if the enriched fields are
+ * absent (e.g. a non-streaming render path).
+ */
+export function buildHeatmapTooltip<TDatum extends Datum = Datum>(
+  options: DefaultRealtimeTooltipOptions<TDatum> = {},
+): (d: HoverData) => ReactNode {
+  const { timeAccessor, valueAccessor, xLabel = "x", yLabel = "y" } = options
+  return (d: HoverData) => {
+    const datum = (d?.data ?? null) as (TDatum & {
+      xi?: number; yi?: number;
+      value?: number; count?: number; sum?: number;
+      xCenter?: number; yCenter?: number;
+      agg?: "count" | "sum" | "mean";
+    }) | null
+    // Prefer the bin's data-space center; fall back to user accessors
+    // for non-streaming or custom-emitted heatcells.
+    const x = datum?.xCenter ?? readField(datum, timeAccessor, "time")
+    const y = datum?.yCenter ?? readField(datum, valueAccessor, "value")
+    const count = datum?.count
+    const value = datum?.value
+    const agg = datum?.agg ?? "count"
+    return (
+      <div className="semiotic-tooltip" style={tooltipStyle}>
+        <div><span style={labelStyle}>{xLabel}:</span>{format(x)}</div>
+        <div><span style={labelStyle}>{yLabel}:</span>{format(y)}</div>
+        {count != null && (
+          <div><span style={labelStyle}>count:</span>{format(count)}</div>
+        )}
+        {agg === "sum" && value != null && value !== count && (
+          <div><span style={labelStyle}>sum:</span>{format(value)}</div>
+        )}
+        {agg === "mean" && value != null && (
+          <div><span style={labelStyle}>mean:</span>{format(value)}</div>
+        )}
+      </div>
+    )
+  }
+}

--- a/src/components/stream/xySceneBuilders/heatmapScene.test.ts
+++ b/src/components/stream/xySceneBuilders/heatmapScene.test.ts
@@ -371,6 +371,62 @@ describe("buildStreamingHeatmapScene", () => {
     expect(nodes).toHaveLength(0)
   })
 
+  it("enriches each cell datum with bin-center coords and aggregation type for tooltip consumption", () => {
+    // Domain [0,100], 5 bins => binSize 20, so:
+    //   bin (0, 0) center = (0 + 0.5) * 20 = 10
+    //   bin (2, 2) center = (2 + 0.5) * 20 = 50
+    //   bin (4, 4) center = (4 + 0.5) * 20 = 90
+    // The bin-center fields drive the realtime heatmap default tooltip
+    // (`x:` / `y:` rows). Without them the streaming heatmap reads as
+    // blank because the cell datum has bin INDICES, not the user's
+    // original `time` / `value` field names.
+    const data = [
+      { x: 5, y: 5, value: 1 },     // → bin (0, 0)
+      { x: 50, y: 50, value: 1 },   // → bin (2, 2)
+      { x: 95, y: 95, value: 1 },   // → bin (4, 4)
+    ]
+    const ctx = makeStreamCtx()
+    const nodes = buildHeatmapScene(ctx, data, defaultLayout)
+    expect(nodes).toHaveLength(3)
+
+    // Sort by xi so positional asserts are stable.
+    const datums = nodes
+      .map((n) => (n as any).datum)
+      .sort((a, b) => a.xi - b.xi)
+
+    // Bin (0, 0) — top-left of the data domain.
+    expect(datums[0].xCenter).toBe(10)
+    expect(datums[0].yCenter).toBe(10)
+    // Bin (2, 2) — middle.
+    expect(datums[1].xCenter).toBe(50)
+    expect(datums[1].yCenter).toBe(50)
+    // Bin (4, 4) — last bin (clamped by the streaming binner).
+    expect(datums[2].xCenter).toBe(90)
+    expect(datums[2].yCenter).toBe(90)
+
+    // Every cell carries the active aggregation type so the tooltip can
+    // pick which row to surface (count/sum/mean) without re-deriving it.
+    expect(datums.every((d) => d.agg === "count")).toBe(true)
+  })
+
+  it("threads the configured agg through to each cell datum (sum / mean)", () => {
+    // The tooltip's sum vs. mean row picks off `datum.agg` directly —
+    // pin both branches so a future config-shape change can't silently
+    // ship a tooltip that reads off the wrong field.
+    const data = [{ x: 10, y: 10, value: 5 }]
+    const sumNodes = buildHeatmapScene(
+      makeStreamCtx({ config: { heatmapAggregation: "sum", heatmapXBins: 5, heatmapYBins: 5, valueAccessor: "value" } }),
+      data, defaultLayout,
+    )
+    expect((sumNodes[0] as any).datum.agg).toBe("sum")
+
+    const meanNodes = buildHeatmapScene(
+      makeStreamCtx({ config: { heatmapAggregation: "mean", heatmapXBins: 5, heatmapYBins: 5, valueAccessor: "value" } }),
+      data, defaultLayout,
+    )
+    expect((meanNodes[0] as any).datum.agg).toBe("mean")
+  })
+
   it("showValues sets label metadata in streaming mode", () => {
     const data = [{ x: 10, y: 10, value: 7 }]
     const ctx = makeStreamCtx({

--- a/src/components/stream/xySceneBuilders/heatmapScene.ts
+++ b/src/components/stream/xySceneBuilders/heatmapScene.ts
@@ -277,10 +277,16 @@ function buildStreamingHeatmapScene(ctx: XYSceneContext, data: Datum[], layout: 
       const labelOpts = showValues
         ? { value: val, showValues: true as const, valueFormat }
         : undefined
+      // Enrich the datum with the bin's data-space center coords + the
+      // aggregation type so consumer tooltips can show meaningful values.
+      // Without these the streaming heatmap datum is just `{xi, yi, ...}`
+      // which doesn't tell the user *where* in their data the cell sits.
+      const xCenter = xMin + (xi + 0.5) * xBinSize
+      const yCenter = yMin + (yi + 0.5) * yBinSize
       nodes.push(buildHeatcellNode(
         xi * cellW, (yBins - 1 - yi) * cellH,
         cellW, cellH, fill,
-        { xi, yi, value: val, count: counts[idx], sum: sums[idx] },
+        { xi, yi, value: val, count: counts[idx], sum: sums[idx], xCenter, yCenter, agg },
         labelOpts
       ))
     }


### PR DESCRIPTION
Introduce a heatmap-specific tooltip builder and include bin center/agg metadata on streaming heatmap nodes. RealtimeHeatmap now uses buildHeatmapTooltip (instead of the generic default) so tooltips show the bin's data-space x/y centers, count, and sum/mean as appropriate. heatmapScene enriches each heatcell datum with xCenter, yCenter and agg fields (and still provides value/count/sum) so consumer tooltips can display meaningful data-space values. The new tooltip falls back to canonical accessors when enriched fields are absent.

This pull request improves the tooltip experience for the streaming heatmap chart by introducing a heatmap-specific tooltip that displays more meaningful and user-relevant information about each cell. The changes ensure that tooltips show the actual data-space coordinates and aggregation details, rather than generic or undefined values. Additionally, the heatmap scene builder now enriches each cell's datum with the bin's center coordinates and aggregation type to support the enhanced tooltip.

**Heatmap Tooltip Improvements:**

* Added a new `buildHeatmapTooltip` function in `defaultRealtimeTooltip.tsx` that generates tooltips displaying the bin's data-space center coordinates, count, sum, and mean, depending on the aggregation type. This provides users with relevant and clear information for each heatmap cell.
* Updated `RealtimeHeatmap.tsx` to use `buildHeatmapTooltip` instead of the generic tooltip builder, ensuring the new tooltip is used by default for heatmap charts. [[1]](diffhunk://#diff-b6e0aa61baa9653f7845bca62594a0e9ae13f27c7eeeb2b23fff5bbab1beea14L21-R21) [[2]](diffhunk://#diff-b6e0aa61baa9653f7845bca62594a0e9ae13f27c7eeeb2b23fff5bbab1beea14L202-R209)

**Data Enrichment for Tooltips:**

* Modified the heatmap scene builder in `heatmapScene.ts` to enrich each cell's datum with `xCenter`, `yCenter`, and `agg` fields, enabling the tooltip to display the cell's location and aggregation type in data-space coordinates.