### PR TITLE
bump version to 3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.1] - 2026-05-05
+
+### Added
+
+- Added explicit extent examples and tests covering chart-level `xExtent`/`yExtent` pass-through.
+
+### Fixed
+
+- Fixed `yExtent` handling so explicit user bounds continue to control the rendered domain instead of being overridden by envelope-derived extents.
+- Fixed realtime heatmap tooltip metadata so bin-center values are available and `agg="sum"` tooltips report summed values.
+
 ## [3.5.0] - 2026-05-02
 
 ### Added

--- a/ai/schema.json
+++ b/ai/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "semiotic",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "React data visualization library for charts, networks, and beyond",
   "tools": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "semiotic",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "semiotic",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "d3-array": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semiotic",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "mcpName": "io.github.nteract/semiotic",
   "description": "React data visualization library with built-in MCP server for AI-assisted chart generation",
   "main": "dist/semiotic.min.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/nteract/semiotic",
     "source": "github"
   },
-  "version": "3.5.0",
+  "version": "3.5.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "semiotic",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
This pull request updates the project to version 3.5.1, introducing improvements and bug fixes related to chart extent handling and heatmap tooltips. The version is incremented across all relevant metadata files, and the changelog is updated to reflect the new changes.

Version bump and changelog update:

* Incremented the version to `3.5.1` in `package.json`, `ai/schema.json`, and `server.json` to reflect the latest release. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-11d73edc35698861bc3e58aa5c3f2e0061aed4a1216352b544d334e92659e575L4-R4) [[3]](diffhunk://#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429L11-R17)
* Updated `CHANGELOG.md` to document new features and fixes in version 3.5.1, including explicit extent example/tests, improved `yExtent` handling, and heatmap tooltip improvements.