### PR TITLE
  Architecture sweep + capability-driven AI surfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,9 +23,9 @@
 **LineChart** — `data`, `xAccessor` ("x"), `yAccessor` ("y"), `lineBy`, `lineDataAccessor`, `colorBy`, `colorScheme`, `curve`, `lineWidth` (2), `showPoints`, `pointRadius` (3), `fillArea` (boolean|string[]), `areaOpacity` (0.3), `lineGradient`, `anomaly`, `forecast`, `directLabel`, `gapStrategy`, `xScaleType`/`yScaleType` ("linear"|"log"|"time"), `tooltip="multi"` for hover-anywhere series comparison
 **AreaChart** — LineChart props + `areaBy`, `y0Accessor`, `gradientFill`, `areaOpacity` (0.7), `showLine` (true), `tooltip="multi"` for hover-anywhere area comparison
 **StackedAreaChart** — flat array + `areaBy` (required), `colorBy`, `normalize`, `baseline` (`"zero"` default | `"wiggle"` for streamgraph | `"silhouette"` for centered), `stackOrder` (`"key"` default alpha | `"insideOut"` largest-in-middle | `"asc"`/`"desc"` by total). For canonical streamgraph aesthetic: `baseline="wiggle"` + `stackOrder="insideOut"` puts the largest series in the middle as a central anchor with smaller series wrapping outward. `baseline` is mutually exclusive with `normalize`. No `lineBy`/`lineDataAccessor`. Pass `tooltip="multi"` for hover-anywhere mode: a single tooltip lists every stacked series at the hovered x, with values interpolated between rendered path samples.
-**Scatterplot** — `data`, `xAccessor`, `yAccessor`, `colorBy`, `sizeBy`, `sizeRange`, `pointRadius` (5), `pointOpacity` (0.8), `marginalGraphics`
-**BubbleChart** — Scatterplot + `sizeBy` (required), `sizeRange` ([5,40])
-**ConnectedScatterplot** — + `orderAccessor`
+**Scatterplot** — `data`, `xAccessor`, `yAccessor`, `colorBy`, `sizeBy`, `sizeRange`, `pointRadius` (5), `pointOpacity` (0.8), `marginalGraphics`, `regression` (boolean | "linear" | "polynomial" | "loess" | RegressionConfig — sugar for a trend-annotation overlay; sits underneath user annotations)
+**BubbleChart** — Scatterplot + `sizeBy` (required), `sizeRange` ([5,40]), `regression`
+**ConnectedScatterplot** — + `orderAccessor`, `regression`
 **QuadrantChart** — Scatterplot + `quadrants` (required), `xCenter`, `yCenter`
 **MultiAxisLineChart** — Dual Y-axis. `series` (required: `[{ yAccessor, label?, color?, format?, extent? }]`). Falls back to multi-line if not 2 series.
 **Heatmap** — `data`, `xAccessor`, `yAccessor`, `valueAccessor`, `colorScheme`, `showValues`, `cellBorderColor`
@@ -35,7 +35,7 @@
 
 ## Ordinal Charts (`semiotic/ordinal`)
 
-**BarChart** — `data`, `categoryAccessor`, `valueAccessor`, `orientation`, `colorBy`, `sort`, `barPadding` (40), `roundedTop`, `gradientFill` (`true` | `{topOpacity, bottomOpacity}` | `{colorStops}` — same API as AreaChart; runs tip→base)
+**BarChart** — `data`, `categoryAccessor`, `valueAccessor`, `orientation`, `colorBy`, `sort`, `barPadding` (40), `roundedTop`, `gradientFill` (`true` | `{topOpacity, bottomOpacity}` | `{colorStops}` — same API as AreaChart; runs tip→base), `regression` (boolean | "linear" | "polynomial" | "loess" | RegressionConfig — sugar for a trend-annotation overlay; categories regressed as category-index, line projects through band scale)
 **StackedBarChart** — + `stackBy` (required), `normalize`, `sort` (default false — insertion order)
 **GroupedBarChart** — + `groupBy` (required), `barPadding` (60), `sort` (default false — insertion order)
 **SwarmPlot** — `colorBy`, `sizeBy`, `pointRadius`, `pointOpacity`
@@ -43,7 +43,7 @@
 **Histogram** — + `bins` (25), `relative`. Always horizontal.
 **ViolinPlot** — + `bins`, `curve`, `showIQR`
 **RidgelinePlot** — + `bins`, `amplitude` (1.5)
-**DotPlot** — + `sort` ("auto" — insertion order when streaming, value-desc on static), `dotRadius`, `showGrid` default true
+**DotPlot** — + `sort` ("auto" — insertion order when streaming, value-desc on static), `dotRadius`, `showGrid` default true, `regression`
 **PieChart** — `categoryAccessor`, `valueAccessor`, `colorBy`, `startAngle`
 **DonutChart** — PieChart + `innerRadius` (60), `centerContent`
 **FunnelChart** — `stepAccessor`, `valueAccessor`, `categoryAccessor` (optional), `connectorOpacity`, `orientation`

--- a/ai/capabilities.json
+++ b/ai/capabilities.json
@@ -1,0 +1,575 @@
+{
+  "__generated": true,
+  "__source": "src/components/charts/shared/chartSpecs.ts",
+  "charts": {
+    "AreaChart": {
+      "category": "xy",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": []
+    },
+    "BubbleChart": {
+      "category": "xy",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "size-encoding",
+        "streaming-domain",
+        "regression-overlay"
+      ]
+    },
+    "CandlestickChart": {
+      "category": "xy",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "ohlc"
+      ]
+    },
+    "ConnectedScatterplot": {
+      "category": "xy",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "regression-overlay"
+      ]
+    },
+    "Heatmap": {
+      "category": "xy",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "sequential",
+      "layoutMode": "plugin",
+      "specialFeatures": []
+    },
+    "LineChart": {
+      "category": "xy",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "forecast",
+        "anomaly",
+        "gap-handling",
+        "direct-labels",
+        "endpoint-labels"
+      ]
+    },
+    "MinimapChart": {
+      "category": "xy",
+      "supportsLegend": true,
+      "supportsSelection": false,
+      "supportsLinkedHover": false,
+      "supportsPush": false,
+      "supportsSSR": false,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "brush",
+        "overview-detail",
+        "composite-delegates-interaction",
+        "hoc-ssr-only"
+      ]
+    },
+    "MultiAxisLineChart": {
+      "category": "xy",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": false,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "dual-axis",
+        "hoc-ssr-only"
+      ]
+    },
+    "QuadrantChart": {
+      "category": "xy",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": false,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "quadrants",
+        "hoc-ssr-only"
+      ]
+    },
+    "Scatterplot": {
+      "category": "xy",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "regression-overlay"
+      ]
+    },
+    "ScatterplotMatrix": {
+      "category": "xy",
+      "supportsLegend": true,
+      "supportsSelection": false,
+      "supportsLinkedHover": false,
+      "supportsPush": false,
+      "supportsSSR": false,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "matrix",
+        "brush",
+        "composite-delegates-interaction",
+        "hoc-ssr-only"
+      ]
+    },
+    "StackedAreaChart": {
+      "category": "xy",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "stack",
+        "streamgraph"
+      ]
+    },
+    "BarChart": {
+      "category": "ordinal",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "regression-overlay"
+      ]
+    },
+    "BoxPlot": {
+      "category": "ordinal",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "statistical"
+      ]
+    },
+    "DonutChart": {
+      "category": "ordinal",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": []
+    },
+    "DotPlot": {
+      "category": "ordinal",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "regression-overlay"
+      ]
+    },
+    "FunnelChart": {
+      "category": "ordinal",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": []
+    },
+    "GaugeChart": {
+      "category": "ordinal",
+      "supportsLegend": false,
+      "supportsSelection": false,
+      "supportsLinkedHover": false,
+      "supportsPush": false,
+      "supportsSSR": true,
+      "colorModel": "threshold",
+      "layoutMode": "synthetic",
+      "specialFeatures": [
+        "threshold-zones",
+        "value-only",
+        "controlled-prop-streaming"
+      ]
+    },
+    "GroupedBarChart": {
+      "category": "ordinal",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": []
+    },
+    "Histogram": {
+      "category": "ordinal",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": []
+    },
+    "LikertChart": {
+      "category": "ordinal",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": []
+    },
+    "PieChart": {
+      "category": "ordinal",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": []
+    },
+    "RidgelinePlot": {
+      "category": "ordinal",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": []
+    },
+    "StackedBarChart": {
+      "category": "ordinal",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "stack"
+      ]
+    },
+    "SwarmPlot": {
+      "category": "ordinal",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": []
+    },
+    "SwimlaneChart": {
+      "category": "ordinal",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "brush"
+      ]
+    },
+    "ViolinPlot": {
+      "category": "ordinal",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "statistical"
+      ]
+    },
+    "ChordDiagram": {
+      "category": "network",
+      "supportsLegend": false,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": []
+    },
+    "CirclePack": {
+      "category": "network",
+      "supportsLegend": false,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": false,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "hierarchy"
+      ]
+    },
+    "ForceDirectedGraph": {
+      "category": "network",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "force-simulation"
+      ]
+    },
+    "OrbitDiagram": {
+      "category": "network",
+      "supportsLegend": false,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": false,
+      "supportsSSR": false,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "hierarchy",
+        "animated",
+        "hoc-ssr-only"
+      ]
+    },
+    "ProcessSankey": {
+      "category": "network",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "custom",
+      "specialFeatures": [
+        "temporal",
+        "particles",
+        "lane-reuse"
+      ]
+    },
+    "SankeyDiagram": {
+      "category": "network",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": []
+    },
+    "TreeDiagram": {
+      "category": "network",
+      "supportsLegend": false,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": false,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "hierarchy"
+      ]
+    },
+    "Treemap": {
+      "category": "network",
+      "supportsLegend": false,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": false,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "hierarchy"
+      ]
+    },
+    "ChoroplethMap": {
+      "category": "geo",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": false,
+      "supportsSSR": true,
+      "colorModel": "sequential",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "controlled-prop-streaming"
+      ]
+    },
+    "DistanceCartogram": {
+      "category": "geo",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": false,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "distortion",
+        "hoc-ssr-only"
+      ]
+    },
+    "FlowMap": {
+      "category": "geo",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "particles"
+      ]
+    },
+    "ProportionalSymbolMap": {
+      "category": "geo",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": true,
+      "colorModel": "sequential",
+      "layoutMode": "plugin",
+      "specialFeatures": []
+    },
+    "RealtimeHeatmap": {
+      "category": "realtime",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": false,
+      "colorModel": "sequential",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "live-stream"
+      ]
+    },
+    "RealtimeHistogram": {
+      "category": "realtime",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": false,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "live-stream",
+        "brush"
+      ]
+    },
+    "RealtimeLineChart": {
+      "category": "realtime",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": false,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "live-stream"
+      ]
+    },
+    "RealtimeSwarmChart": {
+      "category": "realtime",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": false,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "live-stream"
+      ]
+    },
+    "RealtimeWaterfallChart": {
+      "category": "realtime",
+      "supportsLegend": true,
+      "supportsSelection": true,
+      "supportsLinkedHover": true,
+      "supportsPush": true,
+      "supportsSSR": false,
+      "colorModel": "categorical",
+      "layoutMode": "plugin",
+      "specialFeatures": [
+        "live-stream"
+      ]
+    }
+  }
+}

--- a/ai/chartSuggestions.cjs
+++ b/ai/chartSuggestions.cjs
@@ -1,10 +1,91 @@
 "use strict"
 
+const path = require("path")
+
 const VALID_INTENTS = [
   "comparison", "trend", "distribution", "relationship", "composition",
   "geographic", "network", "hierarchy",
 ]
 const MAX_SAMPLE_SIZE = 5
+
+// Capability matrix loaded from `ai/capabilities.json` — generated
+// from `chartSpecs.ts` via `npm run docs:capabilities`. Used to
+// filter suggestions when the caller passes capability constraints.
+// Loaded lazily so a test or build that hasn't generated the file
+// yet still imports cleanly; consumers that pass capability
+// constraints will see an explicit error if the JSON is missing.
+//
+// `__dirname` points at the cjs source location at runtime —
+// when bundled into `ai/dist/mcp-server.js` `__dirname` is
+// `ai/dist/`, so we also probe the parent directory. Mirrors the
+// `schema.json` loader's two-candidate pattern.
+let _capabilityMatrix = null
+function loadCapabilityMatrix() {
+  if (_capabilityMatrix) return _capabilityMatrix
+  const candidates = [
+    path.join(__dirname, "capabilities.json"),
+    path.join(__dirname, "..", "capabilities.json"),
+  ]
+  for (const candidate of candidates) {
+    try {
+      const json = require(candidate)
+      if (json && json.charts) {
+        _capabilityMatrix = json.charts
+        return _capabilityMatrix
+      }
+    } catch {
+      // try next candidate
+    }
+  }
+  _capabilityMatrix = {}
+  return _capabilityMatrix
+}
+
+// Mapping from the capability arg names callers pass (push,
+// linkedHover, ssr, selection, legend) to the chartSpecs field
+// names in capabilities.json (supportsPush, supportsLinkedHover,
+// etc.). Caller-side names are short for ergonomics; matrix-side
+// names mirror the chartSpecs schema so search/grep finds both.
+const CAPABILITY_KEY_MAP = {
+  push: "supportsPush",
+  linkedHover: "supportsLinkedHover",
+  ssr: "supportsSSR",
+  selection: "supportsSelection",
+  legend: "supportsLegend",
+}
+
+const VALID_CAPABILITY_KEYS = Object.keys(CAPABILITY_KEY_MAP)
+
+/**
+ * Test a chart name against a capability constraint object. Returns
+ * `true` when the chart satisfies every constraint (or when no
+ * constraints are set). Unknown chart names fail closed — better to
+ * drop a suggestion than recommend a chart we can't confirm
+ * supports the caller's needs.
+ *
+ * `requirements` shape:
+ *   { push?: boolean, linkedHover?: boolean, ssr?: boolean,
+ *     selection?: boolean, legend?: boolean }
+ *
+ * Each key, when set to `true`, means "the chart MUST support this".
+ * `false` means "the chart MUST NOT support this" (rare, but
+ * symmetric — useful for "give me a chart that intentionally has no
+ * legend"). Unset keys are ignored.
+ */
+function chartSatisfiesCapabilities(chartName, requirements) {
+  if (!requirements || Object.keys(requirements).length === 0) return true
+  const matrix = loadCapabilityMatrix()
+  const spec = matrix[chartName]
+  if (!spec) return false // unknown chart — fail closed
+  for (const [shortKey, want] of Object.entries(requirements)) {
+    if (want == null) continue
+    const matrixKey = CAPABILITY_KEY_MAP[shortKey]
+    if (!matrixKey) continue // unknown short key — ignore (validated upstream)
+    const has = spec[matrixKey] === true
+    if (has !== want) return false
+  }
+  return true
+}
 
 function summarizeFields(data, keys) {
   const numericFields = []
@@ -72,6 +153,7 @@ function uniqueNetworkNodes(data, sourceField, targetField) {
 function suggestCharts(args = {}) {
   const data = args.data
   const intent = args.intent
+  const capabilities = args.capabilities
 
   if (intent && !VALID_INTENTS.includes(intent)) {
     return {
@@ -80,10 +162,26 @@ function suggestCharts(args = {}) {
     }
   }
 
+  if (capabilities) {
+    if (typeof capabilities !== "object" || Array.isArray(capabilities)) {
+      return {
+        ok: false,
+        error: "capabilities must be an object like { push: true, linkedHover: true, ssr: true, selection: true, legend: true }.",
+      }
+    }
+    const unknown = Object.keys(capabilities).filter((k) => !VALID_CAPABILITY_KEYS.includes(k))
+    if (unknown.length > 0) {
+      return {
+        ok: false,
+        error: `Unknown capability key(s): ${unknown.join(", ")}. Expected: ${VALID_CAPABILITY_KEYS.join(", ")}.`,
+      }
+    }
+  }
+
   if (!data || !Array.isArray(data) || data.length === 0) {
     return {
       ok: false,
-      error: "Pass { data: [{ ... }, ...] } with 1-5 sample data objects. Optionally include intent: 'comparison' | 'trend' | 'distribution' | 'relationship' | 'composition' | 'geographic' | 'network' | 'hierarchy'.",
+      error: "Pass { data: [{ ... }, ...] } with 1-5 sample data objects. Optionally include intent: 'comparison' | 'trend' | 'distribution' | 'relationship' | 'composition' | 'geographic' | 'network' | 'hierarchy', or capabilities: { push, linkedHover, ssr, selection, legend }.",
     }
   }
 
@@ -257,12 +355,29 @@ function suggestCharts(args = {}) {
     })
   }
 
+  // Apply capability filter as the last step so data-shape inference
+  // logic stays oblivious to it. Suggestions are kept in their
+  // confidence-ranked order; we just drop anything that doesn't
+  // satisfy the caller's constraints.
+  const filteredSuggestions = capabilities
+    ? suggestions.filter((s) => chartSatisfiesCapabilities(s.component, capabilities))
+    : suggestions
+
   return {
     ok: true,
     intent,
+    capabilities,
     fieldSummary: `Fields: ${keys.join(", ")} (${numericFields.length} numeric, ${stringFields.length} categorical, ${dateFields.length} date)`,
     fields,
-    suggestions,
+    suggestions: filteredSuggestions,
+    // Surface the pre-filter set when a capability constraint was
+    // applied — caller can see which suggestions were dropped and
+    // whether to relax the constraint.
+    ...(capabilities && filteredSuggestions.length < suggestions.length && {
+      filteredOut: suggestions
+        .filter((s) => !chartSatisfiesCapabilities(s.component, capabilities))
+        .map((s) => ({ component: s.component, reason: s.reason })),
+    }),
   }
 }
 
@@ -270,7 +385,10 @@ function formatSuggestionReport(result) {
   if (!result.ok) return result.error
 
   if (result.suggestions.length === 0) {
-    return `Could not confidently recommend a chart type.\n\n${result.fieldSummary}\n\nTry providing intent ('${VALID_INTENTS.join("', '")}') to narrow recommendations, or use getSchema to browse available components.`
+    const tail = result.capabilities && result.filteredOut && result.filteredOut.length > 0
+      ? `\n\nDropped by capability filter (${formatCapabilityConstraints(result.capabilities)}):\n${result.filteredOut.map((s) => `- ${s.component}: ${s.reason}`).join("\n")}\n\nRelax the capability constraints, or use getSchema to browse alternatives.`
+      : `\n\nTry providing intent ('${VALID_INTENTS.join("', '")}') to narrow recommendations, or use getSchema to browse available components.`
+    return `Could not confidently recommend a chart type.\n\n${result.fieldSummary}${tail}`
   }
 
   const lines = result.suggestions.map((suggestion, i) => {
@@ -284,8 +402,19 @@ function formatSuggestionReport(result) {
   return lines.join("\n\n") + themingTip
 }
 
+function formatCapabilityConstraints(capabilities) {
+  return Object.entries(capabilities)
+    .filter(([, v]) => v != null)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(", ")
+}
+
 module.exports = {
   VALID_INTENTS,
+  VALID_CAPABILITY_KEYS,
   formatSuggestionReport,
   suggestCharts,
+  // Exported for tests + callers that want to filter their own
+  // chart-name set without re-running the suggestion pipeline.
+  chartSatisfiesCapabilities,
 }

--- a/ai/chartSuggestions.cjs
+++ b/ai/chartSuggestions.cjs
@@ -12,16 +12,28 @@ const MAX_SAMPLE_SIZE = 5
 // from `chartSpecs.ts` via `npm run docs:capabilities`. Used to
 // filter suggestions when the caller passes capability constraints.
 // Loaded lazily so a test or build that hasn't generated the file
-// yet still imports cleanly; consumers that pass capability
-// constraints will see an explicit error if the JSON is missing.
+// yet still imports cleanly; if the JSON is missing AND a caller
+// passes capability constraints, `suggestCharts` returns an explicit
+// error rather than silently filtering everything out (would happen
+// because `chartSatisfiesCapabilities` fails closed for unknown
+// chart names).
 //
 // `__dirname` points at the cjs source location at runtime —
 // when bundled into `ai/dist/mcp-server.js` `__dirname` is
 // `ai/dist/`, so we also probe the parent directory. Mirrors the
 // `schema.json` loader's two-candidate pattern.
+//
+// `_capabilityMatrixLoaded` differentiates "load attempted, file
+// missing → empty {}" from "load not yet attempted". Without this
+// flag, a build that's missing capabilities.json would set
+// `_capabilityMatrix = {}` and every subsequent call would short-
+// circuit on `if (_capabilityMatrix)` (because `{}` is truthy) and
+// never re-probe — the right behavior for a steady state but
+// incompatible with detecting "loader failed".
 let _capabilityMatrix = null
+let _capabilityMatrixLoaded = false
 function loadCapabilityMatrix() {
-  if (_capabilityMatrix) return _capabilityMatrix
+  if (_capabilityMatrixLoaded) return _capabilityMatrix
   const candidates = [
     path.join(__dirname, "capabilities.json"),
     path.join(__dirname, "..", "capabilities.json"),
@@ -31,13 +43,14 @@ function loadCapabilityMatrix() {
       const json = require(candidate)
       if (json && json.charts) {
         _capabilityMatrix = json.charts
+        _capabilityMatrixLoaded = true
         return _capabilityMatrix
       }
     } catch {
       // try next candidate
     }
   }
-  _capabilityMatrix = {}
+  _capabilityMatrixLoaded = true
   return _capabilityMatrix
 }
 
@@ -75,6 +88,7 @@ const VALID_CAPABILITY_KEYS = Object.keys(CAPABILITY_KEY_MAP)
 function chartSatisfiesCapabilities(chartName, requirements) {
   if (!requirements || Object.keys(requirements).length === 0) return true
   const matrix = loadCapabilityMatrix()
+  if (matrix == null) return false // matrix unavailable — fail closed
   const spec = matrix[chartName]
   if (!spec) return false // unknown chart — fail closed
   for (const [shortKey, want] of Object.entries(requirements)) {
@@ -85,6 +99,33 @@ function chartSatisfiesCapabilities(chartName, requirements) {
     if (has !== want) return false
   }
   return true
+}
+
+/**
+ * Explain why a chart doesn't satisfy a capability constraint set —
+ * used in the `filteredOut[].reason` payload so callers see the
+ * specific mismatched constraint(s) rather than the chart's
+ * data-shape rationale. Returns null when no mismatch (defensive;
+ * callers should only invoke this on charts that already failed
+ * `chartSatisfiesCapabilities`).
+ */
+function explainCapabilityMismatch(chartName, requirements) {
+  if (!requirements || Object.keys(requirements).length === 0) return null
+  const matrix = loadCapabilityMatrix()
+  if (matrix == null) return "capability matrix unavailable (run `npm run docs:capabilities`)"
+  const spec = matrix[chartName]
+  if (!spec) return `${chartName} not found in capability matrix`
+  const mismatches = []
+  for (const [shortKey, want] of Object.entries(requirements)) {
+    if (want == null) continue
+    const matrixKey = CAPABILITY_KEY_MAP[shortKey]
+    if (!matrixKey) continue
+    const has = spec[matrixKey] === true
+    if (has !== want) {
+      mismatches.push(`requires ${shortKey}=${want} but ${matrixKey}=${has}`)
+    }
+  }
+  return mismatches.length > 0 ? mismatches.join("; ") : null
 }
 
 function summarizeFields(data, keys) {
@@ -174,6 +215,15 @@ function suggestCharts(args = {}) {
       return {
         ok: false,
         error: `Unknown capability key(s): ${unknown.join(", ")}. Expected: ${VALID_CAPABILITY_KEYS.join(", ")}.`,
+      }
+    }
+    // Probe matrix availability up front so callers see a clear error
+    // instead of an empty-suggestions silent-failure when
+    // capabilities.json is missing from the build.
+    if (loadCapabilityMatrix() == null) {
+      return {
+        ok: false,
+        error: "Capability matrix unavailable: ai/capabilities.json is missing. Run `npm run docs:capabilities` to generate it. (Capability filtering requires the matrix; suggestions without a `capabilities` arg still work.)",
       }
     }
   }
@@ -376,7 +426,15 @@ function suggestCharts(args = {}) {
     ...(capabilities && filteredSuggestions.length < suggestions.length && {
       filteredOut: suggestions
         .filter((s) => !chartSatisfiesCapabilities(s.component, capabilities))
-        .map((s) => ({ component: s.component, reason: s.reason })),
+        .map((s) => ({
+          component: s.component,
+          // The `reason` here is the capability mismatch (which
+          // constraint failed), not the original data-shape rationale
+          // — callers debugging an empty result need to know which
+          // capability to relax, not why the chart was originally
+          // suggested.
+          reason: explainCapabilityMismatch(s.component, capabilities) || "did not satisfy capability constraints",
+        })),
     }),
   }
 }
@@ -417,4 +475,5 @@ module.exports = {
   // Exported for tests + callers that want to filter their own
   // chart-name set without re-running the suggestion pipeline.
   chartSatisfiesCapabilities,
+  explainCapabilityMismatch,
 }

--- a/ai/dist/mcp-server.js
+++ b/ai/dist/mcp-server.js
@@ -6948,8 +6948,9 @@ var require_chartSuggestions = __commonJS({
     ];
     var MAX_SAMPLE_SIZE = 5;
     var _capabilityMatrix = null;
+    var _capabilityMatrixLoaded = false;
     function loadCapabilityMatrix() {
-      if (_capabilityMatrix) return _capabilityMatrix;
+      if (_capabilityMatrixLoaded) return _capabilityMatrix;
       const candidates = [
         path2.join(__dirname, "capabilities.json"),
         path2.join(__dirname, "..", "capabilities.json")
@@ -6959,12 +6960,13 @@ var require_chartSuggestions = __commonJS({
           const json2 = require(candidate);
           if (json2 && json2.charts) {
             _capabilityMatrix = json2.charts;
+            _capabilityMatrixLoaded = true;
             return _capabilityMatrix;
           }
         } catch {
         }
       }
-      _capabilityMatrix = {};
+      _capabilityMatrixLoaded = true;
       return _capabilityMatrix;
     }
     var CAPABILITY_KEY_MAP = {
@@ -6978,6 +6980,7 @@ var require_chartSuggestions = __commonJS({
     function chartSatisfiesCapabilities(chartName, requirements) {
       if (!requirements || Object.keys(requirements).length === 0) return true;
       const matrix = loadCapabilityMatrix();
+      if (matrix == null) return false;
       const spec = matrix[chartName];
       if (!spec) return false;
       for (const [shortKey, want] of Object.entries(requirements)) {
@@ -6988,6 +6991,24 @@ var require_chartSuggestions = __commonJS({
         if (has !== want) return false;
       }
       return true;
+    }
+    function explainCapabilityMismatch(chartName, requirements) {
+      if (!requirements || Object.keys(requirements).length === 0) return null;
+      const matrix = loadCapabilityMatrix();
+      if (matrix == null) return "capability matrix unavailable (run `npm run docs:capabilities`)";
+      const spec = matrix[chartName];
+      if (!spec) return `${chartName} not found in capability matrix`;
+      const mismatches = [];
+      for (const [shortKey, want] of Object.entries(requirements)) {
+        if (want == null) continue;
+        const matrixKey = CAPABILITY_KEY_MAP[shortKey];
+        if (!matrixKey) continue;
+        const has = spec[matrixKey] === true;
+        if (has !== want) {
+          mismatches.push(`requires ${shortKey}=${want} but ${matrixKey}=${has}`);
+        }
+      }
+      return mismatches.length > 0 ? mismatches.join("; ") : null;
     }
     function summarizeFields(data, keys) {
       const numericFields = [];
@@ -7066,6 +7087,12 @@ var require_chartSuggestions = __commonJS({
           return {
             ok: false,
             error: `Unknown capability key(s): ${unknown2.join(", ")}. Expected: ${VALID_CAPABILITY_KEYS.join(", ")}.`
+          };
+        }
+        if (loadCapabilityMatrix() == null) {
+          return {
+            ok: false,
+            error: "Capability matrix unavailable: ai/capabilities.json is missing. Run `npm run docs:capabilities` to generate it. (Capability filtering requires the matrix; suggestions without a `capabilities` arg still work.)"
           };
         }
       }
@@ -7241,7 +7268,15 @@ var require_chartSuggestions = __commonJS({
         // applied — caller can see which suggestions were dropped and
         // whether to relax the constraint.
         ...capabilities && filteredSuggestions.length < suggestions.length && {
-          filteredOut: suggestions.filter((s) => !chartSatisfiesCapabilities(s.component, capabilities)).map((s) => ({ component: s.component, reason: s.reason }))
+          filteredOut: suggestions.filter((s) => !chartSatisfiesCapabilities(s.component, capabilities)).map((s) => ({
+            component: s.component,
+            // The `reason` here is the capability mismatch (which
+            // constraint failed), not the original data-shape rationale
+            // — callers debugging an empty result need to know which
+            // capability to relax, not why the chart was originally
+            // suggested.
+            reason: explainCapabilityMismatch(s.component, capabilities) || "did not satisfy capability constraints"
+          }))
         }
       };
     }
@@ -7300,7 +7335,8 @@ For accessibility, use \`colorScheme={COLOR_BLIND_SAFE_CATEGORICAL}\` (import fr
       suggestCharts: suggestCharts2,
       // Exported for tests + callers that want to filter their own
       // chart-name set without re-running the suggestion pipeline.
-      chartSatisfiesCapabilities
+      chartSatisfiesCapabilities,
+      explainCapabilityMismatch
     };
   }
 });

--- a/ai/dist/mcp-server.js
+++ b/ai/dist/mcp-server.js
@@ -6935,6 +6935,7 @@ var require_componentMetadata = __commonJS({
 var require_chartSuggestions = __commonJS({
   "ai/chartSuggestions.cjs"(exports2, module2) {
     "use strict";
+    var path2 = require("path");
     var VALID_INTENTS = [
       "comparison",
       "trend",
@@ -6946,6 +6947,48 @@ var require_chartSuggestions = __commonJS({
       "hierarchy"
     ];
     var MAX_SAMPLE_SIZE = 5;
+    var _capabilityMatrix = null;
+    function loadCapabilityMatrix() {
+      if (_capabilityMatrix) return _capabilityMatrix;
+      const candidates = [
+        path2.join(__dirname, "capabilities.json"),
+        path2.join(__dirname, "..", "capabilities.json")
+      ];
+      for (const candidate of candidates) {
+        try {
+          const json2 = require(candidate);
+          if (json2 && json2.charts) {
+            _capabilityMatrix = json2.charts;
+            return _capabilityMatrix;
+          }
+        } catch {
+        }
+      }
+      _capabilityMatrix = {};
+      return _capabilityMatrix;
+    }
+    var CAPABILITY_KEY_MAP = {
+      push: "supportsPush",
+      linkedHover: "supportsLinkedHover",
+      ssr: "supportsSSR",
+      selection: "supportsSelection",
+      legend: "supportsLegend"
+    };
+    var VALID_CAPABILITY_KEYS = Object.keys(CAPABILITY_KEY_MAP);
+    function chartSatisfiesCapabilities(chartName, requirements) {
+      if (!requirements || Object.keys(requirements).length === 0) return true;
+      const matrix = loadCapabilityMatrix();
+      const spec = matrix[chartName];
+      if (!spec) return false;
+      for (const [shortKey, want] of Object.entries(requirements)) {
+        if (want == null) continue;
+        const matrixKey = CAPABILITY_KEY_MAP[shortKey];
+        if (!matrixKey) continue;
+        const has = spec[matrixKey] === true;
+        if (has !== want) return false;
+      }
+      return true;
+    }
     function summarizeFields(data, keys) {
       const numericFields = [];
       const stringFields = [];
@@ -7004,16 +7047,32 @@ var require_chartSuggestions = __commonJS({
     function suggestCharts2(args = {}) {
       const data = args.data;
       const intent = args.intent;
+      const capabilities = args.capabilities;
       if (intent && !VALID_INTENTS.includes(intent)) {
         return {
           ok: false,
           error: `Unknown intent "${intent}". Expected one of: ${VALID_INTENTS.join(", ")}.`
         };
       }
+      if (capabilities) {
+        if (typeof capabilities !== "object" || Array.isArray(capabilities)) {
+          return {
+            ok: false,
+            error: "capabilities must be an object like { push: true, linkedHover: true, ssr: true, selection: true, legend: true }."
+          };
+        }
+        const unknown2 = Object.keys(capabilities).filter((k) => !VALID_CAPABILITY_KEYS.includes(k));
+        if (unknown2.length > 0) {
+          return {
+            ok: false,
+            error: `Unknown capability key(s): ${unknown2.join(", ")}. Expected: ${VALID_CAPABILITY_KEYS.join(", ")}.`
+          };
+        }
+      }
       if (!data || !Array.isArray(data) || data.length === 0) {
         return {
           ok: false,
-          error: "Pass { data: [{ ... }, ...] } with 1-5 sample data objects. Optionally include intent: 'comparison' | 'trend' | 'distribution' | 'relationship' | 'composition' | 'geographic' | 'network' | 'hierarchy'."
+          error: "Pass { data: [{ ... }, ...] } with 1-5 sample data objects. Optionally include intent: 'comparison' | 'trend' | 'distribution' | 'relationship' | 'composition' | 'geographic' | 'network' | 'hierarchy', or capabilities: { push, linkedHover, ssr, selection, legend }."
         };
       }
       if (data.length > MAX_SAMPLE_SIZE) {
@@ -7170,22 +7229,36 @@ var require_chartSuggestions = __commonJS({
           props: { data: jsxExpression("data"), xAccessor: jsxString(xField), yAccessor: jsxString(yField), valueAccessor: jsxString(valueField) }
         });
       }
+      const filteredSuggestions = capabilities ? suggestions.filter((s) => chartSatisfiesCapabilities(s.component, capabilities)) : suggestions;
       return {
         ok: true,
         intent,
+        capabilities,
         fieldSummary: `Fields: ${keys.join(", ")} (${numericFields.length} numeric, ${stringFields.length} categorical, ${dateFields.length} date)`,
         fields,
-        suggestions
+        suggestions: filteredSuggestions,
+        // Surface the pre-filter set when a capability constraint was
+        // applied — caller can see which suggestions were dropped and
+        // whether to relax the constraint.
+        ...capabilities && filteredSuggestions.length < suggestions.length && {
+          filteredOut: suggestions.filter((s) => !chartSatisfiesCapabilities(s.component, capabilities)).map((s) => ({ component: s.component, reason: s.reason }))
+        }
       };
     }
     function formatSuggestionReport2(result) {
       if (!result.ok) return result.error;
       if (result.suggestions.length === 0) {
-        return `Could not confidently recommend a chart type.
+        const tail = result.capabilities && result.filteredOut && result.filteredOut.length > 0 ? `
 
-${result.fieldSummary}
+Dropped by capability filter (${formatCapabilityConstraints(result.capabilities)}):
+${result.filteredOut.map((s) => `- ${s.component}: ${s.reason}`).join("\n")}
+
+Relax the capability constraints, or use getSchema to browse alternatives.` : `
 
 Try providing intent ('${VALID_INTENTS.join("', '")}') to narrow recommendations, or use getSchema to browse available components.`;
+        return `Could not confidently recommend a chart type.
+
+${result.fieldSummary}${tail}`;
       }
       const lines = result.suggestions.map((suggestion, i) => {
         const propsStr = Object.entries(suggestion.props).map(([k, v]) => `${k}=${v}`).join(" ");
@@ -7217,10 +7290,17 @@ Or use \`<ThemeProvider theme="dark">\` / \`<ThemeProvider theme={{ colors: {...
 For accessibility, use \`colorScheme={COLOR_BLIND_SAFE_CATEGORICAL}\` (import from \`semiotic/themes\`) - 8-color palette safe for all forms of color blindness.`;
       return lines.join("\n\n") + themingTip;
     }
+    function formatCapabilityConstraints(capabilities) {
+      return Object.entries(capabilities).filter(([, v]) => v != null).map(([k, v]) => `${k}=${v}`).join(", ");
+    }
     module2.exports = {
       VALID_INTENTS,
+      VALID_CAPABILITY_KEYS,
       formatSuggestionReport: formatSuggestionReport2,
-      suggestCharts: suggestCharts2
+      suggestCharts: suggestCharts2,
+      // Exported for tests + callers that want to filter their own
+      // chart-name set without re-running the suggestion pipeline.
+      chartSatisfiesCapabilities
     };
   }
 });
@@ -32176,6 +32256,7 @@ var COMPONENT_REGISTRY = {
   ForceDirectedGraph: { component: import_ai.ForceDirectedGraph, category: "network" },
   ChordDiagram: { component: import_ai.ChordDiagram, category: "network" },
   SankeyDiagram: { component: import_ai.SankeyDiagram, category: "network" },
+  ProcessSankey: { component: import_ai.ProcessSankey, category: "network" },
   TreeDiagram: { component: import_ai.TreeDiagram, category: "network" },
   Treemap: { component: import_ai.Treemap, category: "network" },
   CirclePack: { component: import_ai.CirclePack, category: "network" },
@@ -32661,10 +32742,17 @@ function createServer2() {
   );
   srv.tool(
     "suggestChart",
-    "Recommend Semiotic chart types for a given data sample. Pass { data: [...] } with 1-5 sample objects. Optionally pass intent to narrow suggestions. Returns ranked recommendations with example props.",
+    "Recommend Semiotic chart types for a given data sample. Pass { data: [...] } with 1-5 sample objects. Optionally pass intent to narrow suggestions, or capabilities to require/forbid features (push API, linked hover, SSR, selection, legend). Returns ranked recommendations with example props; charts that don't satisfy the capability constraints are dropped.",
     {
       data: external_exports3.array(external_exports3.record(external_exports3.string(), external_exports3.unknown())).min(1).max(5).describe("1-5 sample data objects"),
-      intent: external_exports3.enum(["comparison", "trend", "distribution", "relationship", "composition", "geographic", "network", "hierarchy"]).optional().describe("Visualization intent to narrow suggestions")
+      intent: external_exports3.enum(["comparison", "trend", "distribution", "relationship", "composition", "geographic", "network", "hierarchy"]).optional().describe("Visualization intent to narrow suggestions"),
+      capabilities: external_exports3.object({
+        push: external_exports3.boolean().optional().describe("Require ref-based push API (live streaming via ref.current.push())"),
+        linkedHover: external_exports3.boolean().optional().describe("Require cross-chart linked hover support"),
+        ssr: external_exports3.boolean().optional().describe("Require server-side rendering via renderChart()"),
+        selection: external_exports3.boolean().optional().describe("Require named selection / cross-filter support"),
+        legend: external_exports3.boolean().optional().describe("Require a top-level legend")
+      }).optional().describe("Capability constraints \u2014 set a key to true to require, false to forbid. Unset keys are ignored.")
     },
     suggestChartHandler
   );

--- a/ai/dist/mcp-server.js
+++ b/ai/dist/mcp-server.js
@@ -32788,7 +32788,11 @@ function createServer2() {
         ssr: external_exports3.boolean().optional().describe("Require server-side rendering via renderChart()"),
         selection: external_exports3.boolean().optional().describe("Require named selection / cross-filter support"),
         legend: external_exports3.boolean().optional().describe("Require a top-level legend")
-      }).optional().describe("Capability constraints \u2014 set a key to true to require, false to forbid. Unset keys are ignored.")
+        // `.strict()` so the MCP surface rejects unknown capability
+        // keys at the schema layer rather than silently stripping
+        // them — keeps the cjs-level "Unknown capability key(s)"
+        // validation from being unreachable from MCP callers.
+      }).strict().optional().describe("Capability constraints \u2014 set a key to true to require, false to forbid. Unset keys are ignored.")
     },
     suggestChartHandler
   );

--- a/ai/mcp-server.ts
+++ b/ai/mcp-server.ts
@@ -65,7 +65,17 @@ const {
   suggestCharts,
 } = require("./chartSuggestions.cjs") as {
   formatSuggestionReport: (result: SuggestChartResult) => string
-  suggestCharts: (args: { data?: any[]; intent?: string }) => SuggestChartResult
+  suggestCharts: (args: {
+    data?: any[]
+    intent?: string
+    capabilities?: {
+      push?: boolean
+      linkedHover?: boolean
+      ssr?: boolean
+      selection?: boolean
+      legend?: boolean
+    }
+  }) => SuggestChartResult
 }
 const {
   BEHAVIOR_CONTRACTS,
@@ -184,7 +194,11 @@ async function getSchemaHandler(args: { component?: string }): Promise<ToolResul
   }
 }
 
-async function suggestChartHandler(args: { data?: any[]; intent?: string }): Promise<ToolResult> {
+async function suggestChartHandler(args: {
+  data?: any[]
+  intent?: string
+  capabilities?: { push?: boolean; linkedHover?: boolean; ssr?: boolean; selection?: boolean; legend?: boolean }
+}): Promise<ToolResult> {
   const result = suggestCharts(args)
   const content = [{ type: "text" as const, text: formatSuggestionReport(result) }]
   if (!result.ok) {
@@ -559,10 +573,17 @@ function createServer(): McpServer {
 
   srv.tool(
     "suggestChart",
-    "Recommend Semiotic chart types for a given data sample. Pass { data: [...] } with 1-5 sample objects. Optionally pass intent to narrow suggestions. Returns ranked recommendations with example props.",
+    "Recommend Semiotic chart types for a given data sample. Pass { data: [...] } with 1-5 sample objects. Optionally pass intent to narrow suggestions, or capabilities to require/forbid features (push API, linked hover, SSR, selection, legend). Returns ranked recommendations with example props; charts that don't satisfy the capability constraints are dropped.",
     {
       data: z.array(z.record(z.string(), z.unknown())).min(1).max(5).describe("1-5 sample data objects"),
       intent: z.enum(["comparison", "trend", "distribution", "relationship", "composition", "geographic", "network", "hierarchy"]).optional().describe("Visualization intent to narrow suggestions"),
+      capabilities: z.object({
+        push: z.boolean().optional().describe("Require ref-based push API (live streaming via ref.current.push())"),
+        linkedHover: z.boolean().optional().describe("Require cross-chart linked hover support"),
+        ssr: z.boolean().optional().describe("Require server-side rendering via renderChart()"),
+        selection: z.boolean().optional().describe("Require named selection / cross-filter support"),
+        legend: z.boolean().optional().describe("Require a top-level legend"),
+      }).optional().describe("Capability constraints — set a key to true to require, false to forbid. Unset keys are ignored."),
     },
     suggestChartHandler
   )

--- a/ai/mcp-server.ts
+++ b/ai/mcp-server.ts
@@ -583,7 +583,11 @@ function createServer(): McpServer {
         ssr: z.boolean().optional().describe("Require server-side rendering via renderChart()"),
         selection: z.boolean().optional().describe("Require named selection / cross-filter support"),
         legend: z.boolean().optional().describe("Require a top-level legend"),
-      }).optional().describe("Capability constraints — set a key to true to require, false to forbid. Unset keys are ignored."),
+        // `.strict()` so the MCP surface rejects unknown capability
+        // keys at the schema layer rather than silently stripping
+        // them — keeps the cjs-level "Unknown capability key(s)"
+        // validation from being unreachable from MCP callers.
+      }).strict().optional().describe("Capability constraints — set a key to true to require, false to forbid. Unset keys are ignored."),
     },
     suggestChartHandler
   )

--- a/ai/schema.json
+++ b/ai/schema.json
@@ -642,6 +642,14 @@
             "pointOpacity": {
               "type": "number",
               "default": 0.8
+            },
+            "regression": {
+              "type": [
+                "boolean",
+                "string",
+                "object"
+              ],
+              "description": "Overlay a regression line. true = linear, 'linear' | 'polynomial' | 'loess' = method, or full RegressionConfig object. Sugar over the trend annotation."
             }
           },
           "required": [
@@ -1230,6 +1238,14 @@
             "bubbleStrokeColor": {
               "type": "string",
               "default": "white"
+            },
+            "regression": {
+              "type": [
+                "boolean",
+                "string",
+                "object"
+              ],
+              "description": "Overlay a regression line on the bubbles. Same shape as Scatterplot's regression prop."
             }
           },
           "required": [
@@ -1534,6 +1550,14 @@
                 "function"
               ],
               "description": "Accessor for unique point IDs, used by point-anchored annotations"
+            },
+            "regression": {
+              "type": [
+                "boolean",
+                "string",
+                "object"
+              ],
+              "description": "Overlay a regression line under the connected path. Same shape as Scatterplot's regression prop."
             }
           },
           "required": [
@@ -1680,6 +1704,14 @@
             "barPadding": {
               "type": "number",
               "default": 40
+            },
+            "regression": {
+              "type": [
+                "boolean",
+                "string",
+                "object"
+              ],
+              "description": "Overlay a regression line through the bar tops. Accepts true (linear), a method ('linear' | 'polynomial' | 'loess'), or a full RegressionConfig. Pixels resolve through the band scale."
             }
           },
           "required": [
@@ -2997,6 +3029,14 @@
             "categoryPadding": {
               "type": "number",
               "default": 10
+            },
+            "regression": {
+              "type": [
+                "boolean",
+                "string",
+                "object"
+              ],
+              "description": "Overlay a regression line through the dots. Same shape as Scatterplot's regression prop."
             }
           },
           "required": [
@@ -6228,6 +6268,12 @@
               "type": "array"
             },
             "valueAccessor": {
+              "type": [
+                "string",
+                "function"
+              ]
+            },
+            "lineIdAccessor": {
               "type": [
                 "string",
                 "function"

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,0 +1,96 @@
+# Chart Capability Matrix
+
+> Generated from `src/components/charts/shared/chartSpecs.ts`. Do not
+> edit by hand — re-run `npm run docs:capabilities` after adding a
+> chart and commit the output.
+
+Last regen: 2026-05-10 · 44 charts indexed.
+
+**Column key**
+
+- **Legend**: top-level `showLegend` renders a swatch column.
+- **Sel**: consumes a named `selection` to dim/highlight marks.
+- **Hover**: produces a `linkedHover` for cross-chart highlight.
+- **Push**: exposes a ref handle (`ref.current.push(...)`).
+- **SSR**: registered in `serverChartConfigs.ts` for `renderChart()`.
+- **Color**: `categorical`, `sequential`, `threshold`, `continuous`, or `none`.
+- **Layout**: `plugin` (built-in), `custom` (escape hatch), `synthetic` (no layout).
+
+## Xy
+
+| Chart | Legend | Sel | Hover | Push | SSR | Color | Layout | Features |
+|---|:-:|:-:|:-:|:-:|:-:|---|---|---|
+| **AreaChart** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | — |
+| **BubbleChart** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | `size-encoding` `streaming-domain` `regression-overlay` |
+| **CandlestickChart** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | `ohlc` |
+| **ConnectedScatterplot** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | `regression-overlay` |
+| **Heatmap** | ✓ | ✓ | ✓ | ✓ | ✓ | sequential | plugin | — |
+| **LineChart** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | `forecast` `anomaly` `gap-handling` `direct-labels` `endpoint-labels` |
+| **MinimapChart** | ✓ | — | — | — | — | categorical | plugin | `brush` `overview-detail` `composite-delegates-interaction` `hoc-ssr-only` |
+| **MultiAxisLineChart** | ✓ | ✓ | ✓ | ✓ | — | categorical | plugin | `dual-axis` `hoc-ssr-only` |
+| **QuadrantChart** | ✓ | ✓ | ✓ | ✓ | — | categorical | plugin | `quadrants` `hoc-ssr-only` |
+| **Scatterplot** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | `regression-overlay` |
+| **ScatterplotMatrix** | ✓ | — | — | — | — | categorical | plugin | `matrix` `brush` `composite-delegates-interaction` `hoc-ssr-only` |
+| **StackedAreaChart** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | `stack` `streamgraph` |
+
+## Ordinal
+
+| Chart | Legend | Sel | Hover | Push | SSR | Color | Layout | Features |
+|---|:-:|:-:|:-:|:-:|:-:|---|---|---|
+| **BarChart** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | `regression-overlay` |
+| **BoxPlot** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | `statistical` |
+| **DonutChart** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | — |
+| **DotPlot** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | `regression-overlay` |
+| **FunnelChart** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | — |
+| **GaugeChart** | — | — | — | — | ✓ | threshold | synthetic | `threshold-zones` `value-only` `controlled-prop-streaming` |
+| **GroupedBarChart** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | — |
+| **Histogram** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | — |
+| **LikertChart** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | — |
+| **PieChart** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | — |
+| **RidgelinePlot** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | — |
+| **StackedBarChart** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | `stack` |
+| **SwarmPlot** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | — |
+| **SwimlaneChart** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | `brush` |
+| **ViolinPlot** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | `statistical` |
+
+## Network
+
+| Chart | Legend | Sel | Hover | Push | SSR | Color | Layout | Features |
+|---|:-:|:-:|:-:|:-:|:-:|---|---|---|
+| **ChordDiagram** | — | ✓ | ✓ | ✓ | ✓ | categorical | plugin | — |
+| **CirclePack** | — | ✓ | ✓ | — | ✓ | categorical | plugin | `hierarchy` |
+| **ForceDirectedGraph** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | `force-simulation` |
+| **OrbitDiagram** | — | ✓ | ✓ | — | — | categorical | plugin | `hierarchy` `animated` `hoc-ssr-only` |
+| **ProcessSankey** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | custom | `temporal` `particles` `lane-reuse` |
+| **SankeyDiagram** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | — |
+| **TreeDiagram** | — | ✓ | ✓ | — | ✓ | categorical | plugin | `hierarchy` |
+| **Treemap** | — | ✓ | ✓ | — | ✓ | categorical | plugin | `hierarchy` |
+
+## Geo
+
+| Chart | Legend | Sel | Hover | Push | SSR | Color | Layout | Features |
+|---|:-:|:-:|:-:|:-:|:-:|---|---|---|
+| **ChoroplethMap** | ✓ | ✓ | ✓ | — | ✓ | sequential | plugin | `controlled-prop-streaming` |
+| **DistanceCartogram** | ✓ | ✓ | ✓ | ✓ | — | categorical | plugin | `distortion` `hoc-ssr-only` |
+| **FlowMap** | ✓ | ✓ | ✓ | ✓ | ✓ | categorical | plugin | `particles` |
+| **ProportionalSymbolMap** | ✓ | ✓ | ✓ | ✓ | ✓ | sequential | plugin | — |
+
+## Realtime
+
+| Chart | Legend | Sel | Hover | Push | SSR | Color | Layout | Features |
+|---|:-:|:-:|:-:|:-:|:-:|---|---|---|
+| **RealtimeHeatmap** | ✓ | ✓ | ✓ | ✓ | — | sequential | plugin | `live-stream` |
+| **RealtimeHistogram** | ✓ | ✓ | ✓ | ✓ | — | categorical | plugin | `live-stream` `brush` |
+| **RealtimeLineChart** | ✓ | ✓ | ✓ | ✓ | — | categorical | plugin | `live-stream` |
+| **RealtimeSwarmChart** | ✓ | ✓ | ✓ | ✓ | — | categorical | plugin | `live-stream` |
+| **RealtimeWaterfallChart** | ✓ | ✓ | ✓ | ✓ | — | categorical | plugin | `live-stream` |
+
+---
+
+## Aggregate counts
+
+- 38/44 charts render a top-level legend.
+- 36/44 charts expose a push API.
+- 33/44 charts SSR via the `renderChart()` registry.
+- 1/44 charts use the customLayout escape hatch.
+- 1/44 charts use synthetic (no-layout) construction.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -16,7 +16,7 @@ Last regen: 2026-05-10 · 44 charts indexed.
 - **Color**: `categorical`, `sequential`, `threshold`, `continuous`, or `none`.
 - **Layout**: `plugin` (built-in), `custom` (escape hatch), `synthetic` (no layout).
 
-## Xy
+## XY
 
 | Chart | Legend | Sel | Hover | Push | SSR | Color | Layout | Features |
 |---|:-:|:-:|:-:|:-:|:-:|---|---|---|

--- a/docs/src/App.js
+++ b/docs/src/App.js
@@ -92,6 +92,7 @@ import StreamingSystemModelPage from "./pages/features/StreamingSystemModelPage"
 import PerformancePage from "./pages/features/PerformancePage"
 import PushApiPage from "./pages/features/PushApiPage"
 import CustomChartsPage from "./pages/features/CustomChartsPage"
+import CapabilitiesPage from "./pages/features/CapabilitiesPage"
 
 // New cookbook pages
 import HomerunMapPage from "./pages/cookbook/HomerunMapPage"
@@ -396,6 +397,7 @@ export default function DocsApp() {
               <Route path="performance" element={<PerformancePage />} />
               <Route path="push-api" element={<PushApiPage />} />
               <Route path="custom-charts" element={<CustomChartsPage />} />
+              <Route path="capabilities" element={<CapabilitiesPage />} />
             </Route>
 
             {/* Using Server-Side Rendering */}

--- a/docs/src/components/navData.js
+++ b/docs/src/components/navData.js
@@ -120,7 +120,8 @@ const navData = [
       { title: "Streaming System Model", path: "/features/streaming-system-model" },
       { title: "Performance", path: "/features/performance" },
       { title: "Push API", path: "/features/push-api" },
-      { title: "Custom Charts", path: "/features/custom-charts" }
+      { title: "Custom Charts", path: "/features/custom-charts" },
+      { title: "Capability Matrix", path: "/features/capabilities" }
     ]
   },
   {

--- a/docs/src/pages/charts/FlowMapPage.js
+++ b/docs/src/pages/charts/FlowMapPage.js
@@ -105,7 +105,7 @@ const loadingStyle = {
 // Streaming demo — push flows incrementally
 // ---------------------------------------------------------------------------
 
-const streamingFlowCode = `import { useState, useEffect } from "react"
+const streamingFlowCode = `import { useRef, useEffect, useState } from "react"
 import { FlowMap, resolveReferenceGeography } from "semiotic/geo"
 
 const airports = [
@@ -121,9 +121,12 @@ const flights = [
   // ...more routes
 ]
 
+// Push API: omit \`flows\`, drive the chart through \`ref.current.push()\`.
+// FlowMap resolves source/target → coordinates HOC-side via the
+// \`nodes\` lookup, then forwards a coordinate-resolved line to the frame.
 function StreamingFlowMap() {
+  const ref = useRef(null)
   const [areas, setAreas] = useState(null)
-  const [flows, setFlows] = useState([])
 
   useEffect(() => {
     resolveReferenceGeography("world-110m").then(setAreas)
@@ -134,7 +137,7 @@ function StreamingFlowMap() {
     let i = 0
     const id = setInterval(() => {
       if (i < flights.length) {
-        setFlows(prev => [...prev, flights[i]])
+        ref.current?.push(flights[i])
         i++
       } else clearInterval(id)
     }, 500)
@@ -145,8 +148,8 @@ function StreamingFlowMap() {
 
   return (
     <FlowMap
+      ref={ref}
       nodes={airports}
-      flows={flows}
       areas={areas}
       areaStyle={{ fill: "#f0f0f0", stroke: "#ccc", strokeWidth: 0.5 }}
       valueAccessor="passengers"
@@ -161,8 +164,8 @@ function StreamingFlowMap() {
 }`
 
 function StreamingFlowDemo({ width }) {
+  const ref = React.useRef(null)
   const [areas, setAreas] = useState(null)
-  const [flows, setFlows] = useState([])
 
   useEffect(() => {
     resolveReferenceGeography("world-110m").then(setAreas)
@@ -173,8 +176,7 @@ function StreamingFlowDemo({ width }) {
     let i = 0
     const id = setInterval(() => {
       if (i < internationalFlights.length) {
-        const flow = internationalFlights[i]
-        setFlows(prev => [...prev, flow])
+        ref.current?.push(internationalFlights[i])
         i++
       } else {
         clearInterval(id)
@@ -189,8 +191,8 @@ function StreamingFlowDemo({ width }) {
 
   return (
     <FlowMap
+      ref={ref}
       nodes={airports}
-      flows={flows}
       areas={areas}
       areaStyle={{ fill: "#f0f0f0", stroke: "#ccc", strokeWidth: 0.5 }}
       valueAccessor="passengers"

--- a/docs/src/pages/charts/ScatterplotPage.js
+++ b/docs/src/pages/charts/ScatterplotPage.js
@@ -77,6 +77,7 @@ const scatterplotProps = [
   { name: "sizeRange", type: "[number, number]", required: false, default: "[3, 15]", description: "Min and max radius for points when sizeBy is specified." },
   { name: "pointRadius", type: "number", required: false, default: "5", description: "Default point radius when sizeBy is not specified." },
   { name: "pointOpacity", type: "number", required: false, default: "0.8", description: "Opacity of the points." },
+  { name: "regression", type: "boolean | string | object", required: false, default: null, description: "Overlay a regression line. true = linear, \"linear\" | \"polynomial\" | \"loess\" = method, or a full RegressionConfig object. Sugar over the trend annotation." },
   { name: "enableHover", type: "boolean", required: false, default: "true", description: "Enable hover annotations on data points." },
   { name: "showGrid", type: "boolean", required: false, default: "false", description: "Show background grid lines." },
   { name: "showLegend", type: "boolean", required: false, default: "true (when colorBy)", description: "Show a legend. Defaults to true when colorBy is specified." },
@@ -354,6 +355,56 @@ export default function ScatterplotPage() {
       />
 
       {/* ----------------------------------------------------------------- */}
+      {/* Regression overlay */}
+      {/* ----------------------------------------------------------------- */}
+      <h3 id="regression">Regression Overlay</h3>
+      <p>
+        Set <code>regression</code> to overlay a fitted line. Pass{" "}
+        <code>true</code> for a default linear fit, a method name (
+        <code>"linear"</code> | <code>"polynomial"</code> |{" "}
+        <code>"loess"</code>) for the method-only shorthand, or a config
+        object for full styling control. The prop is sugar over the{" "}
+        <code>trend</code> annotation — for multiple regression lines or
+        custom anchoring drop into the <code>annotations</code> array
+        directly.
+      </p>
+
+      <LiveExample
+        frameProps={{
+          data: simpleData,
+          xAccessor: "height",
+          yAccessor: "weight",
+          regression: { method: "linear", color: "#ef4444", label: "Trend" },
+        }}
+        type={Scatterplot}
+        overrideProps={{
+          data: `sampleData`,
+          regression: `{ method: "linear", color: "#ef4444", label: "Trend" }`,
+        }}
+        hiddenProps={{}}
+      />
+
+      <p>
+        Use <code>method: "loess"</code> for non-linear data — bandwidth
+        controls how aggressively the curve smooths.
+      </p>
+
+      <LiveExample
+        frameProps={{
+          data: simpleData,
+          xAccessor: "height",
+          yAccessor: "weight",
+          regression: { method: "loess", bandwidth: 0.5, color: "#8b5cf6", strokeWidth: 2.5 },
+        }}
+        type={Scatterplot}
+        overrideProps={{
+          data: `sampleData`,
+          regression: `{ method: "loess", bandwidth: 0.5, color: "#8b5cf6", strokeWidth: 2.5 }`,
+        }}
+        hiddenProps={{}}
+      />
+
+      {/* ----------------------------------------------------------------- */}
       {/* Props */}
       {/* ----------------------------------------------------------------- */}
       <h2 id="props">Props</h2>
@@ -366,10 +417,15 @@ export default function ScatterplotPage() {
       <h2 id="graduating">Graduating to the Frame</h2>
 
       <p>
-        When you need more control — custom marks, complex annotations,
-        regression lines — graduate to <Link to="/frames/xy-frame">StreamXYFrame</Link>{" "}
+        When you need more control — custom marks, fully bespoke layouts,
+        per-mark scene primitives — graduate to{" "}
+        <Link to="/frames/xy-frame">StreamXYFrame</Link>{" "}
         directly. Every <code>Scatterplot</code> is just a configured{" "}
-        <code>StreamXYFrame</code> under the hood.
+        <code>StreamXYFrame</code> under the hood. Common analytical
+        overlays (regression lines, trend bands, anomaly markers) are
+        already first-class on <code>Scatterplot</code> via the{" "}
+        <code>regression</code> prop and the <code>annotations</code> array
+        — see the regression example below.
       </p>
 
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "16px", marginBottom: "24px" }}>

--- a/docs/src/pages/charts/ScatterplotPage.js
+++ b/docs/src/pages/charts/ScatterplotPage.js
@@ -425,7 +425,7 @@ export default function ScatterplotPage() {
         overlays (regression lines, trend bands, anomaly markers) are
         already first-class on <code>Scatterplot</code> via the{" "}
         <code>regression</code> prop and the <code>annotations</code> array
-        — see the regression example below.
+        — see the <a href="#regression">Regression Overlay</a> section.
       </p>
 
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "16px", marginBottom: "24px" }}>

--- a/docs/src/pages/features/CapabilitiesPage.js
+++ b/docs/src/pages/features/CapabilitiesPage.js
@@ -1,0 +1,272 @@
+import React, { useState, useMemo } from "react"
+import PageLayout from "../../components/PageLayout"
+import CodeBlock from "../../components/CodeBlock"
+import capabilitiesData from "../../../../ai/capabilities.json"
+
+// ── Styles ───────────────────────────────────────────────────────────
+
+const tableStyle = {
+  width: "100%",
+  borderCollapse: "collapse",
+  fontSize: "13px",
+  marginBottom: "32px",
+}
+
+const thStyle = {
+  textAlign: "left",
+  padding: "8px 10px",
+  borderBottom: "2px solid var(--border, #e0e0e0)",
+  background: "var(--surface-2, #f8f8f8)",
+  fontWeight: 600,
+  position: "sticky",
+  top: 0,
+  zIndex: 1,
+}
+
+const tdStyle = {
+  padding: "6px 10px",
+  borderBottom: "1px solid var(--border, #e8e8e8)",
+}
+
+const centerCell = {
+  ...tdStyle,
+  textAlign: "center",
+}
+
+const tickStyle = (b) => ({
+  ...centerCell,
+  color: b ? "var(--semiotic-success, #16a34a)" : "var(--text-secondary, #999)",
+  fontWeight: b ? 700 : 400,
+})
+
+const featureBadge = {
+  display: "inline-block",
+  padding: "1px 6px",
+  marginRight: "4px",
+  marginBottom: "2px",
+  fontSize: "11px",
+  background: "var(--surface-3, #eee)",
+  color: "var(--text-primary, #333)",
+  borderRadius: "3px",
+  fontFamily: "monospace",
+}
+
+const filterBarStyle = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "8px",
+  alignItems: "center",
+  padding: "12px",
+  background: "var(--surface-2, #f8f8f8)",
+  borderRadius: "8px",
+  marginBottom: "16px",
+}
+
+const checkboxLabel = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "4px",
+  fontSize: "13px",
+  cursor: "pointer",
+}
+
+// Stable category ordering for the section blocks.
+const CATEGORY_ORDER = ["xy", "ordinal", "network", "geo", "realtime"]
+const CATEGORY_LABEL = {
+  xy: "XY (continuous-axis)",
+  ordinal: "Ordinal (categorical)",
+  network: "Network",
+  geo: "Geo",
+  realtime: "Realtime",
+}
+
+// ── Page ──────────────────────────────────────────────────────────────
+
+export default function CapabilitiesPage() {
+  const charts = capabilitiesData.charts
+
+  const [requirements, setRequirements] = useState({
+    push: false,
+    linkedHover: false,
+    ssr: false,
+    selection: false,
+    legend: false,
+  })
+
+  const filteredByCategory = useMemo(() => {
+    const out = {}
+    for (const cat of CATEGORY_ORDER) out[cat] = []
+    for (const [name, spec] of Object.entries(charts)) {
+      if (requirements.push && !spec.supportsPush) continue
+      if (requirements.linkedHover && !spec.supportsLinkedHover) continue
+      if (requirements.ssr && !spec.supportsSSR) continue
+      if (requirements.selection && !spec.supportsSelection) continue
+      if (requirements.legend && !spec.supportsLegend) continue
+      const list = out[spec.category] || (out[spec.category] = [])
+      list.push({ name, ...spec })
+    }
+    for (const cat of Object.keys(out)) out[cat].sort((a, b) => a.name.localeCompare(b.name))
+    return out
+  }, [charts, requirements])
+
+  const totalShown = useMemo(
+    () => Object.values(filteredByCategory).reduce((n, list) => n + list.length, 0),
+    [filteredByCategory],
+  )
+
+  const totalAll = Object.keys(charts).length
+
+  const filterToggle = (key) => () =>
+    setRequirements((prev) => ({ ...prev, [key]: !prev[key] }))
+
+  return (
+    <PageLayout
+      title="Capability Matrix"
+      breadcrumbs={[
+        { label: "Features", path: "/features" },
+        { label: "Capability Matrix", path: "/features/capabilities" },
+      ]}
+      prevPage={{ title: "Custom Charts", path: "/features/custom-charts" }}
+      nextPage={null}
+    >
+      <p>
+        Every Semiotic chart declares a fixed set of capabilities — does it
+        support a ref-based push API? Server-side rendering? Linked hover for
+        cross-chart highlight? A top-level legend? The matrix below is
+        generated directly from{" "}
+        <code>src/components/charts/shared/chartSpecs.ts</code> and
+        validated in CI against the actual HOC source. Use the toggles to
+        narrow the list to charts that satisfy a set of constraints.
+      </p>
+
+      <p>
+        For programmatic access, the same matrix is exposed to the
+        <code>suggestChart</code> AI tool — pass{" "}
+        <code>{`capabilities: { push: true, linkedHover: true }`}</code> to
+        the MCP <code>suggestChart</code> tool and it will only surface
+        charts that satisfy your constraints.
+      </p>
+
+      <div style={filterBarStyle}>
+        <span style={{ fontWeight: 600, fontSize: "13px" }}>Require:</span>
+        {[
+          { key: "push", label: "Push API" },
+          { key: "linkedHover", label: "Linked Hover" },
+          { key: "ssr", label: "SSR" },
+          { key: "selection", label: "Selection" },
+          { key: "legend", label: "Legend" },
+        ].map((f) => (
+          <label key={f.key} style={checkboxLabel}>
+            <input
+              type="checkbox"
+              checked={requirements[f.key]}
+              onChange={filterToggle(f.key)}
+            />
+            {f.label}
+          </label>
+        ))}
+        <span style={{ marginLeft: "auto", fontSize: "12px", color: "var(--text-secondary, #888)" }}>
+          {totalShown} of {totalAll} charts match
+        </span>
+      </div>
+
+      {CATEGORY_ORDER.map((cat) => {
+        const rows = filteredByCategory[cat]
+        if (!rows || rows.length === 0) return null
+        return (
+          <section key={cat} style={{ marginBottom: "24px" }}>
+            <h2 style={{ marginBottom: "8px" }}>{CATEGORY_LABEL[cat] || cat}</h2>
+            <table style={tableStyle}>
+              <thead>
+                <tr>
+                  <th style={thStyle}>Chart</th>
+                  <th style={{ ...thStyle, textAlign: "center" }}>Push</th>
+                  <th style={{ ...thStyle, textAlign: "center" }}>Linked Hover</th>
+                  <th style={{ ...thStyle, textAlign: "center" }}>SSR</th>
+                  <th style={{ ...thStyle, textAlign: "center" }}>Selection</th>
+                  <th style={{ ...thStyle, textAlign: "center" }}>Legend</th>
+                  <th style={thStyle}>Color</th>
+                  <th style={thStyle}>Layout</th>
+                  <th style={thStyle}>Features</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.name}>
+                    <td style={{ ...tdStyle, fontWeight: 600 }}>{row.name}</td>
+                    <td style={tickStyle(row.supportsPush)}>{row.supportsPush ? "✓" : "—"}</td>
+                    <td style={tickStyle(row.supportsLinkedHover)}>{row.supportsLinkedHover ? "✓" : "—"}</td>
+                    <td style={tickStyle(row.supportsSSR)}>{row.supportsSSR ? "✓" : "—"}</td>
+                    <td style={tickStyle(row.supportsSelection)}>{row.supportsSelection ? "✓" : "—"}</td>
+                    <td style={tickStyle(row.supportsLegend)}>{row.supportsLegend ? "✓" : "—"}</td>
+                    <td style={{ ...tdStyle, fontFamily: "monospace", fontSize: "12px" }}>{row.colorModel}</td>
+                    <td style={{ ...tdStyle, fontFamily: "monospace", fontSize: "12px" }}>{row.layoutMode}</td>
+                    <td style={tdStyle}>
+                      {row.specialFeatures.length === 0
+                        ? <span style={{ color: "var(--text-secondary, #aaa)" }}>—</span>
+                        : row.specialFeatures.map((f) => (
+                          <code key={f} style={featureBadge}>{f}</code>
+                        ))}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </section>
+        )
+      })}
+
+      <h2 id="ai-tool">Programmatic Access</h2>
+      <p>
+        Pass capability constraints to the MCP <code>suggestChart</code>{" "}
+        tool to get a narrowed recommendation set:
+      </p>
+
+      <CodeBlock
+        language="json"
+        code={`{
+  "name": "suggestChart",
+  "arguments": {
+    "data": [
+      { "category": "A", "value": 10 },
+      { "category": "B", "value": 20 }
+    ],
+    "intent": "comparison",
+    "capabilities": {
+      "push": true,
+      "linkedHover": true
+    }
+  }
+}`}
+      />
+
+      <p>
+        Charts that don't satisfy every constraint are dropped; the tool
+        also reports which suggestions were filtered out so callers can
+        relax constraints if the result set is empty.
+      </p>
+
+      <h2 id="raw-json">Raw JSON</h2>
+      <p>
+        The full matrix is published at{" "}
+        <code>ai/capabilities.json</code> with the same shape shown
+        below. The <code>npm run docs:capabilities</code> script
+        regenerates both the markdown table and this JSON; CI's{" "}
+        <code>check:capabilities</code> step locks them against{" "}
+        <code>chartSpecs.ts</code>.
+      </p>
+
+      <CodeBlock
+        language="json"
+        code={JSON.stringify({
+          __generated: capabilitiesData.__generated,
+          __source: capabilitiesData.__source,
+          charts: {
+            BarChart: charts.BarChart,
+            "...": "(44 charts indexed total)",
+          },
+        }, null, 2)}
+      />
+    </PageLayout>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -149,6 +149,8 @@
     "check:surface": "node scripts/check-surface-parity.js",
     "check:ai-contracts": "node scripts/generate-ai-behavior-contracts.mjs --check",
     "check:ssr": "node scripts/check-ssr-alignment.js",
+    "check:capabilities": "node scripts/check-capabilities.mjs",
+    "docs:capabilities": "node scripts/generate-capabilities-md.mjs && node scripts/generate-capabilities-json.mjs",
     "check:chart-specs": "npx tsx scripts/check-chart-specs.ts",
     "docs:chart-specs:schema": "npx tsx scripts/regenerate-schema.ts",
     "check:test-quality": "node scripts/check-test-quality-gate.mjs",

--- a/scripts/check-capabilities.mjs
+++ b/scripts/check-capabilities.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * Verify the capability tags in `chartSpecs.ts` against runtime
+ * behavior. The audit's anti-goal is "Do not make registry metadata
+ * aspirational. It should describe real runtime behavior and be
+ * checked." — this script is the check.
+ *
+ * Today the script enforces two locks (the cheapest, highest-signal
+ * pair):
+ *
+ *   1. `supportsSSR: true` ↔ entry in `serverChartConfigs.ts`
+ *      CHART_CONFIGS. A chart claiming SSR support must be
+ *      registered for `renderChart()`. A chart in CHART_CONFIGS but
+ *      claiming `supportsSSR: false` is also an error — drift in the
+ *      other direction.
+ *
+ *   2. `supportsPush: true` ↔ HOC source imports
+ *      `useFrameImperativeHandle` (or a documented exemption tag in
+ *      `specialFeatures`). The shared imperative-handle hook is the
+ *      standardized push-API surface; charts claiming push support
+ *      without it would expose an inconsistent ref API.
+ *
+ * Future locks (reserved as TODO comments in the script) will check
+ * `supportsLinkedHover` ↔ `useChartSelection` import,
+ * `supportsLegend` ↔ legend-rendering signal, and `layoutMode:
+ * "custom"` ↔ `customNetworkLayout`/`customXYLayout`/etc. import.
+ *
+ * Usage:
+ *   node scripts/check-capabilities.mjs
+ *
+ * Exit code 1 on any mismatch.
+ */
+
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { parseCapabilityMatrix } from "./lib/capabilityMatrix.mjs"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const ROOT = path.resolve(__dirname, "..")
+
+const SERVER_CONFIGS_PATH = path.join(ROOT, "src/components/server/serverChartConfigs.ts")
+const CHARTS_DIR = path.join(ROOT, "src/components/charts")
+
+// Parse via the shared helper so this script, the markdown
+// generator, and the JSON generator all read chartSpecs the same
+// way. Returns entries shaped { name, category, legend, selection,
+// linkedHover, push, ssr, colorModel, layoutMode, features } sorted
+// by (category, name).
+const matrix = parseCapabilityMatrix()
+// Re-shape into the field names the rest of this script expects.
+// Keeping the local rename is intentional: the existing readability
+// of `entry.supportsSSR` / `.supportsPush` reads like a capability
+// claim better than `.ssr` / `.push`, especially in error messages.
+const specEntries = matrix.map((e) => ({
+  name: e.name,
+  category: e.category,
+  supportsSSR: e.ssr,
+  supportsPush: e.push,
+  supportsLinkedHover: e.linkedHover,
+  supportsLegend: e.legend,
+  supportsSelection: e.selection,
+  colorModel: e.colorModel,
+  layoutMode: e.layoutMode,
+  specialFeatures: e.features,
+}))
+
+if (specEntries.length === 0) {
+  console.error("✗ check-capabilities: no chart entries parsed from chartSpecs.ts")
+  process.exit(1)
+}
+
+// ── Index serverChartConfigs CHART_CONFIGS for the SSR gate ────────
+const configsSource = fs.readFileSync(SERVER_CONFIGS_PATH, "utf8")
+const ssrRegistered = new Set()
+const registryStart = configsSource.indexOf("export const CHART_CONFIGS")
+const registrySource = registryStart >= 0 ? configsSource.slice(registryStart) : configsSource
+for (const match of registrySource.matchAll(/^ {2}([A-Z][A-Za-z]+):\s/gm)) {
+  ssrRegistered.add(match[1])
+}
+
+// ── Index HOC source files for the push-API gate ───────────────────
+//
+// `supportsPush: true` charts must import the shared
+// `useFrameImperativeHandle` hook. Read each HOC's source and grep
+// for the import; charts claiming push without the hook fail.
+const HOC_DIRS = ["xy", "ordinal", "network", "geo", "realtime"]
+const hocSources = new Map()
+for (const dir of HOC_DIRS) {
+  const fullDir = path.join(CHARTS_DIR, dir)
+  if (!fs.existsSync(fullDir)) continue
+  for (const file of fs.readdirSync(fullDir)) {
+    if (file.endsWith(".test.tsx") || file.endsWith(".test.ts")) continue
+    if (file === "index.ts" || file === "index.tsx") continue
+    if (!file.endsWith(".tsx")) continue
+    const name = file.replace(".tsx", "")
+    hocSources.set(name, fs.readFileSync(path.join(fullDir, file), "utf8"))
+  }
+}
+
+// ── Run the locks ─────────────────────────────────────────────────
+const errors = []
+
+for (const e of specEntries) {
+  // Lock 1: SSR claim ↔ CHART_CONFIGS membership.
+  const inServerConfigs = ssrRegistered.has(e.name)
+  if (e.supportsSSR && !inServerConfigs) {
+    errors.push(
+      `✗ ${e.name}: capabilities.supportsSSR=true but not in serverChartConfigs.ts CHART_CONFIGS. ` +
+      `Either add a server config entry, or set supportsSSR=false (and consider adding "hoc-ssr-only" to specialFeatures).`,
+    )
+  }
+  if (!e.supportsSSR && inServerConfigs) {
+    errors.push(
+      `✗ ${e.name}: registered in serverChartConfigs.ts but capabilities.supportsSSR=false. ` +
+      `Either set supportsSSR=true or remove the server config entry.`,
+    )
+  }
+
+  // Lock 2: push claim ↔ a recognized push wiring mechanism.
+  // Three paths qualify:
+  //   - `useFrameImperativeHandle` — the standard ref bridge used by
+  //     XY, network, and the simpler ordinal HOCs.
+  //   - `useOrdinalStreaming` — the aggregator-aware push pipeline
+  //     used by BarChart family.
+  //   - `useImperativeHandle(` (a raw call, not just an import) —
+  //     bespoke bridges for composite charts (ScatterplotMatrix,
+  //     MinimapChart) and aggregators that pre-process via a
+  //     specialized hook (LikertChart via useLikertAggregation).
+  // The first two are preferred; the raw call is the fallback for
+  // charts whose ref API legitimately needs custom plumbing. All
+  // three signal that the chart exposes a working `ref.current.push`.
+  const source = hocSources.get(e.name)
+  if (e.supportsPush) {
+    if (!source) {
+      // Couldn't find the HOC source — skip rather than false-positive.
+      continue
+    }
+    const importsPushHook =
+      /\buseFrameImperativeHandle\b/.test(source) ||
+      /\buseOrdinalStreaming\b/.test(source) ||
+      /\buseImperativeHandle\(/.test(source)
+    if (!importsPushHook) {
+      errors.push(
+        `✗ ${e.name}: capabilities.supportsPush=true but does not wire a push handle ` +
+        `(useFrameImperativeHandle, useOrdinalStreaming, or a raw useImperativeHandle call). ` +
+        `Either wire one of those, or set supportsPush=false (and document the exemption in specialFeatures).`,
+      )
+    }
+  }
+
+  // Lock 3: linkedHover claim ↔ useChartSelection or useChartSetup
+  // (which calls useChartSelection internally) or useNetworkChartSetup
+  // (also wraps useChartSelection). The hook is the only standardized
+  // way to wire `linkedHover` into the frame's hover-selection
+  // pipeline; charts claiming linked-hover support without it would
+  // have a no-op `linkedHover` prop.
+  if (e.supportsLinkedHover) {
+    if (!source) continue
+    const wired =
+      /\buseChartSelection\b/.test(source) ||
+      /\buseChartSetup\b/.test(source) ||
+      /\buseNetworkChartSetup\b/.test(source)
+    if (!wired) {
+      errors.push(
+        `✗ ${e.name}: capabilities.supportsLinkedHover=true but does not wire selection. ` +
+        `Either import useChartSelection / useChartSetup / useNetworkChartSetup, or set ` +
+        `supportsLinkedHover=false.`,
+      )
+    }
+  }
+
+  // Lock 4: layoutMode === "custom" ↔ customNetworkLayout /
+  // customXYLayout / customOrdinalLayout reference. The escape-hatch
+  // claim must be backed by a real customLayout dispatch.
+  if (e.layoutMode === "custom") {
+    if (!source) continue
+    const wired =
+      /\bcustomNetworkLayout\b/.test(source) ||
+      /\bcustomXYLayout\b/.test(source) ||
+      /\bcustomOrdinalLayout\b/.test(source)
+    if (!wired) {
+      errors.push(
+        `✗ ${e.name}: capabilities.layoutMode="custom" but does not reference any customLayout ` +
+        `escape hatch. Either wire customNetworkLayout/customXYLayout/customOrdinalLayout, or ` +
+        `set layoutMode="plugin".`,
+      )
+    }
+  }
+
+  // TODO (next pass):
+  //   - supportsLegend ↔ a legend signal (showLegend prop on the
+  //     props interface OR useChartLegendAndMargin import). Harder
+  //     to gate cleanly because chord-style "interaction-only"
+  //     legends pass `showLegend: false` to the hook but still
+  //     produce a categorical interaction surface.
+}
+
+// ── Lock 3: ai/capabilities.json mirrors chartSpecs ───────────────
+//
+// `ai/capabilities.json` is consumed by `ai/chartSuggestions.cjs` so
+// the AI suggestion path can filter recommendations by capability
+// (push, linkedHover, ssr, etc.) without re-parsing TS at runtime.
+// If chartSpecs has changed since the JSON was last regenerated, the
+// AI surface is silently stale — fail with a regenerate hint.
+const CAPABILITIES_JSON_PATH = path.join(ROOT, "ai/capabilities.json")
+if (fs.existsSync(CAPABILITIES_JSON_PATH)) {
+  const expected = {}
+  for (const e of specEntries) {
+    expected[e.name] = {
+      category: e.category,
+      supportsLegend: e.supportsLegend,
+      supportsSelection: e.supportsSelection,
+      supportsLinkedHover: e.supportsLinkedHover,
+      supportsPush: e.supportsPush,
+      supportsSSR: e.supportsSSR,
+      colorModel: e.colorModel,
+      layoutMode: e.layoutMode,
+      specialFeatures: e.specialFeatures,
+    }
+  }
+  // Sort keys to match the generator's output (category-then-name).
+  const ORDER = ["xy", "ordinal", "network", "geo", "realtime"]
+  const sortedNames = Object.keys(expected).sort((a, b) => {
+    const ai = ORDER.indexOf(expected[a].category)
+    const bi = ORDER.indexOf(expected[b].category)
+    if (ai !== bi) return ai - bi
+    return a.localeCompare(b)
+  })
+  const expectedSorted = {}
+  for (const name of sortedNames) expectedSorted[name] = expected[name]
+
+  const actual = JSON.parse(fs.readFileSync(CAPABILITIES_JSON_PATH, "utf8"))
+  const actualCharts = actual?.charts ?? {}
+  if (JSON.stringify(actualCharts) !== JSON.stringify(expectedSorted)) {
+    errors.push(
+      "ai/capabilities.json drifted from chartSpecs. Regenerate with `npm run docs:capabilities`.",
+    )
+  }
+} else {
+  errors.push(
+    "ai/capabilities.json missing. Generate with `npm run docs:capabilities`.",
+  )
+}
+
+if (errors.length > 0) {
+  console.error(`✗ Capability claims drifted from runtime behavior (${errors.length} issue(s)):\n`)
+  for (const e of errors) console.error("  " + e)
+  console.error("\nFix: edit chartSpecs.ts capability tags or wire up the missing runtime support.")
+  process.exit(1)
+}
+
+console.log(`✓ Capability matrix locked — ${specEntries.length} chart spec(s) match runtime behavior.`)
+console.log(`  ${[...ssrRegistered].length} SSR-registered charts`)
+console.log(`  ${specEntries.filter((e) => e.supportsPush).length} charts claim push support`)
+console.log(`  ${specEntries.filter((e) => e.layoutMode === "custom").length} charts use custom layouts`)
+console.log(`  ai/capabilities.json in sync`)

--- a/scripts/generate-capabilities-json.mjs
+++ b/scripts/generate-capabilities-json.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * Generate `ai/capabilities.json` from the chartSpecs capability
+ * matrix. The CJS chart-suggestion path (`ai/chartSuggestions.cjs`)
+ * loads this JSON to filter recommendations by capability — without
+ * it, the suggestion logic can't reason over `supportsPush`,
+ * `supportsLinkedHover`, etc.
+ *
+ * Usage: node scripts/generate-capabilities-json.mjs
+ */
+
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { parseCapabilityMatrix } from "./lib/capabilityMatrix.mjs"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const ROOT = path.resolve(__dirname, "..")
+const OUT = path.join(ROOT, "ai/capabilities.json")
+
+const entries = parseCapabilityMatrix()
+
+// Emit as `{ ChartName: { …capability flags } }` for O(1) lookup
+// keyed by chart name. The CJS suggestion path looks up the chart
+// it's about to recommend, so name-keyed is the right shape.
+const byName = {}
+for (const e of entries) {
+  byName[e.name] = {
+    category: e.category,
+    supportsLegend: e.legend,
+    supportsSelection: e.selection,
+    supportsLinkedHover: e.linkedHover,
+    supportsPush: e.push,
+    supportsSSR: e.ssr,
+    colorModel: e.colorModel,
+    layoutMode: e.layoutMode,
+    specialFeatures: e.features,
+  }
+}
+
+const output = {
+  // Generated marker — guards against hand-edits and sets reader
+  // expectations. The `__source` mirrors the convention in
+  // `ai/schema.json`.
+  __generated: true,
+  __source: "src/components/charts/shared/chartSpecs.ts",
+  charts: byName,
+}
+
+fs.writeFileSync(OUT, JSON.stringify(output, null, 2) + "\n")
+console.log(`✅ wrote ${OUT}`)
+console.log(`   ${entries.length} chart(s) indexed`)

--- a/scripts/generate-capabilities-md.mjs
+++ b/scripts/generate-capabilities-md.mjs
@@ -44,11 +44,23 @@ lines.push("- **Color**: `categorical`, `sequential`, `threshold`, `continuous`,
 lines.push("- **Layout**: `plugin` (built-in), `custom` (escape hatch), `synthetic` (no layout).")
 lines.push("")
 
+// Display labels for category headings. Plain capitalization
+// (`xy → Xy`) is wrong for the family acronyms — keep the surface
+// consistent with how the docs and CLAUDE.md refer to them.
+const CATEGORY_DISPLAY_LABEL = {
+  xy: "XY",
+  ordinal: "Ordinal",
+  network: "Network",
+  geo: "Geo",
+  realtime: "Realtime",
+}
+
 let lastCategory = null
 for (const e of entries) {
   if (e.category !== lastCategory) {
     if (lastCategory !== null) lines.push("")
-    lines.push(`## ${e.category[0].toUpperCase()}${e.category.slice(1)}`)
+    const label = CATEGORY_DISPLAY_LABEL[e.category] ?? e.category
+    lines.push(`## ${label}`)
     lines.push("")
     lines.push("| Chart | Legend | Sel | Hover | Push | SSR | Color | Layout | Features |")
     lines.push("|---|:-:|:-:|:-:|:-:|:-:|---|---|---|")

--- a/scripts/generate-capabilities-md.mjs
+++ b/scripts/generate-capabilities-md.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Generate `docs/capabilities.md` from the chartSpecs capability
+ * matrix. Drop-in markdown table for docs nav + AI/MCP capability
+ * surfacing. Re-run after adding a chart entry; commit the result.
+ *
+ * Usage: node scripts/generate-capabilities-md.mjs
+ */
+
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { parseCapabilityMatrix } from "./lib/capabilityMatrix.mjs"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const ROOT = path.resolve(__dirname, "..")
+
+const OUT = path.join(ROOT, "docs/capabilities.md")
+
+const entries = parseCapabilityMatrix()
+
+const tick = (b) => (b ? "✓" : "—")
+const fmtFeatures = (xs) =>
+  xs.length === 0 ? "—" : xs.map((x) => `\`${x}\``).join(" ")
+
+const lines = []
+lines.push("# Chart Capability Matrix")
+lines.push("")
+lines.push("> Generated from `src/components/charts/shared/chartSpecs.ts`. Do not")
+lines.push("> edit by hand — re-run `npm run docs:capabilities` after adding a")
+lines.push("> chart and commit the output.")
+lines.push("")
+lines.push(`Last regen: ${new Date().toISOString().slice(0, 10)} · ${entries.length} charts indexed.`)
+lines.push("")
+lines.push("**Column key**")
+lines.push("")
+lines.push("- **Legend**: top-level `showLegend` renders a swatch column.")
+lines.push("- **Sel**: consumes a named `selection` to dim/highlight marks.")
+lines.push("- **Hover**: produces a `linkedHover` for cross-chart highlight.")
+lines.push("- **Push**: exposes a ref handle (`ref.current.push(...)`).")
+lines.push("- **SSR**: registered in `serverChartConfigs.ts` for `renderChart()`.")
+lines.push("- **Color**: `categorical`, `sequential`, `threshold`, `continuous`, or `none`.")
+lines.push("- **Layout**: `plugin` (built-in), `custom` (escape hatch), `synthetic` (no layout).")
+lines.push("")
+
+let lastCategory = null
+for (const e of entries) {
+  if (e.category !== lastCategory) {
+    if (lastCategory !== null) lines.push("")
+    lines.push(`## ${e.category[0].toUpperCase()}${e.category.slice(1)}`)
+    lines.push("")
+    lines.push("| Chart | Legend | Sel | Hover | Push | SSR | Color | Layout | Features |")
+    lines.push("|---|:-:|:-:|:-:|:-:|:-:|---|---|---|")
+    lastCategory = e.category
+  }
+  lines.push(
+    `| **${e.name}** | ${tick(e.legend)} | ${tick(e.selection)} | ` +
+    `${tick(e.linkedHover)} | ${tick(e.push)} | ${tick(e.ssr)} | ` +
+    `${e.colorModel} | ${e.layoutMode} | ${fmtFeatures(e.features)} |`,
+  )
+}
+
+lines.push("")
+lines.push("---")
+lines.push("")
+lines.push("## Aggregate counts")
+lines.push("")
+const total = entries.length
+const counts = {
+  legend: entries.filter((e) => e.legend).length,
+  push: entries.filter((e) => e.push).length,
+  ssr: entries.filter((e) => e.ssr).length,
+  customLayout: entries.filter((e) => e.layoutMode === "custom").length,
+  synthetic: entries.filter((e) => e.layoutMode === "synthetic").length,
+}
+lines.push(`- ${counts.legend}/${total} charts render a top-level legend.`)
+lines.push(`- ${counts.push}/${total} charts expose a push API.`)
+lines.push(`- ${counts.ssr}/${total} charts SSR via the \`renderChart()\` registry.`)
+lines.push(`- ${counts.customLayout}/${total} charts use the customLayout escape hatch.`)
+lines.push(`- ${counts.synthetic}/${total} charts use synthetic (no-layout) construction.`)
+lines.push("")
+
+fs.writeFileSync(OUT, lines.join("\n"))
+console.log(`✅ wrote ${OUT}`)
+console.log(`   ${entries.length} chart(s) indexed across ${new Set(entries.map((e) => e.category)).size} categories`)

--- a/scripts/lib/capabilityMatrix.mjs
+++ b/scripts/lib/capabilityMatrix.mjs
@@ -1,0 +1,85 @@
+/**
+ * Parse the capability matrix out of `chartSpecs.ts`.
+ *
+ * Three call sites consume this:
+ *   1. `check-capabilities.mjs` — CI gate that locks runtime ↔ matrix.
+ *   2. `generate-capabilities-md.mjs` — emits `docs/capabilities.md`.
+ *   3. `generate-capabilities-json.mjs` — emits `ai/capabilities.json`
+ *      so the AI suggestion path can filter by capability without
+ *      re-parsing TS at runtime.
+ *
+ * Keeping the parser in one place means a chartSpecs schema change
+ * touches one regex set, not three.
+ */
+
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const ROOT = path.resolve(__dirname, "..", "..")
+const SPECS_PATH = path.join(ROOT, "src/components/charts/shared/chartSpecs.ts")
+
+/**
+ * Read `chartSpecs.ts` and return a sorted array of capability entries.
+ * Each entry has the same shape consumers expect:
+ *   { name, category, legend, selection, linkedHover, push, ssr,
+ *     colorModel, layoutMode, features }
+ */
+export function parseCapabilityMatrix() {
+  const text = fs.readFileSync(SPECS_PATH, "utf8")
+  const entries = []
+  const entryStart = /^ {2}([A-Z][A-Za-z]+):\s*\{$/gm
+  let m
+  while ((m = entryStart.exec(text))) {
+    const name = m[1]
+    let i = text.indexOf("{", m.index) + 1
+    let depth = 1
+    while (i < text.length && depth > 0) {
+      if (text[i] === "{") depth++
+      else if (text[i] === "}") depth--
+      i++
+    }
+    const body = text.slice(m.index, i)
+    const cap = body.match(/capabilities:\s*\{([\s\S]*?)\n\s{4}\}/)
+    if (!cap) continue
+    const get = (key) => {
+      const r = cap[1].match(new RegExp(`${key}:\\s*([^,\\n]+)`))
+      return r ? r[1].trim() : null
+    }
+    const arr = (key) => {
+      const r = cap[1].match(new RegExp(`${key}:\\s*\\[([^\\]]*)\\]`))
+      if (!r) return []
+      return r[1].split(",").map((s) => s.trim().replace(/^"|"$/g, "")).filter(Boolean)
+    }
+    const cat = body.match(/category:\s*"([^"]+)"/)
+    entries.push({
+      name,
+      category: cat ? cat[1] : "?",
+      legend: get("supportsLegend") === "true",
+      selection: get("supportsSelection") === "true",
+      linkedHover: get("supportsLinkedHover") === "true",
+      push: get("supportsPush") === "true",
+      ssr: get("supportsSSR") === "true",
+      colorModel: (get("colorModel") || "").replace(/^"|"$/g, ""),
+      layoutMode: (get("layoutMode") || "").replace(/^"|"$/g, ""),
+      features: arr("specialFeatures"),
+    })
+  }
+
+  // Sort by category then alphabetical within category — same order
+  // both md/json consumers expect.
+  const ORDER = ["xy", "ordinal", "network", "geo", "realtime"]
+  entries.sort((a, b) => {
+    const ai = ORDER.indexOf(a.category)
+    const bi = ORDER.indexOf(b.category)
+    if (ai !== bi) return ai - bi
+    return a.name.localeCompare(b.name)
+  })
+
+  return entries
+}
+
+/** Category sort order used by the matrix output. */
+export const CATEGORY_ORDER = ["xy", "ordinal", "network", "geo", "realtime"]

--- a/src/__tests__/scenarios/chart-suggestions-capabilities.test.ts
+++ b/src/__tests__/scenarios/chart-suggestions-capabilities.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit-test the capability-filter logic in `ai/chartSuggestions.cjs`
+ * directly. The MCP-level integration is covered in
+ * `mcp-protocol.test.ts`; this file pins down the behavior at the
+ * function boundary so a chartSpecs change can't quietly break the
+ * suggestion ranking.
+ */
+import { describe, it, expect } from "vitest"
+// Dynamic require: the cjs module ships in `ai/` and we run vitest
+// in mixed-module mode. Casting to `any` keeps the test ergonomic
+// without authoring a `.d.ts` stub.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { suggestCharts, chartSatisfiesCapabilities, VALID_CAPABILITY_KEYS } =
+  require("../../../ai/chartSuggestions.cjs") as {
+    suggestCharts: (args: any) => any
+    chartSatisfiesCapabilities: (chartName: string, requirements: any) => boolean
+    VALID_CAPABILITY_KEYS: string[]
+  }
+
+describe("chartSuggestions — capability filter", () => {
+  describe("VALID_CAPABILITY_KEYS", () => {
+    it("exposes the supported capability constraints", () => {
+      expect(VALID_CAPABILITY_KEYS.sort()).toEqual([
+        "legend", "linkedHover", "push", "selection", "ssr",
+      ])
+    })
+  })
+
+  describe("chartSatisfiesCapabilities", () => {
+    it("returns true when no constraints are set", () => {
+      expect(chartSatisfiesCapabilities("Scatterplot", {})).toBe(true)
+      expect(chartSatisfiesCapabilities("Scatterplot", undefined)).toBe(true)
+    })
+
+    it("returns true when chart satisfies a single requirement", () => {
+      // Scatterplot supports both push and SSR (verified in chartSpecs).
+      expect(chartSatisfiesCapabilities("Scatterplot", { push: true })).toBe(true)
+      expect(chartSatisfiesCapabilities("Scatterplot", { ssr: true })).toBe(true)
+    })
+
+    it("returns false when chart fails a single requirement", () => {
+      // GaugeChart's chartSpecs entry has supportsPush: false.
+      expect(chartSatisfiesCapabilities("GaugeChart", { push: true })).toBe(false)
+      // ChoroplethMap also does not support push.
+      expect(chartSatisfiesCapabilities("ChoroplethMap", { push: true })).toBe(false)
+    })
+
+    it("returns true when all multi-key requirements pass", () => {
+      expect(chartSatisfiesCapabilities("Scatterplot", { push: true, ssr: true, linkedHover: true })).toBe(true)
+    })
+
+    it("returns false when any multi-key requirement fails", () => {
+      // GaugeChart has push: false, ssr: true. Asking for both fails.
+      expect(chartSatisfiesCapabilities("GaugeChart", { push: true, ssr: true })).toBe(false)
+    })
+
+    it("supports forbid-style constraints (require: false)", () => {
+      // Asking for a chart that does NOT support push.
+      expect(chartSatisfiesCapabilities("GaugeChart", { push: false })).toBe(true)
+      expect(chartSatisfiesCapabilities("Scatterplot", { push: false })).toBe(false)
+    })
+
+    it("fails closed for unknown chart names", () => {
+      expect(chartSatisfiesCapabilities("NotARealChart", { push: true })).toBe(false)
+    })
+  })
+
+  describe("suggestCharts({ capabilities })", () => {
+    const numericData = [{ x: 1, y: 10 }, { x: 2, y: 20 }, { x: 3, y: 15 }]
+    const networkData = [{ source: "A", target: "B", value: 5 }, { source: "B", target: "C", value: 3 }]
+
+    it("filters out non-push charts when push is required", () => {
+      // Network data normally suggests SankeyDiagram + ForceDirectedGraph.
+      // Both should support push (verified in chartSpecs).
+      const result = suggestCharts({ data: networkData, capabilities: { push: true } })
+      expect(result.ok).toBe(true)
+      // Every returned suggestion should claim push support.
+      for (const s of result.suggestions) {
+        expect(chartSatisfiesCapabilities(s.component, { push: true })).toBe(true)
+      }
+    })
+
+    it("preserves confidence ordering after filtering", () => {
+      const result = suggestCharts({ data: numericData, capabilities: { push: true } })
+      expect(result.ok).toBe(true)
+      expect(result.suggestions.length).toBeGreaterThan(0)
+      // Scatterplot is the highest-confidence suggestion for two-numeric data.
+      expect(result.suggestions[0].component).toBe("Scatterplot")
+    })
+
+    it("surfaces filteredOut when constraints drop suggestions", () => {
+      // Force a constraint that nothing satisfies — `push: false` for
+      // tabular numeric data which only suggests push-supporting charts.
+      const allPushOnlySuggested = suggestCharts({ data: numericData })
+      expect(allPushOnlySuggested.suggestions.every((s: any) =>
+        chartSatisfiesCapabilities(s.component, { push: true })
+      )).toBe(true)
+
+      const filtered = suggestCharts({ data: numericData, capabilities: { push: false } })
+      expect(filtered.ok).toBe(true)
+      expect(filtered.suggestions.length).toBe(0)
+      expect(filtered.filteredOut).toBeDefined()
+      expect(filtered.filteredOut.length).toBeGreaterThan(0)
+      expect(filtered.filteredOut[0]).toHaveProperty("component")
+      expect(filtered.filteredOut[0]).toHaveProperty("reason")
+    })
+
+    it("rejects unknown capability keys", () => {
+      const result = suggestCharts({
+        data: numericData,
+        capabilities: { wibble: true },
+      })
+      expect(result.ok).toBe(false)
+      expect(result.error).toContain("Unknown capability")
+    })
+
+    it("rejects non-object capabilities", () => {
+      const result = suggestCharts({
+        data: numericData,
+        capabilities: "push" as any,
+      })
+      expect(result.ok).toBe(false)
+      expect(result.error).toContain("must be an object")
+    })
+
+    it("echoes the capabilities arg in the result for caller visibility", () => {
+      const reqs = { push: true, ssr: true }
+      const result = suggestCharts({ data: numericData, capabilities: reqs })
+      expect(result.capabilities).toEqual(reqs)
+    })
+  })
+})

--- a/src/__tests__/scenarios/chart-suggestions-capabilities.test.ts
+++ b/src/__tests__/scenarios/chart-suggestions-capabilities.test.ts
@@ -10,10 +10,11 @@ import { describe, it, expect } from "vitest"
 // in mixed-module mode. Casting to `any` keeps the test ergonomic
 // without authoring a `.d.ts` stub.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { suggestCharts, chartSatisfiesCapabilities, VALID_CAPABILITY_KEYS } =
+const { suggestCharts, chartSatisfiesCapabilities, explainCapabilityMismatch, VALID_CAPABILITY_KEYS } =
   require("../../../ai/chartSuggestions.cjs") as {
     suggestCharts: (args: any) => any
     chartSatisfiesCapabilities: (chartName: string, requirements: any) => boolean
+    explainCapabilityMismatch: (chartName: string, requirements: any) => string | null
     VALID_CAPABILITY_KEYS: string[]
   }
 
@@ -23,6 +24,33 @@ describe("chartSuggestions — capability filter", () => {
       expect(VALID_CAPABILITY_KEYS.sort()).toEqual([
         "legend", "linkedHover", "push", "selection", "ssr",
       ])
+    })
+  })
+
+  describe("explainCapabilityMismatch", () => {
+    it("returns null when no mismatch", () => {
+      expect(explainCapabilityMismatch("Scatterplot", { push: true })).toBeNull()
+    })
+
+    it("describes a single-constraint mismatch", () => {
+      // GaugeChart has supportsPush: false. Asking for push: true mismatches.
+      const reason = explainCapabilityMismatch("GaugeChart", { push: true })
+      expect(reason).toContain("push=true")
+      expect(reason).toContain("supportsPush=false")
+    })
+
+    it("describes multiple-constraint mismatches with separator", () => {
+      // GaugeChart: supportsLegend=false, supportsLinkedHover=false.
+      // Asking for both should surface both.
+      const reason = explainCapabilityMismatch("GaugeChart", { legend: true, linkedHover: true })
+      expect(reason).toContain("legend=true")
+      expect(reason).toContain("linkedHover=true")
+      expect(reason).toContain(";")
+    })
+
+    it("explains unknown chart name", () => {
+      const reason = explainCapabilityMismatch("NotARealChart", { push: true })
+      expect(reason).toContain("not found")
     })
   })
 
@@ -103,6 +131,22 @@ describe("chartSuggestions — capability filter", () => {
       expect(filtered.filteredOut.length).toBeGreaterThan(0)
       expect(filtered.filteredOut[0]).toHaveProperty("component")
       expect(filtered.filteredOut[0]).toHaveProperty("reason")
+    })
+
+    it("filteredOut.reason cites the specific capability mismatch", () => {
+      // Drop GaugeChart-style data (single-value would never match
+      // here anyway) — instead use Scatterplot which we know
+      // supports push, and forbid push to force a mismatch.
+      const filtered = suggestCharts({ data: numericData, capabilities: { push: false } })
+      expect(filtered.ok).toBe(true)
+      const scatterFiltered = filtered.filteredOut.find((f: any) => f.component === "Scatterplot")
+      expect(scatterFiltered).toBeDefined()
+      // Reason should mention the failed constraint, not the data-shape rationale.
+      expect(scatterFiltered.reason).toMatch(/push=false/)
+      expect(scatterFiltered.reason).toMatch(/supportsPush=true/)
+      // Sanity — the data-shape rationale (which used to be the
+      // reason) should not be the value here.
+      expect(scatterFiltered.reason).not.toMatch(/scatterplot shows relationships/)
     })
 
     it("rejects unknown capability keys", () => {

--- a/src/__tests__/scenarios/mcp-protocol.test.ts
+++ b/src/__tests__/scenarios/mcp-protocol.test.ts
@@ -499,6 +499,26 @@ describe("MCP protocol round-trip", () => {
     expect(sc.capabilities).toEqual({ push: true, ssr: true })
   })
 
+  it("suggestChart rejects unknown capability keys at the MCP schema layer", async () => {
+    // The zod schema is `.strict()`, so an unknown key causes the
+    // MCP framework to return a JSON-RPC error rather than silently
+    // strip the key (which would mask the cjs-level validation).
+    const result = await sendRequest(proc, "tools/call", {
+      name: "suggestChart",
+      arguments: {
+        data: [{ x: 1, y: 1 }, { x: 2, y: 2 }],
+        capabilities: { wibble: true },
+      },
+    }, "suggest-cap-strict")
+
+    // Either a JSON-RPC error (zod rejected) OR a tool-level error
+    // (cjs validator caught it). Both are valid fail-closed shapes;
+    // the assertion only requires that the unknown key didn't get
+    // silently dropped + processed as an empty constraint set.
+    const errored = result.error != null || result.result?.isError === true
+    expect(errored).toBe(true)
+  })
+
 
   it("renderChart produces SVG output", async () => {
     const result = await sendRequest(proc, "tools/call", {

--- a/src/__tests__/scenarios/mcp-protocol.test.ts
+++ b/src/__tests__/scenarios/mcp-protocol.test.ts
@@ -474,6 +474,32 @@ describe("MCP protocol round-trip", () => {
     expect(result.result.isError).toBe(true)
   })
 
+  it("suggestChart filters recommendations by capability constraint", async () => {
+    // Numeric x/y → ranks Scatterplot first by default. Demanding
+    // SSR support drops nothing (Scatterplot supports SSR). Demanding
+    // a constraint no XY chart satisfies should drop them all and
+    // surface the filteredOut list.
+    const result = await sendRequest(proc, "tools/call", {
+      name: "suggestChart",
+      arguments: {
+        data: [
+          { x: 1, y: 10 },
+          { x: 2, y: 20 },
+          { x: 3, y: 15 },
+        ],
+        capabilities: { push: true, ssr: true },
+      },
+    }, "suggest-cap-1")
+
+    expect(result.result.isError).toBeFalsy()
+    const sc = result.result.structuredContent
+    expect(sc.ok).toBe(true)
+    // Scatterplot satisfies push + ssr — should be in the filtered set.
+    expect(sc.suggestions.some((s: any) => s.component === "Scatterplot")).toBe(true)
+    expect(sc.capabilities).toEqual({ push: true, ssr: true })
+  })
+
+
   it("renderChart produces SVG output", async () => {
     const result = await sendRequest(proc, "tools/call", {
       name: "renderChart",

--- a/src/components/charts/geo/FlowMap.test.tsx
+++ b/src/components/charts/geo/FlowMap.test.tsx
@@ -4,13 +4,34 @@ import { render } from "@testing-library/react"
 import { FlowMap } from "./FlowMap"
 import { TooltipProvider } from "../../store/TooltipStore"
 
-// Mock StreamGeoFrame to capture props
+// Mock StreamGeoFrame to capture props AND expose a fake imperative
+// handle so push-API tests can spy on `pushLine`/`pushManyLines`/etc.
 let lastGeoFrameProps: any = null
+const fakeFrameHandle = {
+  push: vi.fn(),
+  pushMany: vi.fn(),
+  removePoint: vi.fn(() => []),
+  pushLine: vi.fn(),
+  pushManyLines: vi.fn(),
+  removeLine: vi.fn(() => []),
+  getLines: vi.fn(() => []),
+  clear: vi.fn(),
+  getProjection: vi.fn(() => null),
+  getGeoPath: vi.fn(() => null),
+  getCartogramLayout: vi.fn(() => null),
+  getZoom: vi.fn(() => 1),
+  resetZoom: vi.fn(),
+  getData: vi.fn(() => []),
+}
 vi.mock("../../stream/StreamGeoFrame", () => {
   return {
     __esModule: true,
-    default: React.forwardRef((props: any, _ref: any) => {
+    default: React.forwardRef((props: any, ref: any) => {
       lastGeoFrameProps = props
+      // Wire the forwarded ref to the fake handle so `useFrameImperativeHandle`
+      // routes through it.
+      if (typeof ref === "function") ref(fakeFrameHandle)
+      else if (ref) ref.current = fakeFrameHandle
       return <div className="stream-geo-frame"><svg /></div>
     })
   }
@@ -40,6 +61,9 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => (
 describe("FlowMap", () => {
   beforeEach(() => {
     lastGeoFrameProps = null
+    Object.values(fakeFrameHandle).forEach((fn) => {
+      if (typeof (fn as any)?.mockClear === "function") (fn as any).mockClear()
+    })
   })
 
   // ── Hooks-before-early-return fix ─────────────────────────────────────
@@ -289,6 +313,93 @@ describe("FlowMap", () => {
         </Wrapper>
       )
       expect(lastGeoFrameProps.zoomable).toBe(true)
+    })
+  })
+
+  // ── Push API ──────────────────────────────────────────────────────────
+  //
+  // FlowMap pushes raw flows (`{ source, target, value }`); the HOC
+  // resolves source/target through `nodeLookup` HOC-side, then forwards
+  // a `{ ...flow, coordinates: [...] }` line entry to the frame's
+  // `pushLine`/`pushManyLines`. See `useFrameImperativeHandle` `geo-lines`
+  // variant.
+
+  describe("push API", () => {
+    it("translates a pushed flow into a coordinate-resolved line", () => {
+      const ref = React.createRef<any>()
+      render(
+        <Wrapper>
+          <FlowMap ref={ref} nodes={sampleNodes} />
+        </Wrapper>
+      )
+      ref.current?.push({ source: "A", target: "B", passengers: 100 })
+
+      expect(fakeFrameHandle.pushLine).toHaveBeenCalledTimes(1)
+      const line = (fakeFrameHandle.pushLine as any).mock.calls[0][0]
+      expect(line.source).toBe("A")
+      expect(line.target).toBe("B")
+      expect(line.passengers).toBe(100)
+      expect(line.coordinates).toHaveLength(2)
+      expect(line.coordinates[0].lon).toBe(-73.7)
+      expect(line.coordinates[1].lon).toBe(-0.4)
+    })
+
+    it("drops a pushed flow whose endpoints aren't in nodeLookup", () => {
+      const ref = React.createRef<any>()
+      render(
+        <Wrapper>
+          <FlowMap ref={ref} nodes={sampleNodes} />
+        </Wrapper>
+      )
+      ref.current?.push({ source: "A", target: "MISSING", value: 1 })
+      expect(fakeFrameHandle.pushLine).not.toHaveBeenCalled()
+    })
+
+    it("batches pushMany into a single pushManyLines call", () => {
+      const ref = React.createRef<any>()
+      render(
+        <Wrapper>
+          <FlowMap ref={ref} nodes={sampleNodes} />
+        </Wrapper>
+      )
+      ref.current?.pushMany([
+        { source: "A", target: "B", value: 1 },
+        { source: "B", target: "C", value: 2 },
+        { source: "A", target: "MISSING", value: 99 }, // dropped
+      ])
+
+      expect(fakeFrameHandle.pushManyLines).toHaveBeenCalledTimes(1)
+      const lines = (fakeFrameHandle.pushManyLines as any).mock.calls[0][0]
+      expect(lines).toHaveLength(2)
+    })
+
+    it("forwards remove(id) to the frame's removeLine", () => {
+      const ref = React.createRef<any>()
+      render(
+        <Wrapper>
+          <FlowMap ref={ref} nodes={sampleNodes} lineIdAccessor="id" />
+        </Wrapper>
+      )
+      ref.current?.remove("flow-1")
+      expect(fakeFrameHandle.removeLine).toHaveBeenCalledWith("flow-1")
+    })
+
+    it("forwards lineIdAccessor through to streamProps", () => {
+      render(
+        <Wrapper>
+          <FlowMap nodes={sampleNodes} flows={sampleFlows} lineIdAccessor="id" />
+        </Wrapper>
+      )
+      expect(lastGeoFrameProps.lineIdAccessor).toBe("id")
+    })
+
+    it("omits `lines` from streamProps when flows prop is undefined (push mode)", () => {
+      render(
+        <Wrapper>
+          <FlowMap nodes={sampleNodes} />
+        </Wrapper>
+      )
+      expect(lastGeoFrameProps.lines).toBeUndefined()
     })
   })
 

--- a/src/components/charts/geo/FlowMap.test.tsx
+++ b/src/components/charts/geo/FlowMap.test.tsx
@@ -178,11 +178,15 @@ describe("FlowMap", () => {
         </Wrapper>
       )
       expect(lastGeoFrameProps.lines).toHaveLength(3)
-      // Each line should have coordinates array
+      // Each line should have coordinates array. Synthesized coords
+      // carry stable internal keys (__semiotic_x / __semiotic_y);
+      // the frame reads them via FlowMap's hybrid xAccessor /
+      // yAccessor so the user-facing lon/lat is preserved at read
+      // time. See "hybrid xAccessor reads…" tests below.
       for (const line of lastGeoFrameProps.lines) {
         expect(line.coordinates).toHaveLength(2)
-        expect(line.coordinates[0]).toHaveProperty("lon")
-        expect(line.coordinates[0]).toHaveProperty("lat")
+        expect(line.coordinates[0]).toHaveProperty("__semiotic_x")
+        expect(line.coordinates[0]).toHaveProperty("__semiotic_y")
       }
     })
 
@@ -340,8 +344,47 @@ describe("FlowMap", () => {
       expect(line.target).toBe("B")
       expect(line.passengers).toBe(100)
       expect(line.coordinates).toHaveLength(2)
-      expect(line.coordinates[0].lon).toBe(-73.7)
-      expect(line.coordinates[1].lon).toBe(-0.4)
+      // Synthesized coords carry stable internal keys
+      // (`__semiotic_x` / `__semiotic_y`); the frame reads them via
+      // FlowMap's hybrid xReader/yReader (verified separately by
+      // checking lastGeoFrameProps.xAccessor returns the value when
+      // called on a synthesized coord).
+      expect(line.coordinates[0].__semiotic_x).toBe(-73.7)
+      expect(line.coordinates[1].__semiotic_x).toBe(-0.4)
+    })
+
+    it("hybrid xAccessor reads synthesized coords AND user nodes", () => {
+      // String-form user accessor: nodes use { lon, lat } keys, synthesized
+      // coords use the stable internal keys. Both must work through the
+      // single accessor passed to the frame.
+      render(
+        <Wrapper>
+          <FlowMap nodes={sampleNodes} flows={sampleFlows} />
+        </Wrapper>
+      )
+      const xAcc = lastGeoFrameProps.xAccessor as (d: any) => number
+      // Reads from a node (user shape).
+      expect(xAcc({ lon: 100, lat: 50 })).toBe(100)
+      // Reads from a synthesized coord (stable key).
+      expect(xAcc({ __semiotic_x: 7, __semiotic_y: 8 })).toBe(7)
+    })
+
+    it("hybrid xAccessor works with function user accessors", () => {
+      // Function accessor: would have silently failed with the old
+      // [xAccessor as string] coord-key pattern.
+      const lonFn = (d: any) => d.lon * 2
+      render(
+        <Wrapper>
+          <FlowMap nodes={sampleNodes} flows={sampleFlows} xAccessor={lonFn} />
+        </Wrapper>
+      )
+      const xAcc = lastGeoFrameProps.xAccessor as (d: any) => number
+      // Node shape — falls back to the user function.
+      expect(xAcc({ lon: 5 })).toBe(10)
+      // Synthesized coord — stable key wins (the user function would
+      // have returned NaN here because synthesized coords don't carry
+      // the user's expected shape).
+      expect(xAcc({ __semiotic_x: 99 })).toBe(99)
     })
 
     it("drops a pushed flow whose endpoints aren't in nodeLookup", () => {

--- a/src/components/charts/geo/FlowMap.tsx
+++ b/src/components/charts/geo/FlowMap.tsx
@@ -2,9 +2,11 @@
 import type { Datum } from "../shared/datumTypes"
 import { EMPTY_ARRAY, filterSparseArray } from "../shared/sparseArray"
 import * as React from "react"
-import { useMemo, useCallback } from "react"
+import { useMemo, useCallback, useRef, forwardRef } from "react"
 import StreamGeoFrame from "../../stream/StreamGeoFrame"
-import type { StreamGeoFrameProps, ProjectionProp } from "../../stream/geoTypes"
+import type { StreamGeoFrameProps, ProjectionProp, StreamGeoFrameHandle } from "../../stream/geoTypes"
+import type { RealtimeFrameHandle } from "../../realtime/types"
+import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
 import type { BaseChartProps, ChartAccessor } from "../shared/types"
 import { normalizeTooltip, type TooltipProp } from "../../Tooltip/Tooltip"
 import { getColor } from "../shared/colorUtils"
@@ -90,6 +92,13 @@ export interface FlowMapProps<TDatum extends Datum = Datum> extends BaseChartPro
   tileCacheSize?: number
   /** Annotations */
   annotations?: Datum[]
+  /**
+   * ID accessor on flow records — required for `ref.current.remove(id)`
+   * and `ref.current.update(id, …)`. The accessor reads the same field
+   * the user supplies on each flow; the field is preserved on the
+   * resolved line entry so the frame's `removeLine` can match by id.
+   */
+  lineIdAccessor?: string | ((d: Datum) => string)
   /** Passthrough */
   frameProps?: Partial<Omit<StreamGeoFrameProps, "projection">>
 }
@@ -144,7 +153,10 @@ export interface FlowMapProps<TDatum extends Datum = Datum> extends BaseChartPro
  * />
  * ```
  */
-export function FlowMap<TDatum extends Datum = Datum>(props: FlowMapProps<TDatum>) {
+export const FlowMap = forwardRef(function FlowMap<TDatum extends Datum = Datum>(
+  props: FlowMapProps<TDatum>,
+  ref: React.Ref<RealtimeFrameHandle>,
+) {
 
   const resolved = useChartMode(props.mode, {
     width: props.width,
@@ -201,6 +213,7 @@ export function FlowMap<TDatum extends Datum = Datum>(props: FlowMapProps<TDatum
     stroke,
     strokeWidth,
     opacity,
+    lineIdAccessor,
   } = props
 
   // Tile maps default to zoomable; non-tile maps default to not zoomable
@@ -277,6 +290,59 @@ export function FlowMap<TDatum extends Datum = Datum>(props: FlowMapProps<TDatum
     }
     return map
   }, [safeNodes, nodeIdAccessor])
+
+  // Push API. Flows arrive shaped `{ source, target, value, ... }`; the
+  // frame stores resolved line records `{ ...flow, coordinates: [...] }`.
+  // The translation needs the current `nodeLookup` + accessors, which
+  // change when their props change, so we route them through refs to
+  // keep the imperative handle reference-stable across renders.
+  const frameRef = useRef<StreamGeoFrameHandle>(null)
+  const nodeLookupRef = useRef(nodeLookup)
+  nodeLookupRef.current = nodeLookup
+  const xAccessorRef = useRef(xAccessor)
+  xAccessorRef.current = xAccessor
+  const yAccessorRef = useRef(yAccessor)
+  yAccessorRef.current = yAccessor
+
+  const resolveFlowToLine = useCallback((flow: Datum): Datum | null => {
+    if (!flow || typeof flow !== "object" || flow.source == null || flow.target == null) return null
+    const map = nodeLookupRef.current
+    const src = map.get(String(flow.source))
+    const tgt = map.get(String(flow.target))
+    if (!src || !tgt) return null
+    const xAcc = typeof xAccessorRef.current === "function"
+      ? xAccessorRef.current
+      : (d: Datum) => d[xAccessorRef.current as string]
+    const yAcc = typeof yAccessorRef.current === "function"
+      ? yAccessorRef.current
+      : (d: Datum) => d[yAccessorRef.current as string]
+    return {
+      ...flow,
+      coordinates: [
+        { [xAccessorRef.current as string]: xAcc(src), [yAccessorRef.current as string]: yAcc(src) },
+        { [xAccessorRef.current as string]: xAcc(tgt), [yAccessorRef.current as string]: yAcc(tgt) },
+      ],
+    }
+  }, [])
+
+  useFrameImperativeHandle(ref, {
+    variant: "geo-lines",
+    frameRef,
+    overrides: {
+      push: (flow) => {
+        const line = resolveFlowToLine(flow)
+        if (line) frameRef.current?.pushLine(line)
+      },
+      pushMany: (flows) => {
+        const lines: Datum[] = []
+        for (const flow of flows) {
+          const line = resolveFlowToLine(flow)
+          if (line) lines.push(line)
+        }
+        if (lines.length > 0) frameRef.current?.pushManyLines(lines)
+      },
+    },
+  })
 
   // Reverse lookup: nodeId → first flow touching that node
   // Used to emit flow-relevant fields when a point node is hovered
@@ -443,11 +509,16 @@ export function FlowMap<TDatum extends Datum = Datum>(props: FlowMapProps<TDatum
 
   const streamProps: StreamGeoFrameProps = {
     projection,
-    lines: lineData,
+    // Push-mode entry: when `flows` is undefined the user is driving
+    // the chart through `ref.current.push()`; omit `lines` so the frame
+    // doesn't reset its store on every parent re-render. With `flows`
+    // supplied we hand the translated `lineData` over as usual.
+    ...(flows != null && { lines: lineData }),
     points: safeNodes,
     xAccessor: xAccessor as any,
     yAccessor: yAccessor as any,
     lineDataAccessor: "coordinates",
+    ...(lineIdAccessor != null && { lineIdAccessor }),
     lineType,
     flowStyle,
     lineStyle: lineStyleFn,
@@ -488,8 +559,13 @@ export function FlowMap<TDatum extends Datum = Datum>(props: FlowMapProps<TDatum
 
   return (
     <SafeRender componentName="FlowMap" width={resolved.width} height={resolved.height}>
-      <StreamGeoFrame {...streamProps} />
+      <StreamGeoFrame ref={frameRef} {...streamProps} />
     </SafeRender>
   )
+}) as unknown as {
+  <TDatum extends Datum = Datum>(
+    props: FlowMapProps<TDatum> & React.RefAttributes<RealtimeFrameHandle>,
+  ): React.ReactElement | null
+  displayName?: string
 }
 FlowMap.displayName = "FlowMap"

--- a/src/components/charts/geo/FlowMap.tsx
+++ b/src/components/charts/geo/FlowMap.tsx
@@ -7,6 +7,15 @@ import StreamGeoFrame from "../../stream/StreamGeoFrame"
 import type { StreamGeoFrameProps, ProjectionProp, StreamGeoFrameHandle } from "../../stream/geoTypes"
 import type { RealtimeFrameHandle } from "../../realtime/types"
 import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
+
+// Stable internal keys for synthesized line-coord objects. The
+// frame's xAccessor / yAccessor would otherwise need to know how to
+// read user-supplied function accessors against synthesized objects
+// (which have no user-controlled shape). By writing coords with
+// these fixed keys and passing hybrid accessors that prefer them,
+// FlowMap supports both string and function user accessors.
+const COORD_X_KEY = "__semiotic_x"
+const COORD_Y_KEY = "__semiotic_y"
 import type { BaseChartProps, ChartAccessor } from "../shared/types"
 import { normalizeTooltip, type TooltipProp } from "../../Tooltip/Tooltip"
 import { getColor } from "../shared/colorUtils"
@@ -316,11 +325,16 @@ export const FlowMap = forwardRef(function FlowMap<TDatum extends Datum = Datum>
     const yAcc = typeof yAccessorRef.current === "function"
       ? yAccessorRef.current
       : (d: Datum) => d[yAccessorRef.current as string]
+    // Synthesized coords use stable keys. The frame reads them via
+    // the hybrid `xReader` / `yReader` defined below, which prefer
+    // these stable keys on coord objects and fall back to the
+    // user's accessor on nodes — supports both string and function
+    // user accessors.
     return {
       ...flow,
       coordinates: [
-        { [xAccessorRef.current as string]: xAcc(src), [yAccessorRef.current as string]: yAcc(src) },
-        { [xAccessorRef.current as string]: xAcc(tgt), [yAccessorRef.current as string]: yAcc(tgt) },
+        { [COORD_X_KEY]: xAcc(src), [COORD_Y_KEY]: yAcc(src) },
+        { [COORD_X_KEY]: xAcc(tgt), [COORD_Y_KEY]: yAcc(tgt) },
       ],
     }
   }, [])
@@ -406,7 +420,8 @@ export const FlowMap = forwardRef(function FlowMap<TDatum extends Datum = Datum>
   // Click behavior is the standard pass-through — no translation needed.
   const customClickBehavior = setup.customClickBehavior
 
-  // Convert flows to line data
+  // Convert flows to line data. Coords use stable internal keys
+  // (see resolveFlowToLine for the same pattern in the push path).
   const lineData = useMemo(() => {
     const xAcc = typeof xAccessor === "function" ? xAccessor : (d: Datum) => d[xAccessor as string]
     const yAcc = typeof yAccessor === "function" ? yAccessor : (d: Datum) => d[yAccessor as string]
@@ -419,12 +434,39 @@ export const FlowMap = forwardRef(function FlowMap<TDatum extends Datum = Datum>
       return {
         ...flow,
         coordinates: [
-          { [xAccessor as string]: xAcc(src), [yAccessor as string]: yAcc(src) },
-          { [xAccessor as string]: xAcc(tgt), [yAccessor as string]: yAcc(tgt) }
+          { [COORD_X_KEY]: xAcc(src), [COORD_Y_KEY]: yAcc(src) },
+          { [COORD_X_KEY]: xAcc(tgt), [COORD_Y_KEY]: yAcc(tgt) },
         ]
       }
     }).filter(Boolean) as Datum[]
   }, [safeFlows, nodeLookup, xAccessor, yAccessor])
+
+  // Hybrid x/y readers passed to the frame as `xAccessor` /
+  // `yAccessor`. On synthesized line-coord objects (which carry
+  // `COORD_X_KEY` / `COORD_Y_KEY`) we read the stable keys; on
+  // anything else (nodes / user-shaped data) we fall back to the
+  // user's accessor. This is the integration point that lets
+  // FlowMap accept function accessors — the synthesized coords
+  // never have to satisfy a user-defined function shape.
+  const xReader = useMemo(() => {
+    const userRead = typeof xAccessor === "function"
+      ? xAccessor
+      : (d: Datum) => d[xAccessor as string]
+    return (d: Datum) => {
+      if (d != null && typeof d === "object" && COORD_X_KEY in d) return d[COORD_X_KEY]
+      return userRead(d)
+    }
+  }, [xAccessor])
+
+  const yReader = useMemo(() => {
+    const userRead = typeof yAccessor === "function"
+      ? yAccessor
+      : (d: Datum) => d[yAccessor as string]
+    return (d: Datum) => {
+      if (d != null && typeof d === "object" && COORD_Y_KEY in d) return d[COORD_Y_KEY]
+      return userRead(d)
+    }
+  }, [yAccessor])
 
   // Edge width scale
   const widthScale = useMemo(() => {
@@ -515,8 +557,8 @@ export const FlowMap = forwardRef(function FlowMap<TDatum extends Datum = Datum>
     // supplied we hand the translated `lineData` over as usual.
     ...(flows != null && { lines: lineData }),
     points: safeNodes,
-    xAccessor: xAccessor as any,
-    yAccessor: yAccessor as any,
+    xAccessor: xReader as any,
+    yAccessor: yReader as any,
     lineDataAccessor: "coordinates",
     ...(lineIdAccessor != null && { lineIdAccessor }),
     lineType,

--- a/src/components/charts/network/ChordDiagram.tsx
+++ b/src/components/charts/network/ChordDiagram.tsx
@@ -1,6 +1,5 @@
 "use client"
 import type { Datum } from "../shared/datumTypes"
-import { filterSparseArray } from "../shared/sparseArray"
 import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
 import * as React from "react"
 import { useMemo, forwardRef, useRef } from "react"
@@ -10,12 +9,13 @@ import type { RealtimeFrameHandle } from "../../realtime/types"
 import { getColor, COLOR_SCHEMES, DEFAULT_COLORS } from "../shared/colorUtils"
 import type { BaseChartProps, ChartAccessor } from "../shared/types"
 import { normalizeTooltip, type TooltipProp } from "../../Tooltip/Tooltip"
-import { inferNodesFromEdges, createEdgeStyleFn } from "../shared/networkUtils"
-import { useColorScale, useChartMode, useChartSelection, useLegendInteraction, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { createEdgeStyleFn } from "../shared/networkUtils"
+import { useChartMode, resolveDefaultFill } from "../shared/hooks"
 import type { LegendInteractionMode } from "../shared/hooks"
+import { useNetworkChartSetup } from "../shared/useNetworkChartSetup"
 import { mergeShapeStyle } from "../shared/mergeShapeStyle"
 import ChartError from "../shared/ChartError"
-import { SafeRender, renderEmptyState, renderLoadingState } from "../shared/withChartWrapper"
+import { SafeRender } from "../shared/withChartWrapper"
 import { validateNetworkData } from "../shared/validateChartData"
 
 /**
@@ -141,56 +141,41 @@ export const ChordDiagram = forwardRef(function ChordDiagram<TNode extends Datum
 
   const { width, height, enableHover, showLabels = true, title, description, summary, accessibleTable } = resolved
 
-  // Identity-preserving sparse-array filter for both edges and nodes
-  // before downstream iteration (`inferNodesFromEdges`, color extraction).
-  const safeEdges = useMemo(() => filterSparseArray(edges), [edges])
-  const safeInputNodes = useMemo(() => filterSparseArray(nodes), [nodes])
-
-  // ── Loading / empty states (computed early, returned after all hooks) ───
-  // Drive empty-state off the filtered edge list so a sparse-only
-  // `[null, undefined]` triggers the empty UI instead of a blank chord.
-  const loadingEl = renderLoadingState(loading, width, height)
-  const emptyEl = !loadingEl
-    ? renderEmptyState(edges === undefined ? undefined : safeEdges, width, height, emptyContent)
-    : null
-
-  // Infer nodes from edges if not provided
-  const inferredNodes = useMemo(
-    () => inferNodesFromEdges(safeInputNodes, safeEdges, sourceAccessor, targetAccessor),
-    [safeInputNodes, safeEdges, sourceAccessor, targetAccessor]
-  )
-
-  const colorScale = useColorScale(inferredNodes, colorBy, colorScheme)
-
-  // Legend interaction
-  const allCategories = useMemo(() => {
-    if (!colorBy) return []
-    const vals = new Set<string>()
-    for (const d of inferredNodes as Datum[]) {
-      const v = typeof colorBy === "function" ? colorBy(d) : d[colorBy as string]
-      if (v != null) vals.add(String(v))
-    }
-    return Array.from(vals)
-  }, [inferredNodes, colorBy])
-
-  const legendState = useLegendInteraction(legendInteraction, colorBy, allCategories)
-
-  // Theme-aware default fill: ThemeProvider categorical > colorScheme > DEFAULT_COLOR
-  const themeCategorical = useThemeCategorical()
+  // Consolidated network setup. ChordDiagram doesn't have a top-level
+  // `showLegend` prop — its legend is the `legendInteraction`-driven
+  // hover/isolate behavior — so pass `showLegend: false` to suppress
+  // the hook's auto-legend (and thus the legend-aware margin
+  // reservation), matching the pre-migration manual margin.
+  const setup = useNetworkChartSetup({
+    nodes,
+    edges,
+    inferNodes: true,
+    nodeIdAccessor,
+    sourceAccessor,
+    targetAccessor,
+    colorBy,
+    colorScheme,
+    showLegend: false,
+    legendInteraction,
+    selection,
+    linkedHover,
+    onObservation,
+    onClick,
+    chartType: "ChordDiagram",
+    chartId,
+    marginDefaults: resolved.marginDefaults,
+    userMargin,
+    width, height,
+    loading,
+    emptyContent,
+  })
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [])
-
-  const effectivePalette = useMemo(() => {
-    if (Array.isArray(colorScheme)) return colorScheme
-    if (themeCategorical && themeCategorical.length > 0) return themeCategorical
-    const resolved = COLOR_SCHEMES[colorScheme as keyof typeof COLOR_SCHEMES]
-    return Array.isArray(resolved) ? resolved as string[] : DEFAULT_COLORS as unknown as string[]
-  }, [colorScheme, themeCategorical])
 
   // When data is empty (push API, no edges at mount), the HOC's colorScale
   // is built from zero data points and returns "#999" for everything.
   // In that case, skip passing nodeStyle/edgeStyle so the chord layout
   // plugin's built-in nodeColorMap palette handles coloring per node index.
-  const hasColorData = inferredNodes.length > 0
+  const hasColorData = setup.safeNodes.length > 0
 
   // Node style function — d is a RealtimeNode, user data on d.data
   const baseNodeStyle = useMemo(() => {
@@ -201,7 +186,7 @@ export const ChordDiagram = forwardRef(function ChordDiagram<TNode extends Datum
         strokeWidth: 1
       }
       if (colorBy) {
-        baseStyle.fill = getColor(d.data || d, colorBy, colorScale)
+        baseStyle.fill = getColor(d.data || d, colorBy, setup.colorScale)
       } else {
         const palette = Array.isArray(colorScheme) ? colorScheme : (COLOR_SCHEMES[colorScheme as keyof typeof COLOR_SCHEMES] || DEFAULT_COLORS)
         const colors = Array.isArray(palette) ? palette : DEFAULT_COLORS
@@ -210,7 +195,7 @@ export const ChordDiagram = forwardRef(function ChordDiagram<TNode extends Datum
       }
       return baseStyle
     }
-  }, [hasColorData, colorBy, colorScale, colorScheme])
+  }, [hasColorData, colorBy, setup.colorScale, colorScheme])
 
   // Overlay top-level primitive props (stroke/strokeWidth/opacity) last.
   const nodeStyle = useMemo(
@@ -224,12 +209,12 @@ export const ChordDiagram = forwardRef(function ChordDiagram<TNode extends Datum
     return createEdgeStyleFn({
       edgeColorBy,
       colorBy,
-      colorScale,
-      nodeStyleFn: nodeStyle || ((_d: Datum) => ({ fill: resolveDefaultFill(undefined, themeCategorical, colorScheme, undefined, categoryIndexMap) })),
+      colorScale: setup.colorScale,
+      nodeStyleFn: nodeStyle || ((_d: Datum) => ({ fill: resolveDefaultFill(undefined, setup.themeCategorical, colorScheme, undefined, categoryIndexMap) })),
       edgeOpacity,
       baseStyle: { stroke: "black", strokeWidth: 0.5, strokeOpacity: edgeOpacity }
     })
-  }, [hasColorData, edgeColorBy, colorBy, colorScale, nodeStyle, edgeOpacity, themeCategorical, colorScheme, categoryIndexMap])
+  }, [hasColorData, edgeColorBy, colorBy, setup.colorScale, nodeStyle, edgeOpacity, setup.themeCategorical, colorScheme, categoryIndexMap])
 
   const edgeStyle = useMemo(
     () => baseEdgeStyle ? mergeShapeStyle(baseEdgeStyle, { stroke, strokeWidth, opacity }) : undefined,
@@ -245,15 +230,6 @@ export const ChordDiagram = forwardRef(function ChordDiagram<TNode extends Datum
     return (d: Datum) => d.data?.[accessor] ?? d[accessor] ?? d.id
   }, [showLabels, nodeLabel, nodeIdAccessor])
 
-  // Margin
-  const margin = { ...resolved.marginDefaults, ...(typeof userMargin === "number" ? { top: userMargin, bottom: userMargin, left: userMargin, right: userMargin } : userMargin) }
-
-  const { customHoverBehavior, customClickBehavior } = useChartSelection({
-    selection, linkedHover,
-    fallbackFields: colorBy ? [typeof colorBy === "string" ? colorBy : ""] : [],
-    unwrapData: true, onObservation, onClick, chartType: "ChordDiagram", chartId,
-  })
-
   // Validate
   const error = validateNetworkData({
     componentName: "ChordDiagram",
@@ -263,20 +239,20 @@ export const ChordDiagram = forwardRef(function ChordDiagram<TNode extends Datum
   if (error) return <ChartError componentName="ChordDiagram" message={error} width={width} height={height} />
 
   // ── Loading / empty guards (deferred to after all hooks) ───────────────
-  if (loadingEl) return loadingEl
-  if (emptyEl) return emptyEl
+  if (setup.loadingEl) return setup.loadingEl
+  if (setup.emptyEl) return setup.emptyEl
 
   return (
     <SafeRender componentName="ChordDiagram" width={width} height={height}>
     <StreamNetworkFrame
       ref={frameRef}
       chartType="chord"
-      {...(inferredNodes.length > 0 && { nodes: inferredNodes })}
-      {...(edges != null && { edges: safeEdges })}
+      {...(setup.safeNodes.length > 0 && { nodes: setup.safeNodes })}
+      {...(edges != null && { edges: setup.safeEdges })}
       size={[width, height]}
       responsiveWidth={props.responsiveWidth}
       responsiveHeight={props.responsiveHeight}
-      margin={margin}
+      margin={setup.margin}
       nodeIDAccessor={nodeIdAccessor}
       sourceAccessor={sourceAccessor}
       targetAccessor={targetAccessor}
@@ -287,20 +263,20 @@ export const ChordDiagram = forwardRef(function ChordDiagram<TNode extends Datum
       nodeStyle={nodeStyle}
       edgeStyle={edgeStyle}
       colorBy={colorBy}
-      colorScheme={effectivePalette}
+      colorScheme={setup.effectivePalette}
       edgeColorBy={edgeColorBy}
       edgeOpacity={edgeOpacity}
       nodeLabel={nodeLabelFn}
       showLabels={showLabels}
       enableHover={enableHover}
       tooltipContent={tooltip === false ? () => null : (normalizeTooltip(tooltip) || undefined)}
-      customHoverBehavior={(linkedHover || onObservation || onClick) ? customHoverBehavior : undefined}
-      customClickBehavior={(onObservation || onClick) ? customClickBehavior : undefined}
+      customHoverBehavior={(linkedHover || onObservation || onClick) ? setup.customHoverBehavior : undefined}
+      customClickBehavior={(onObservation || onClick) ? setup.customClickBehavior : undefined}
       {...(legendInteraction && legendInteraction !== "none" && {
-        legendHoverBehavior: legendState.onLegendHover,
-        legendClickBehavior: legendState.onLegendClick,
-        legendHighlightedCategory: legendState.highlightedCategory,
-        legendIsolatedCategories: legendState.isolatedCategories,
+        legendHoverBehavior: setup.legendState.onLegendHover,
+        legendClickBehavior: setup.legendState.onLegendClick,
+        legendHighlightedCategory: setup.legendState.highlightedCategory,
+        legendIsolatedCategories: setup.legendState.isolatedCategories,
       })}
       className={className}
       title={title}

--- a/src/components/charts/network/CirclePack.tsx
+++ b/src/components/charts/network/CirclePack.tsx
@@ -4,15 +4,16 @@ import * as React from "react"
 import { useMemo } from "react"
 import StreamNetworkFrame from "../../stream/StreamNetworkFrame"
 import type { StreamNetworkFrameProps } from "../../stream/networkTypes"
-import { getColor, DEPTH_PALETTE_COLORS, COLOR_SCHEMES, DEFAULT_COLORS } from "../shared/colorUtils"
+import { getColor, DEPTH_PALETTE_COLORS } from "../shared/colorUtils"
 import { flattenHierarchy, resolveHierarchySum } from "../shared/networkUtils"
 import type { BaseChartProps, ChartAccessor } from "../shared/types"
 import { normalizeTooltip, type TooltipProp } from "../../Tooltip/Tooltip"
-import { useChartMode, useChartSelection, useColorScale, useLegendInteraction, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { useChartMode, resolveDefaultFill } from "../shared/hooks"
 import type { LegendInteractionMode } from "../shared/hooks"
+import { useNetworkChartSetup } from "../shared/useNetworkChartSetup"
 import { mergeShapeStyle } from "../shared/mergeShapeStyle"
 import ChartError from "../shared/ChartError"
-import { SafeRender, renderLoadingState } from "../shared/withChartWrapper"
+import { SafeRender } from "../shared/withChartWrapper"
 import { validateObjectData } from "../shared/validateChartData"
 
 /**
@@ -118,38 +119,34 @@ export function CirclePack<TNode extends Datum = Datum>(props: CirclePackProps<T
 
   const { width, height, enableHover, showLabels = true, title, description, summary, accessibleTable } = resolved
 
-  // ── Loading state (computed early, returned after all hooks) ─────────────
-  const loadingEl = renderLoadingState(loading, width, height)
-
   const allNodes = useMemo(() => {
     return flattenHierarchy(data ?? null, childrenAccessor as string | ((d: Datum) => any[]))
   }, [data, childrenAccessor])
 
-  const colorScale = useColorScale(allNodes, colorByDepth ? undefined : colorBy, colorScheme)
-
-  // Legend interaction
-  const allCategories = useMemo(() => {
-    if (!colorBy || colorByDepth) return []
-    const vals = new Set<string>()
-    for (const d of allNodes as Datum[]) {
-      const v = typeof colorBy === "function" ? colorBy(d) : d[colorBy as string]
-      if (v != null) vals.add(String(v))
-    }
-    return Array.from(vals)
-  }, [allNodes, colorBy, colorByDepth])
-
-  const legendState = useLegendInteraction(legendInteraction, colorByDepth ? undefined : colorBy as string | ((d: Datum) => string) | undefined, allCategories)
-
-  // Theme-aware default fill: ThemeProvider categorical > colorScheme > DEFAULT_COLOR
-  const themeCategorical = useThemeCategorical()
+  // Consolidated network setup. Same shape as Treemap's migration —
+  // hierarchy charts feed flattened descendants into the hook with
+  // node inference off, so colorScale / categories / legend state /
+  // selection wiring all funnel through one call.
+  const setup = useNetworkChartSetup({
+    nodes: allNodes,
+    edges: undefined,
+    inferNodes: false,
+    colorBy: colorByDepth ? undefined : (colorBy as string | ((d: Datum) => string) | undefined),
+    colorScheme,
+    showLegend: false,
+    legendInteraction,
+    selection,
+    linkedHover,
+    onObservation,
+    onClick,
+    chartType: "CirclePack",
+    chartId,
+    marginDefaults: resolved.marginDefaults,
+    userMargin,
+    width, height,
+    loading,
+  })
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [])
-
-  const effectivePalette = useMemo(() => {
-    if (Array.isArray(colorScheme)) return colorScheme
-    if (themeCategorical && themeCategorical.length > 0) return themeCategorical
-    const resolved = COLOR_SCHEMES[colorScheme as keyof typeof COLOR_SCHEMES]
-    return Array.isArray(resolved) ? resolved as string[] : DEFAULT_COLORS as unknown as string[]
-  }, [colorScheme, themeCategorical])
 
   const baseNodeStyleFn = useMemo(() => {
     return (d: Datum) => {
@@ -162,13 +159,13 @@ export function CirclePack<TNode extends Datum = Datum>(props: CirclePackProps<T
       if (colorByDepth) {
         baseStyle.fill = DEPTH_PALETTE_COLORS[(d.depth || 0) % DEPTH_PALETTE_COLORS.length]
       } else if (colorBy) {
-        baseStyle.fill = getColor(d.data || d, colorBy as string | ((d: Datum) => string), colorScale)
+        baseStyle.fill = getColor(d.data || d, colorBy as string | ((d: Datum) => string), setup.colorScale)
       } else {
-        baseStyle.fill = resolveDefaultFill(undefined, themeCategorical, colorScheme, undefined, categoryIndexMap)
+        baseStyle.fill = resolveDefaultFill(undefined, setup.themeCategorical, colorScheme, undefined, categoryIndexMap)
       }
       return baseStyle
     }
-  }, [colorBy, colorByDepth, colorScale, circleOpacity, themeCategorical, colorScheme, categoryIndexMap])
+  }, [colorBy, colorByDepth, setup.colorScale, circleOpacity, setup.themeCategorical, colorScheme, categoryIndexMap])
 
   const nodeStyleFn = useMemo(
     () => mergeShapeStyle(baseNodeStyleFn, { stroke, strokeWidth, opacity }),
@@ -179,21 +176,12 @@ export function CirclePack<TNode extends Datum = Datum>(props: CirclePackProps<T
     return resolveHierarchySum(valueAccessor)
   }, [valueAccessor])
 
-  // Margin
-  const margin = { ...resolved.marginDefaults, ...(typeof userMargin === "number" ? { top: userMargin, bottom: userMargin, left: userMargin, right: userMargin } : userMargin) }
-
-  const { customHoverBehavior, customClickBehavior } = useChartSelection({
-    selection, linkedHover,
-    fallbackFields: colorBy ? [typeof colorBy === "string" ? colorBy : ""] : [],
-    unwrapData: true, onObservation, onClick, chartType: "CirclePack", chartId,
-  })
-
   // Validate
   const error = validateObjectData({ componentName: "CirclePack", data })
   if (error) return <ChartError componentName="CirclePack" message={error} width={width} height={height} />
 
   // ── Loading guard (deferred to after all hooks) ────────────────────────
-  if (loadingEl) return loadingEl
+  if (setup.loadingEl) return setup.loadingEl
 
   return (
     <SafeRender componentName="CirclePack" width={width} height={height}>
@@ -203,26 +191,26 @@ export function CirclePack<TNode extends Datum = Datum>(props: CirclePackProps<T
       size={[width, height]}
       responsiveWidth={props.responsiveWidth}
       responsiveHeight={props.responsiveHeight}
-      margin={margin}
+      margin={setup.margin}
       nodeIDAccessor={nodeIdAccessor}
       childrenAccessor={childrenAccessor}
       hierarchySum={hierarchySumFn}
       padding={paddingProp}
       nodeStyle={nodeStyleFn}
       colorBy={colorBy}
-      colorScheme={effectivePalette}
+      colorScheme={setup.effectivePalette}
       colorByDepth={colorByDepth}
       nodeLabel={showLabels ? (nodeLabel || nodeIdAccessor) : undefined}
       showLabels={showLabels}
       enableHover={enableHover}
       tooltipContent={tooltip === false ? () => null : (normalizeTooltip(tooltip) || undefined)}
-      customHoverBehavior={(linkedHover || onObservation || onClick) ? customHoverBehavior : undefined}
-      customClickBehavior={(onObservation || onClick) ? customClickBehavior : undefined}
+      customHoverBehavior={(linkedHover || onObservation || onClick) ? setup.customHoverBehavior : undefined}
+      customClickBehavior={(onObservation || onClick) ? setup.customClickBehavior : undefined}
       {...(legendInteraction && legendInteraction !== "none" && {
-        legendHoverBehavior: legendState.onLegendHover,
-        legendClickBehavior: legendState.onLegendClick,
-        legendHighlightedCategory: legendState.highlightedCategory,
-        legendIsolatedCategories: legendState.isolatedCategories,
+        legendHoverBehavior: setup.legendState.onLegendHover,
+        legendClickBehavior: setup.legendState.onLegendClick,
+        legendHighlightedCategory: setup.legendState.highlightedCategory,
+        legendIsolatedCategories: setup.legendState.isolatedCategories,
       })}
       className={className}
       title={title}

--- a/src/components/charts/network/ForceDirectedGraph.tsx
+++ b/src/components/charts/network/ForceDirectedGraph.tsx
@@ -1,20 +1,20 @@
 "use client"
 import type { Datum } from "../shared/datumTypes"
-import { filterSparseArray } from "../shared/sparseArray"
 import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
 import * as React from "react"
 import { useMemo, forwardRef, useRef } from "react"
 import StreamNetworkFrame from "../../stream/StreamNetworkFrame"
 import type { StreamNetworkFrameProps, StreamNetworkFrameHandle } from "../../stream/networkTypes"
 import type { RealtimeFrameHandle } from "../../realtime/types"
-import { getColor, COLOR_SCHEMES, DEFAULT_COLORS } from "../shared/colorUtils"
+import { getColor } from "../shared/colorUtils"
 import type { BaseChartProps, ChartAccessor } from "../shared/types"
 import { normalizeTooltip, type TooltipProp } from "../../Tooltip/Tooltip"
-import { useColorScale, useChartLegendAndMargin, useChartMode, useChartSelection, useLegendInteraction, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { useChartMode, resolveDefaultFill } from "../shared/hooks"
 import type { LegendInteractionMode, LegendPosition } from "../shared/hooks"
+import { useNetworkChartSetup } from "../shared/useNetworkChartSetup"
 import { mergeShapeStyle } from "../shared/mergeShapeStyle"
 import ChartError from "../shared/ChartError"
-import { SafeRender, renderEmptyState, renderLoadingState } from "../shared/withChartWrapper"
+import { SafeRender } from "../shared/withChartWrapper"
 import { validateNetworkData } from "../shared/validateChartData"
 
 /**
@@ -239,63 +239,53 @@ export const ForceDirectedGraph = forwardRef(function ForceDirectedGraph<TNode e
 
   const { width, height, enableHover, showLegend, showLabels = false, title, description, summary, accessibleTable } = resolved
 
-  // Identity-preserving sparse-array filter: drop `null`/non-object
-  // entries before any iteration. CSV/loader pipelines commonly emit
-  // such interlopers, and the network color/legend/scene paths read
-  // `n.id` / `e.source` without null-checks.
-  const safeNodes = useMemo(() => filterSparseArray(nodes), [nodes])
-  const safeEdges = useMemo(() => filterSparseArray(edges), [edges])
+  // Consolidated network setup. ForceDirected requires explicit
+  // nodes (no inference from edges) and keys empty-state off nodes
+  // — pass `inferNodes: false` and `emptyDataKey: "nodes"` to match
+  // the pre-migration behavior.
+  const setup = useNetworkChartSetup({
+    nodes,
+    edges,
+    inferNodes: false,
+    nodeIdAccessor: nodeIDAccessor,
+    sourceAccessor,
+    targetAccessor,
+    colorBy,
+    colorScheme,
+    showLegend,
+    legendPosition: legendPositionProp,
+    legendInteraction,
+    selection,
+    linkedHover,
+    onObservation,
+    onClick,
+    chartType: "ForceDirectedGraph",
+    chartId,
+    marginDefaults: resolved.marginDefaults,
+    userMargin,
+    width, height,
+    loading,
+    emptyContent,
+    emptyDataKey: "nodes",
+  })
 
-  // ── Loading / empty states (computed early, returned after all hooks) ───
-  // Drive the empty-state decision off the filtered node list so a
-  // sparse-only input like `[null, undefined]` lands on the empty UI
-  // instead of rendering a blank canvas.
-  const loadingEl = renderLoadingState(loading, width, height)
-  const emptyEl = !loadingEl
-    ? renderEmptyState(nodes === undefined ? undefined : safeNodes, width, height, emptyContent)
-    : null
-
-  const colorScale = useColorScale(safeNodes, colorBy, colorScheme)
-
-  // Legend interaction
-  const allCategories = useMemo(() => {
-    if (!colorBy) return []
-    const vals = new Set<string>()
-    for (const d of safeNodes as Datum[]) {
-      const v = typeof colorBy === "function" ? colorBy(d) : d[colorBy as string]
-      if (v != null) vals.add(String(v))
-    }
-    return Array.from(vals)
-  }, [safeNodes, colorBy])
-
-  const legendState = useLegendInteraction(legendInteraction, colorBy, allCategories)
-
-  // Theme-aware default fill: ThemeProvider categorical > colorScheme > DEFAULT_COLOR
-  const themeCategorical = useThemeCategorical()
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [])
-
-  const effectivePalette = useMemo(() => {
-    if (Array.isArray(colorScheme)) return colorScheme
-    if (themeCategorical && themeCategorical.length > 0) return themeCategorical
-    const resolved = COLOR_SCHEMES[colorScheme as keyof typeof COLOR_SCHEMES]
-    return Array.isArray(resolved) ? resolved as string[] : DEFAULT_COLORS as unknown as string[]
-  }, [colorScheme, themeCategorical])
 
   // Node style function — d is a RealtimeNode, user data on d.data
   const baseNodeStyle = useMemo(() => {
     return (d: Datum) => {
       const baseStyle: Record<string, string | number> = {}
       if (colorBy) {
-        baseStyle.fill = getColor(d.data || d, colorBy, colorScale)
+        baseStyle.fill = getColor(d.data || d, colorBy, setup.colorScale)
       } else {
-        baseStyle.fill = resolveDefaultFill(undefined, themeCategorical, colorScheme, undefined, categoryIndexMap)
+        baseStyle.fill = resolveDefaultFill(undefined, setup.themeCategorical, colorScheme, undefined, categoryIndexMap)
       }
       if (typeof nodeSize === "number") {
         baseStyle.r = nodeSize
       }
       return baseStyle
     }
-  }, [colorBy, colorScale, nodeSize, themeCategorical, colorScheme, categoryIndexMap])
+  }, [colorBy, setup.colorScale, nodeSize, setup.themeCategorical, colorScheme, categoryIndexMap])
 
   // Overlay top-level primitive props onto nodeStyle; top-level wins over base.
   const nodeStyle = useMemo(
@@ -326,25 +316,6 @@ export const ForceDirectedGraph = forwardRef(function ForceDirectedGraph<TNode e
     return (d: Datum) => d.data?.[nodeLabel] ?? d[nodeLabel] ?? d.id
   }, [showLabels, nodeLabel])
 
-  // Legend & margin
-  const { legend, margin, legendPosition } = useChartLegendAndMargin({
-    data: safeNodes,
-    colorBy,
-    colorScale,
-    showLegend,
-    legendPosition: legendPositionProp,
-    userMargin,
-    defaults: resolved.marginDefaults
-  })
-
-  const { customHoverBehavior, customClickBehavior } = useChartSelection({
-    selection,
-    linkedHover,
-    fallbackFields: colorBy ? [typeof colorBy === "string" ? colorBy : ""] : [],
-    unwrapData: true,
-    onObservation, onClick, chartType: "ForceDirectedGraph", chartId,
-  })
-
   // Validate
   const error = validateNetworkData({
     componentName: "ForceDirectedGraph",
@@ -357,20 +328,20 @@ export const ForceDirectedGraph = forwardRef(function ForceDirectedGraph<TNode e
   if (error) return <ChartError componentName="ForceDirectedGraph" message={error} width={width} height={height} />
 
   // ── Loading / empty guards (deferred to after all hooks) ───────────────
-  if (loadingEl) return loadingEl
-  if (emptyEl) return emptyEl
+  if (setup.loadingEl) return setup.loadingEl
+  if (setup.emptyEl) return setup.emptyEl
 
   return (
     <SafeRender componentName="ForceDirectedGraph" width={width} height={height}>
     <StreamNetworkFrame
       ref={frameRef}
       chartType="force"
-      {...(nodes != null && { nodes: safeNodes })}
-      {...(edges != null && { edges: safeEdges })}
+      {...(nodes != null && { nodes: setup.safeNodes })}
+      {...(edges != null && { edges: setup.safeEdges })}
       size={[width, height]}
       responsiveWidth={props.responsiveWidth}
       responsiveHeight={props.responsiveHeight}
-      margin={margin}
+      margin={setup.margin}
       nodeIDAccessor={nodeIDAccessor}
       sourceAccessor={sourceAccessor}
       targetAccessor={targetAccessor}
@@ -379,22 +350,22 @@ export const ForceDirectedGraph = forwardRef(function ForceDirectedGraph<TNode e
       nodeStyle={nodeStyle}
       edgeStyle={edgeStyle}
       colorBy={colorBy}
-      colorScheme={effectivePalette}
+      colorScheme={setup.effectivePalette}
       nodeSize={nodeSize}
       nodeSizeRange={nodeSizeRange}
       nodeLabel={nodeLabelFn}
       showLabels={showLabels}
       enableHover={enableHover}
       tooltipContent={tooltip === false ? () => null : (normalizeTooltip(tooltip) || undefined)}
-      customHoverBehavior={(linkedHover || onObservation || onClick) ? customHoverBehavior : undefined}
-      customClickBehavior={(onObservation || onClick) ? customClickBehavior : undefined}
-      legend={legend}
-      legendPosition={legendPosition}
+      customHoverBehavior={(linkedHover || onObservation || onClick) ? setup.customHoverBehavior : undefined}
+      customClickBehavior={(onObservation || onClick) ? setup.customClickBehavior : undefined}
+      legend={setup.legend}
+      legendPosition={setup.legendPosition}
       {...(legendInteraction && legendInteraction !== "none" && {
-        legendHoverBehavior: legendState.onLegendHover,
-        legendClickBehavior: legendState.onLegendClick,
-        legendHighlightedCategory: legendState.highlightedCategory,
-        legendIsolatedCategories: legendState.isolatedCategories,
+        legendHoverBehavior: setup.legendState.onLegendHover,
+        legendClickBehavior: setup.legendState.onLegendClick,
+        legendHighlightedCategory: setup.legendState.highlightedCategory,
+        legendIsolatedCategories: setup.legendState.isolatedCategories,
       })}
       className={className}
       title={title}

--- a/src/components/charts/network/OrbitDiagram.tsx
+++ b/src/components/charts/network/OrbitDiagram.tsx
@@ -8,10 +8,11 @@ import { getColor, DEPTH_PALETTE_COLORS, DEFAULT_COLORS, COLOR_SCHEMES } from ".
 import { flattenHierarchy } from "../shared/networkUtils"
 import type { BaseChartProps } from "../shared/types"
 import { normalizeTooltip, type TooltipProp } from "../../Tooltip/Tooltip"
-import { useChartMode, useChartSelection, useColorScale, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { useChartMode, resolveDefaultFill } from "../shared/hooks"
+import { useNetworkChartSetup } from "../shared/useNetworkChartSetup"
 import { mergeShapeStyle } from "../shared/mergeShapeStyle"
 import ChartError from "../shared/ChartError"
-import { SafeRender, renderLoadingState } from "../shared/withChartWrapper"
+import { SafeRender } from "../shared/withChartWrapper"
 import { validateObjectData } from "../shared/validateChartData"
 
 // ── Orbit layout types (kept for API compatibility) ──────────────────
@@ -184,26 +185,35 @@ export function OrbitDiagram<TDatum extends Datum = Datum>(
 
   const { width, height, enableHover, title, description, summary, accessibleTable } = resolved
 
-  // ── Loading state (computed early, returned after all hooks) ─────────────
-  const loadingEl = renderLoadingState(loading, width, height)
-
   // ── Flatten for color scale ──────────────────────────────────────────────
   const allNodes = useMemo(() => {
     return flattenHierarchy(data, childrenAccessor as string | ((d: Datum) => any[]))
   }, [data, childrenAccessor])
 
-  const colorScale = useColorScale(allNodes, colorByDepth ? undefined : colorBy, colorScheme)
-
-  // Theme-aware default fill: ThemeProvider categorical > colorScheme > DEFAULT_COLOR
-  const themeCategorical = useThemeCategorical()
+  // Consolidated network setup. OrbitDiagram uses tighter margin
+  // defaults (10px on all sides) than the standard chart-mode
+  // defaults — pass them through so the hook's margin reservation
+  // honors the legacy spacing instead of the standard chart-grid one.
+  const setup = useNetworkChartSetup({
+    nodes: allNodes,
+    edges: undefined,
+    inferNodes: false,
+    colorBy: colorByDepth ? undefined : (colorBy as string | ((d: Datum) => string) | undefined),
+    colorScheme,
+    showLegend: false,             // no top-level legend
+    legendInteraction: undefined,
+    selection,
+    linkedHover,
+    onObservation,
+    onClick,
+    chartType: "OrbitDiagram",
+    chartId,
+    marginDefaults: { top: 10, right: 10, bottom: 10, left: 10 },
+    userMargin,
+    width, height,
+    loading,
+  })
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [])
-
-  const effectivePalette = useMemo(() => {
-    if (Array.isArray(colorScheme)) return colorScheme
-    if (themeCategorical && themeCategorical.length > 0) return themeCategorical
-    const resolved = COLOR_SCHEMES[colorScheme as keyof typeof COLOR_SCHEMES]
-    return Array.isArray(resolved) ? resolved as string[] : DEFAULT_COLORS as unknown as string[]
-  }, [colorScheme, themeCategorical])
 
   // ── Node style — d is a RealtimeNode, user data on d.data ───────────────
   // Resolve the scheme colors array for root node coloring
@@ -223,14 +233,14 @@ export function OrbitDiagram<TDatum extends Datum = Datum>(
           ? schemeColors[0]
           : DEPTH_COLORS[(d.depth || 0) % DEPTH_COLORS.length]
       } else if (colorBy) {
-        baseStyle.fill = getColor(d.data || d, colorBy as string | ((d: Datum) => string), colorScale)
+        baseStyle.fill = getColor(d.data || d, colorBy as string | ((d: Datum) => string), setup.colorScale)
       } else {
-        baseStyle.fill = resolveDefaultFill(undefined, themeCategorical, colorScheme, undefined, categoryIndexMap)
+        baseStyle.fill = resolveDefaultFill(undefined, setup.themeCategorical, colorScheme, undefined, categoryIndexMap)
       }
       baseStyle.opacity = isRoot ? 1 : 0.85
       return baseStyle
     }
-  }, [colorBy, colorByDepth, colorScale, schemeColors, themeCategorical, colorScheme, categoryIndexMap])
+  }, [colorBy, colorByDepth, setup.colorScale, schemeColors, setup.themeCategorical, colorScheme, categoryIndexMap])
 
   const nodeStyleFn = useMemo(
     () => mergeShapeStyle(baseNodeStyleFn, { stroke, strokeWidth, opacity }),
@@ -243,47 +253,36 @@ export function OrbitDiagram<TDatum extends Datum = Datum>(
     return () => ({ stroke: "rgba(128,128,128,0.35)", strokeWidth: 0.5, opacity: 1 })
   }, [])
 
-  // Margin
-  const margin = { top: 10, right: 10, bottom: 10, left: 10, ...(typeof userMargin === "number" ? { top: userMargin, bottom: userMargin, left: userMargin, right: userMargin } : userMargin) }
-
-  // Selection
-  const { customHoverBehavior, customClickBehavior } = useChartSelection({
-    selection, linkedHover,
-    fallbackFields: colorBy ? [typeof colorBy === "string" ? colorBy : ""] : [],
-    unwrapData: true,
-    onObservation, onClick, chartType: "OrbitDiagram", chartId,
-  })
-
   // Unwrap RealtimeNode wrapper — StreamNetworkFrame's hover payload has
   // data: RealtimeNode, and the user's raw datum is on RealtimeNode.data
   const wrappedHoverBehavior = useMemo(() => {
-    if (!customHoverBehavior) return undefined
+    if (!setup.customHoverBehavior) return undefined
     return (hover: any) => {
       if (hover && hover.data && hover.data.data !== undefined) {
-        customHoverBehavior({ ...hover, data: hover.data.data })
+        setup.customHoverBehavior({ ...hover, data: hover.data.data })
       } else {
-        customHoverBehavior(hover)
+        setup.customHoverBehavior(hover)
       }
     }
-  }, [customHoverBehavior])
+  }, [setup.customHoverBehavior])
 
   const wrappedClickBehavior = useMemo(() => {
-    if (!customClickBehavior) return undefined
+    if (!setup.customClickBehavior) return undefined
     return (click: any) => {
       if (click && click.data && click.data.data !== undefined) {
-        customClickBehavior({ ...click, data: click.data.data })
+        setup.customClickBehavior({ ...click, data: click.data.data })
       } else {
-        customClickBehavior(click)
+        setup.customClickBehavior(click)
       }
     }
-  }, [customClickBehavior])
+  }, [setup.customClickBehavior])
 
   // Validate
   const error = validateObjectData({ componentName: "OrbitDiagram", data })
   if (error) return <ChartError componentName="OrbitDiagram" message={error} width={width} height={height} />
 
   // ── Loading guard (deferred to after all hooks) ────────────────────────
-  if (loadingEl) return loadingEl
+  if (setup.loadingEl) return setup.loadingEl
 
   return (
     <SafeRender componentName="OrbitDiagram" width={width} height={height}>
@@ -293,13 +292,13 @@ export function OrbitDiagram<TDatum extends Datum = Datum>(
         size={[width, height]}
         responsiveWidth={props.responsiveWidth}
         responsiveHeight={props.responsiveHeight}
-        margin={margin}
+        margin={setup.margin}
         nodeIDAccessor={nodeIdAccessor}
         childrenAccessor={childrenAccessor as string | ((d: Datum) => any[])}
         nodeStyle={nodeStyleFn}
         edgeStyle={edgeStyleFn}
         colorBy={colorBy}
-        colorScheme={effectivePalette}
+        colorScheme={setup.effectivePalette}
         colorByDepth={colorByDepth}
         nodeSize={nodeRadiusProp}
         nodeLabel={showLabels ? nodeIdAccessor : undefined}

--- a/src/components/charts/network/ProcessSankey.tsx
+++ b/src/components/charts/network/ProcessSankey.tsx
@@ -24,12 +24,11 @@ import {
 import type { Datum } from "../shared/datumTypes"
 import type { BaseChartProps, ChartAccessor } from "../shared/types"
 import type { RealtimeFrameHandle, HoverData } from "../../realtime/types"
-import { useColorScale, useThemeCategorical } from "../shared/hooks"
-import { getColor, COLOR_SCHEMES, DEFAULT_COLORS } from "../shared/colorUtils"
+import { getColor } from "../shared/colorUtils"
 import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
+import { useNetworkChartSetup } from "../shared/useNetworkChartSetup"
 import { inferNodesFromEdges } from "../shared/networkUtils"
 import { filterSparseArray } from "../shared/sparseArray"
-import { renderLoadingState, renderEmptyState } from "../shared/withChartWrapper"
 import StreamNetworkFrame from "../../stream/StreamNetworkFrame"
 import type {
   StreamNetworkFrameProps,
@@ -524,20 +523,56 @@ export const ProcessSankey = forwardRef(function ProcessSankey<TNode extends Dat
     sourceAccessor, targetAccessor, valueAccessor, startTimeAccessor, endTimeAccessor,
   ])
 
-  // ── Margin: extend right/bottom for the legend just like the auto-legend hook does. ──
-  const legendActive = (showLegend ?? !!colorBy) && !!colorBy
+  // ── Consolidated network setup (aligned with SankeyDiagram et al). ──
+  // ProcessSankey shares the standard setup pieces with every other
+  // network HOC: sparse-filter, color scale, palette resolution,
+  // category extraction, legend interaction, selection/linkedHover
+  // wiring, and loading/empty states. The custom pieces — temporal
+  // scene specs, particles, axis chrome — stay below. We pass
+  // `inferNodes: false` because ProcessSankey requires explicit
+  // nodes (xExtent / category metadata can't be derived from edges)
+  // and `showLegend: false` so the hook skips its auto-legend
+  // (ProcessSankey builds its own swatch list using `colorOf` so
+  // the chart's palette-fallback behavior — visible bands when
+  // colorBy is unset — stays consistent between bands and legend).
+  const setup = useNetworkChartSetup({
+    nodes: rawNodes,
+    edges: rawEdges,
+    inferNodes: false,
+    nodeIdAccessor,
+    sourceAccessor,
+    targetAccessor,
+    colorBy,
+    colorScheme,
+    showLegend: false,                      // ProcessSankey owns the legend (see legendNode below)
+    legendPosition,
+    selection: undefined,                   // selection wiring not yet exposed; reserved
+    linkedHover: undefined,
+    onObservation,
+    onClick,
+    chartType: "ProcessSankey",
+    chartId,
+    marginDefaults: { top: 30, right: 80, bottom: 40, left: 80 },
+    userMargin,
+    width, height,
+    loading,
+    emptyContent,
+  })
 
+  // Margin extension for the legend. The setup hook's
+  // `useChartLegendAndMargin` is suppressed via `showLegend: false`,
+  // so we apply the same right/bottom reservation here that the hook
+  // would otherwise do — keeps the band/ribbon layout consistent
+  // whether the auto-legend or our custom legend is rendering.
+  const legendActive = (showLegend ?? !!colorBy) && !!colorBy
   const margin = useMemo(() => {
-    const base = { top: 30, right: 80, bottom: 40, left: 80 }
-    const merged = userMargin
-      ? { ...base, ...(userMargin as Record<string, number>) }
-      : base
+    const merged = { ...setup.margin }
     if (legendActive) {
       if (legendPosition === "right" && merged.right < 140) merged.right = 140
       else if (legendPosition === "bottom" && merged.bottom < 80) merged.bottom = 80
     }
     return merged
-  }, [userMargin, legendActive, legendPosition])
+  }, [setup.margin, legendActive, legendPosition])
 
   const plotW = width - margin.left - margin.right
   const plotH = height - margin.top - margin.bottom
@@ -553,22 +588,20 @@ export const ProcessSankey = forwardRef(function ProcessSankey<TNode extends Dat
   const xScale = useMemo(() => scaleTime().domain(domain).range([0, plotW]), [domain, plotW])
 
   // ── Color resolution ────────────────────────────────────────────────
-  const themeCategorical = useThemeCategorical()
-  const colorScale = useColorScale((rawNodes ?? []) as Datum[], colorBy as ChartAccessor<Datum, string> | undefined, colorScheme)
-  const palette = useMemo(() => {
-    if (Array.isArray(colorScheme)) return colorScheme
-    if (themeCategorical && themeCategorical.length > 0) return themeCategorical
-    const resolved = COLOR_SCHEMES[colorScheme as keyof typeof COLOR_SCHEMES]
-    return Array.isArray(resolved) ? resolved as string[] : DEFAULT_COLORS as unknown as string[]
-  }, [colorScheme, themeCategorical])
-
+  // `colorOf` falls through to the palette when colorBy is unset so
+  // each band gets a distinct color even without a categorical
+  // accessor — matches ProcessSankey's per-node visual identity.
+  // SankeyDiagram doesn't have this fallback (its bands collapse to
+  // a single theme color when colorBy is unset); the divergence
+  // is intentional because ProcessSankey is process-step coded
+  // and visual differentiation per node matters more.
   const colorOf = useCallback((id: string, idx: number): string => {
     if (colorBy && rawNodes) {
       const raw = rawNodeById.get(id)
-      if (raw) return getColor(raw, colorBy as ChartAccessor<Datum, string>, colorScale) as string
+      if (raw) return getColor(raw, colorBy as ChartAccessor<Datum, string>, setup.colorScale) as string
     }
-    return palette[idx % palette.length] || "#475569"
-  }, [colorBy, rawNodes, rawNodeById, colorScale, palette])
+    return setup.effectivePalette[idx % setup.effectivePalette.length] || "#475569"
+  }, [colorBy, rawNodes, rawNodeById, setup.colorScale, setup.effectivePalette])
 
   // ── Build band + ribbon scene specs from layout output. ─────────────
   // These flow to the customNetworkLayout via layoutConfig — the layout
@@ -931,17 +964,13 @@ export const ProcessSankey = forwardRef(function ProcessSankey<TNode extends Dat
     [rawEdges, getEdgeId, sourceAccessor, targetAccessor],
   )
 
-  // ── Loading / empty states ────────────────────────────────────────
-  // Both helpers fire AFTER all hooks above so React doesn't see a
-  // hook-count change when the chart switches between
-  // empty/loading/active. Empty state triggers when neither edges nor
-  // nodes were supplied AND nothing's been pushed.
-  const loadingEl = renderLoadingState(loading, width, height)
-  const noUserData = (rawEdgesProp === undefined && pushedEdges.length === 0)
-    && (rawNodesProp === undefined && pushedNodes.length === 0)
-  const emptyEl = !loadingEl
-    ? renderEmptyState(noUserData ? undefined : safeFrameEdges, width, height, emptyContent)
-    : null
+  // Loading / empty states come from `setup` — same gates every
+  // other network HOC uses. The hook keys empty-state on the edges
+  // list (default), which matches ProcessSankey's primary data
+  // shape. Push-mode (edges/nodes both undefined) bypasses the
+  // empty UI by design.
+  const loadingEl = setup.loadingEl
+  const emptyEl = setup.emptyEl
 
   // ── Validation gate ──
   if (issues.length > 0) {

--- a/src/components/charts/network/SankeyDiagram.tsx
+++ b/src/components/charts/network/SankeyDiagram.tsx
@@ -1,22 +1,22 @@
 "use client"
 import type { Datum } from "../shared/datumTypes"
-import { filterSparseArray } from "../shared/sparseArray"
 import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
 import * as React from "react"
 import { useMemo, forwardRef, useRef } from "react"
 import StreamNetworkFrame from "../../stream/StreamNetworkFrame"
 import type { StreamNetworkFrameProps, StreamNetworkFrameHandle } from "../../stream/networkTypes"
 import type { RealtimeFrameHandle } from "../../realtime/types"
-import { getColor, COLOR_SCHEMES, DEFAULT_COLORS } from "../shared/colorUtils"
+import { getColor } from "../shared/colorUtils"
 
 import type { BaseChartProps, ChartAccessor } from "../shared/types"
 import { normalizeTooltip, type TooltipProp } from "../../Tooltip/Tooltip"
-import { inferNodesFromEdges, createEdgeStyleFn } from "../shared/networkUtils"
-import { useColorScale, useChartMode, useChartSelection, useLegendInteraction, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { createEdgeStyleFn } from "../shared/networkUtils"
+import { useChartMode, resolveDefaultFill } from "../shared/hooks"
 import type { LegendInteractionMode } from "../shared/hooks"
+import { useNetworkChartSetup } from "../shared/useNetworkChartSetup"
 import { mergeShapeStyle } from "../shared/mergeShapeStyle"
 import ChartError from "../shared/ChartError"
-import { SafeRender, renderEmptyState, renderLoadingState } from "../shared/withChartWrapper"
+import { SafeRender } from "../shared/withChartWrapper"
 import { validateNetworkData } from "../shared/validateChartData"
 
 /**
@@ -163,58 +163,35 @@ export const SankeyDiagram = forwardRef(function SankeyDiagram<TNode extends Dat
 
   const { width, height, enableHover, showLabels = true, title, description, summary, accessibleTable } = resolved
 
-  // Safe data defaults (hooks must always run). Identity-preserving
-  // sparse-array filter drops `null`/non-object entries before any
-  // iteration; downstream `inferNodesFromEdges` and color paths
-  // dereference fields without null-checks.
-  const safeEdges = useMemo(() => filterSparseArray(edges), [edges])
-  const safeInputNodes = useMemo(() => filterSparseArray(nodes), [nodes])
-
-  // ── Loading / empty states (computed early, returned after all hooks) ───
-  // Drive empty-state off the filtered edge list so a sparse-only
-  // `[null, undefined]` triggers the empty UI rather than rendering
-  // a blank chart over zero valid edges.
-  const loadingEl = renderLoadingState(loading, width, height)
-  const emptyEl = !loadingEl
-    ? renderEmptyState(edges === undefined ? undefined : safeEdges, width, height, emptyContent)
-    : null
-
-  // Infer nodes from edges if not provided
-  const inferredNodes = useMemo(
-    () => inferNodesFromEdges(safeInputNodes, safeEdges, sourceAccessor, targetAccessor),
-    [safeInputNodes, safeEdges, sourceAccessor, targetAccessor]
-  )
-
-  // Create color scale if colorBy is specified
-  const colorScale = useColorScale(inferredNodes, colorBy, colorScheme)
-
-  // Legend interaction
-  const allCategories = useMemo(() => {
-    if (!colorBy) return []
-    const vals = new Set<string>()
-    for (const d of inferredNodes as Datum[]) {
-      const v = typeof colorBy === "function" ? colorBy(d) : d[colorBy as string]
-      if (v != null) vals.add(String(v))
-    }
-    return Array.from(vals)
-  }, [inferredNodes, colorBy])
-
-  const legendState = useLegendInteraction(legendInteraction, colorBy, allCategories)
+  // Consolidated setup — sparse filtering, node inference, color
+  // scale, palette resolution, category extraction, legend
+  // interaction, margin/legend composition, and selection wiring.
+  const setup = useNetworkChartSetup({
+    nodes,
+    edges,
+    inferNodes: true,
+    nodeIdAccessor,
+    sourceAccessor,
+    targetAccessor,
+    colorBy,
+    colorScheme,
+    showLegend: undefined,        // SankeyDiagram doesn't expose a top-level showLegend; auto from colorBy
+    legendInteraction,
+    selection,
+    linkedHover,
+    onObservation,
+    onClick,
+    chartType: "SankeyDiagram",
+    chartId,
+    marginDefaults: resolved.marginDefaults,
+    userMargin,
+    width, height,
+    loading,
+    emptyContent,
+  })
 
   // Theme-aware default fill: ThemeProvider categorical > colorScheme > DEFAULT_COLOR
-  const themeCategorical = useThemeCategorical()
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [])
-
-  // Resolve the effective palette array. This is passed to StreamNetworkFrame so that
-  // its internal getNodeColor (used for particles, hover, interactions) uses the same
-  // colors as the HOC's nodeStyle. Without this, the frame only sees the raw colorScheme
-  // string and falls back to category10 regardless of ThemeProvider.
-  const effectivePalette = useMemo(() => {
-    if (Array.isArray(colorScheme)) return colorScheme
-    if (themeCategorical && themeCategorical.length > 0) return themeCategorical
-    const resolved = COLOR_SCHEMES[colorScheme as keyof typeof COLOR_SCHEMES]
-    return Array.isArray(resolved) ? resolved as string[] : DEFAULT_COLORS as unknown as string[]
-  }, [colorScheme, themeCategorical])
 
   // Node style function
   // d is a RealtimeNode — user data lives on d.data
@@ -226,14 +203,14 @@ export const SankeyDiagram = forwardRef(function SankeyDiagram<TNode extends Dat
       }
 
       if (colorBy) {
-        baseStyle.fill = getColor(d.data || d, colorBy, colorScale)
+        baseStyle.fill = getColor(d.data || d, colorBy, setup.colorScale)
       } else {
-        baseStyle.fill = resolveDefaultFill(undefined, themeCategorical, colorScheme, undefined, categoryIndexMap)
+        baseStyle.fill = resolveDefaultFill(undefined, setup.themeCategorical, colorScheme, undefined, categoryIndexMap)
       }
 
       return baseStyle
     }
-  }, [colorBy, colorScale, themeCategorical, colorScheme, categoryIndexMap])
+  }, [colorBy, setup.colorScale, setup.themeCategorical, colorScheme, categoryIndexMap])
 
   // Overlay top-level primitive props onto nodeStyle.
   const nodeStyle = useMemo(
@@ -246,11 +223,11 @@ export const SankeyDiagram = forwardRef(function SankeyDiagram<TNode extends Dat
   const baseEdgeStyle = useMemo(() => createEdgeStyleFn({
     edgeColorBy,
     colorBy,
-    colorScale,
+    colorScale: setup.colorScale,
     nodeStyleFn: nodeStyle,
     edgeOpacity,
     baseStyle: { stroke: "none", strokeWidth: 0 }
-  }), [edgeColorBy, colorBy, colorScale, nodeStyle, edgeOpacity])
+  }), [edgeColorBy, colorBy, setup.colorScale, nodeStyle, edgeOpacity])
 
   const edgeStyle = useMemo(
     () => mergeShapeStyle(baseEdgeStyle, { stroke, strokeWidth, opacity }),
@@ -266,20 +243,6 @@ export const SankeyDiagram = forwardRef(function SankeyDiagram<TNode extends Dat
     return (d: Datum) => d.data?.[accessor] ?? d[accessor] ?? d.id
   }, [showLabels, nodeLabel, nodeIdAccessor])
 
-  // Margin
-  const margin = { ...resolved.marginDefaults, ...(typeof userMargin === "number" ? { top: userMargin, bottom: userMargin, left: userMargin, right: userMargin } : userMargin) }
-
-  const { customHoverBehavior, customClickBehavior } = useChartSelection({
-    selection,
-    linkedHover,
-    fallbackFields: colorBy ? [typeof colorBy === "string" ? colorBy : ""] : [],
-    unwrapData: true,
-    onObservation,
-    onClick,
-    chartType: "SankeyDiagram",
-    chartId,
-  })
-
   // Validate data (after all hooks)
   const error = validateNetworkData({
     componentName: "SankeyDiagram",
@@ -289,20 +252,20 @@ export const SankeyDiagram = forwardRef(function SankeyDiagram<TNode extends Dat
   if (error) return <ChartError componentName="SankeyDiagram" message={error} width={width} height={height} />
 
   // ── Loading / empty guards (deferred to after all hooks) ───────────────
-  if (loadingEl) return loadingEl
-  if (emptyEl) return emptyEl
+  if (setup.loadingEl) return setup.loadingEl
+  if (setup.emptyEl) return setup.emptyEl
 
   return (
     <SafeRender componentName="SankeyDiagram" width={width} height={height}>
     <StreamNetworkFrame
       ref={frameRef}
       chartType="sankey"
-      {...(inferredNodes.length > 0 && { nodes: inferredNodes })}
-      {...(edges != null && { edges: safeEdges })}
+      {...(setup.safeNodes.length > 0 && { nodes: setup.safeNodes })}
+      {...(edges != null && { edges: setup.safeEdges })}
       size={[width, height]}
       responsiveWidth={props.responsiveWidth}
       responsiveHeight={props.responsiveHeight}
-      margin={margin}
+      margin={setup.margin}
       nodeIDAccessor={nodeIdAccessor}
       sourceAccessor={sourceAccessor}
       targetAccessor={targetAccessor}
@@ -314,7 +277,7 @@ export const SankeyDiagram = forwardRef(function SankeyDiagram<TNode extends Dat
       nodeStyle={nodeStyle}
       edgeStyle={edgeStyle}
       colorBy={colorBy}
-      colorScheme={effectivePalette}
+      colorScheme={setup.effectivePalette}
       edgeColorBy={edgeColorBy}
       edgeOpacity={edgeOpacity}
       edgeSort={edgeSort}
@@ -322,13 +285,13 @@ export const SankeyDiagram = forwardRef(function SankeyDiagram<TNode extends Dat
       showLabels={showLabels}
       enableHover={enableHover}
       tooltipContent={tooltip === false ? () => null : (normalizeTooltip(tooltip) || undefined)}
-      customHoverBehavior={(linkedHover || onObservation || onClick) ? customHoverBehavior : undefined}
-      customClickBehavior={(onObservation || onClick) ? customClickBehavior : undefined}
+      customHoverBehavior={(linkedHover || onObservation || onClick) ? setup.customHoverBehavior : undefined}
+      customClickBehavior={(onObservation || onClick) ? setup.customClickBehavior : undefined}
       {...(legendInteraction && legendInteraction !== "none" && {
-        legendHoverBehavior: legendState.onLegendHover,
-        legendClickBehavior: legendState.onLegendClick,
-        legendHighlightedCategory: legendState.highlightedCategory,
-        legendIsolatedCategories: legendState.isolatedCategories,
+        legendHoverBehavior: setup.legendState.onLegendHover,
+        legendClickBehavior: setup.legendState.onLegendClick,
+        legendHighlightedCategory: setup.legendState.highlightedCategory,
+        legendIsolatedCategories: setup.legendState.isolatedCategories,
       })}
       className={className}
       title={title}

--- a/src/components/charts/network/TreeDiagram.tsx
+++ b/src/components/charts/network/TreeDiagram.tsx
@@ -4,15 +4,16 @@ import * as React from "react"
 import { useMemo } from "react"
 import StreamNetworkFrame from "../../stream/StreamNetworkFrame"
 import type { StreamNetworkFrameProps } from "../../stream/networkTypes"
-import { getColor, DEPTH_PALETTE_COLORS, COLOR_SCHEMES, DEFAULT_COLORS } from "../shared/colorUtils"
+import { getColor, DEPTH_PALETTE_COLORS } from "../shared/colorUtils"
 import { flattenHierarchy, resolveHierarchySum } from "../shared/networkUtils"
 import type { BaseChartProps, ChartAccessor } from "../shared/types"
 import { normalizeTooltip, type TooltipProp } from "../../Tooltip/Tooltip"
-import { useChartMode, useChartSelection, useColorScale, useLegendInteraction, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { useChartMode, resolveDefaultFill } from "../shared/hooks"
 import type { LegendInteractionMode } from "../shared/hooks"
+import { useNetworkChartSetup } from "../shared/useNetworkChartSetup"
 import { mergeShapeStyle } from "../shared/mergeShapeStyle"
 import ChartError from "../shared/ChartError"
-import { SafeRender, renderLoadingState } from "../shared/withChartWrapper"
+import { SafeRender } from "../shared/withChartWrapper"
 import { validateObjectData } from "../shared/validateChartData"
 
 /**
@@ -122,39 +123,34 @@ export function TreeDiagram<TNode extends Datum = Datum>(props: TreeDiagramProps
 
   const { width, height, enableHover, showLabels = true, title, description, summary, accessibleTable } = resolved
 
-  // ── Loading state (computed early, returned after all hooks) ─────────────
-  const loadingEl = renderLoadingState(loading, width, height)
-
   // Node style function
   const allNodes = useMemo(() => {
     return flattenHierarchy(data ?? null, childrenAccessor as string | ((d: Datum) => any[]))
   }, [data, childrenAccessor])
 
-  const colorScale = useColorScale(allNodes, colorByDepth ? undefined : colorBy, colorScheme)
-
-  // Legend interaction
-  const allCategories = useMemo(() => {
-    if (!colorBy || colorByDepth) return []
-    const vals = new Set<string>()
-    for (const d of allNodes as Datum[]) {
-      const v = typeof colorBy === "function" ? colorBy(d) : d[colorBy as string]
-      if (v != null) vals.add(String(v))
-    }
-    return Array.from(vals)
-  }, [allNodes, colorBy, colorByDepth])
-
-  const legendState = useLegendInteraction(legendInteraction, colorByDepth ? undefined : colorBy as string | ((d: Datum) => string) | undefined, allCategories)
-
-  // Theme-aware default fill: ThemeProvider categorical > colorScheme > DEFAULT_COLOR
-  const themeCategorical = useThemeCategorical()
+  // Consolidated network setup — same hierarchy-shape pattern as
+  // Treemap/CirclePack: flattened descendants flow into the hook,
+  // node inference off, no top-level legend.
+  const setup = useNetworkChartSetup({
+    nodes: allNodes,
+    edges: undefined,
+    inferNodes: false,
+    colorBy: colorByDepth ? undefined : (colorBy as string | ((d: Datum) => string) | undefined),
+    colorScheme,
+    showLegend: false,
+    legendInteraction,
+    selection,
+    linkedHover,
+    onObservation,
+    onClick,
+    chartType: "TreeDiagram",
+    chartId,
+    marginDefaults: resolved.marginDefaults,
+    userMargin,
+    width, height,
+    loading,
+  })
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [])
-
-  const effectivePalette = useMemo(() => {
-    if (Array.isArray(colorScheme)) return colorScheme
-    if (themeCategorical && themeCategorical.length > 0) return themeCategorical
-    const resolved = COLOR_SCHEMES[colorScheme as keyof typeof COLOR_SCHEMES]
-    return Array.isArray(resolved) ? resolved as string[] : DEFAULT_COLORS as unknown as string[]
-  }, [colorScheme, themeCategorical])
 
   // d is a RealtimeNode — user data on d.data, depth on d.depth
   const baseNodeStyleFn = useMemo(() => {
@@ -163,13 +159,13 @@ export function TreeDiagram<TNode extends Datum = Datum>(props: TreeDiagramProps
       if (colorByDepth) {
         baseStyle.fill = DEPTH_PALETTE_COLORS[(d.depth || 0) % DEPTH_PALETTE_COLORS.length]
       } else if (colorBy) {
-        baseStyle.fill = getColor(d.data || d, colorBy as string | ((d: Datum) => string), colorScale)
+        baseStyle.fill = getColor(d.data || d, colorBy as string | ((d: Datum) => string), setup.colorScale)
       } else {
-        baseStyle.fill = resolveDefaultFill(undefined, themeCategorical, colorScheme, undefined, categoryIndexMap)
+        baseStyle.fill = resolveDefaultFill(undefined, setup.themeCategorical, colorScheme, undefined, categoryIndexMap)
       }
       return baseStyle
     }
-  }, [colorBy, colorByDepth, colorScale, themeCategorical, colorScheme, categoryIndexMap])
+  }, [colorBy, colorByDepth, setup.colorScale, setup.themeCategorical, colorScheme, categoryIndexMap])
 
   const nodeStyleFn = useMemo(
     () => mergeShapeStyle(baseNodeStyleFn, { stroke, strokeWidth, opacity }),
@@ -192,21 +188,12 @@ export function TreeDiagram<TNode extends Datum = Datum>(props: TreeDiagramProps
     return undefined
   }, [layout, valueAccessor])
 
-  // Margin
-  const margin = { ...resolved.marginDefaults, ...(typeof userMargin === "number" ? { top: userMargin, bottom: userMargin, left: userMargin, right: userMargin } : userMargin) }
-
-  const { customHoverBehavior, customClickBehavior } = useChartSelection({
-    selection, linkedHover,
-    fallbackFields: colorBy ? [typeof colorBy === "string" ? colorBy : ""] : [],
-    unwrapData: true, onObservation, onClick, chartType: "TreeDiagram", chartId,
-  })
-
   // Validate
   const error = validateObjectData({ componentName: "TreeDiagram", data })
   if (error) return <ChartError componentName="TreeDiagram" message={error} width={width} height={height} />
 
   // ── Loading guard (deferred to after all hooks) ────────────────────────
-  if (loadingEl) return loadingEl
+  if (setup.loadingEl) return setup.loadingEl
 
   return (<SafeRender componentName="TreeDiagram" width={width} height={height}>
     <StreamNetworkFrame
@@ -215,7 +202,7 @@ export function TreeDiagram<TNode extends Datum = Datum>(props: TreeDiagramProps
       size={[width, height]}
       responsiveWidth={props.responsiveWidth}
       responsiveHeight={props.responsiveHeight}
-      margin={margin}
+      margin={setup.margin}
       nodeIDAccessor={nodeIdAccessor}
       childrenAccessor={childrenAccessor}
       hierarchySum={hierarchySumFn}
@@ -224,20 +211,20 @@ export function TreeDiagram<TNode extends Datum = Datum>(props: TreeDiagramProps
       nodeStyle={nodeStyleFn}
       edgeStyle={edgeStyleFn}
       colorBy={colorBy}
-      colorScheme={effectivePalette}
+      colorScheme={setup.effectivePalette}
       colorByDepth={colorByDepth}
       nodeSize={nodeSize}
       nodeLabel={showLabels ? (nodeLabel || nodeIdAccessor) : undefined}
       showLabels={showLabels}
       enableHover={enableHover}
       tooltipContent={tooltip === false ? () => null : (normalizeTooltip(tooltip) || undefined)}
-      customHoverBehavior={(linkedHover || onObservation || onClick) ? customHoverBehavior : undefined}
-      customClickBehavior={(onObservation || onClick) ? customClickBehavior : undefined}
+      customHoverBehavior={(linkedHover || onObservation || onClick) ? setup.customHoverBehavior : undefined}
+      customClickBehavior={(onObservation || onClick) ? setup.customClickBehavior : undefined}
       {...(legendInteraction && legendInteraction !== "none" && {
-        legendHoverBehavior: legendState.onLegendHover,
-        legendClickBehavior: legendState.onLegendClick,
-        legendHighlightedCategory: legendState.highlightedCategory,
-        legendIsolatedCategories: legendState.isolatedCategories,
+        legendHoverBehavior: setup.legendState.onLegendHover,
+        legendClickBehavior: setup.legendState.onLegendClick,
+        legendHighlightedCategory: setup.legendState.highlightedCategory,
+        legendIsolatedCategories: setup.legendState.isolatedCategories,
       })}
       className={className}
       title={title}

--- a/src/components/charts/network/Treemap.tsx
+++ b/src/components/charts/network/Treemap.tsx
@@ -4,15 +4,16 @@ import * as React from "react"
 import { useMemo, useCallback } from "react"
 import StreamNetworkFrame from "../../stream/StreamNetworkFrame"
 import type { StreamNetworkFrameProps } from "../../stream/networkTypes"
-import { getColor, DEPTH_PALETTE_COLORS, COLOR_SCHEMES, DEFAULT_COLORS } from "../shared/colorUtils"
+import { getColor, DEPTH_PALETTE_COLORS } from "../shared/colorUtils"
 import { flattenHierarchy, resolveHierarchySum } from "../shared/networkUtils"
 import type { BaseChartProps, ChartAccessor } from "../shared/types"
 import { normalizeTooltip, type TooltipProp } from "../../Tooltip/Tooltip"
-import { useChartMode, useChartSelection, useColorScale, useLegendInteraction, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { useChartMode, resolveDefaultFill } from "../shared/hooks"
 import type { LegendInteractionMode } from "../shared/hooks"
+import { useNetworkChartSetup } from "../shared/useNetworkChartSetup"
 import { mergeShapeStyle } from "../shared/mergeShapeStyle"
 import ChartError from "../shared/ChartError"
-import { SafeRender, renderLoadingState } from "../shared/withChartWrapper"
+import { SafeRender } from "../shared/withChartWrapper"
 import { validateObjectData } from "../shared/validateChartData"
 import { useResolvedSelection } from "../shared/useResolvedSelection"
 import { DEFAULT_SELECTION_OPACITY } from "../shared/selectionUtils"
@@ -122,21 +123,47 @@ export function Treemap<TNode extends Datum = Datum>(props: TreemapProps<TNode>)
 
   const { width, height, enableHover, showLabels = true, title, description, summary, accessibleTable } = resolved
 
-  // ── Loading state (computed early, returned after all hooks) ─────────────
-  const loadingEl = renderLoadingState(loading, width, height)
+  // Flatten the hierarchy once so the consolidated setup hook can
+  // build its color scale + categories off the same node array
+  // node-style/legend logic uses below.
+  const allNodes = useMemo(() => {
+    return flattenHierarchy(data ?? null, childrenAccessor as string | ((d: Datum) => any[]))
+  }, [data, childrenAccessor])
 
-  const { activeSelectionHook, customHoverBehavior: baseHoverBehavior, customClickBehavior } = useChartSelection({
+  // Consolidated network setup. Treemap's data shape is a hierarchy
+  // root, not nodes/edges, so we feed `allNodes` (the flattened
+  // descendants) and turn off node inference. `colorByDepth` paints
+  // by tree depth instead of a categorical accessor — pass undefined
+  // for `colorBy` in that case so the color scale + categories don't
+  // try to extract categories that wouldn't drive the styling.
+  const setup = useNetworkChartSetup({
+    nodes: allNodes,
+    edges: undefined,
+    inferNodes: false,
+    colorBy: colorByDepth ? undefined : (colorBy as string | ((d: Datum) => string) | undefined),
+    colorScheme,
+    showLegend: false,             // Treemap has no top-level legend prop
+    legendInteraction,
     selection,
     linkedHover,
-    fallbackFields: colorBy ? [typeof colorBy === "string" ? colorBy : ""] : [],
-    onObservation, onClick, chartType: "Treemap", chartId
+    onObservation,
+    onClick,
+    chartType: "Treemap",
+    chartId,
+    marginDefaults: resolved.marginDefaults,
+    userMargin,
+    width, height,
+    loading,
+    // No emptyContent gate — `data` is a hierarchy root validated
+    // separately by validateObjectData, not the array-empty path.
   })
 
   const resolvedSelection = useResolvedSelection(selection)
+  const baseHoverBehavior = setup.customHoverBehavior
 
   // Network frame hover: { type, data: sceneNode, x, y }
-  // sceneNode.data = original datum for this hierarchy node
-  // Pass it as { data: originalDatum } so useChartSelection unwraps correctly
+  // sceneNode.data = original datum for this hierarchy node.
+  // Pass it as { data: originalDatum } so useChartSelection unwraps correctly.
   const customHoverBehavior = useCallback(
     (d: Datum | null) => {
       if (!d) return baseHoverBehavior(null)
@@ -147,35 +174,7 @@ export function Treemap<TNode extends Datum = Datum>(props: TreemapProps<TNode>)
     [baseHoverBehavior]
   )
 
-  const allNodes = useMemo(() => {
-    return flattenHierarchy(data ?? null, childrenAccessor as string | ((d: Datum) => any[]))
-  }, [data, childrenAccessor])
-
-  const colorScale = useColorScale(allNodes, colorByDepth ? undefined : colorBy, colorScheme)
-
-  // Legend interaction
-  const allCategories = useMemo(() => {
-    if (!colorBy || colorByDepth) return []
-    const vals = new Set<string>()
-    for (const d of allNodes as Datum[]) {
-      const v = typeof colorBy === "function" ? colorBy(d) : d[colorBy as string]
-      if (v != null) vals.add(String(v))
-    }
-    return Array.from(vals)
-  }, [allNodes, colorBy, colorByDepth])
-
-  const legendState = useLegendInteraction(legendInteraction, colorByDepth ? undefined : colorBy as string | ((d: Datum) => string) | undefined, allCategories)
-
-  // Theme-aware default fill: ThemeProvider categorical > colorScheme > DEFAULT_COLOR
-  const themeCategorical = useThemeCategorical()
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [])
-
-  const effectivePalette = useMemo(() => {
-    if (Array.isArray(colorScheme)) return colorScheme
-    if (themeCategorical && themeCategorical.length > 0) return themeCategorical
-    const resolved = COLOR_SCHEMES[colorScheme as keyof typeof COLOR_SCHEMES]
-    return Array.isArray(resolved) ? resolved as string[] : DEFAULT_COLORS as unknown as string[]
-  }, [colorScheme, themeCategorical])
 
   const nodeStyleFn = useMemo(() => {
     return (d: Datum) => {
@@ -183,13 +182,13 @@ export function Treemap<TNode extends Datum = Datum>(props: TreemapProps<TNode>)
       if (colorByDepth) {
         baseStyle.fill = DEPTH_PALETTE_COLORS[(d.depth || 0) % DEPTH_PALETTE_COLORS.length]
       } else if (colorBy) {
-        baseStyle.fill = getColor(d.data || d, colorBy as string | ((d: Datum) => string), colorScale)
+        baseStyle.fill = getColor(d.data || d, colorBy as string | ((d: Datum) => string), setup.colorScale)
       } else {
-        baseStyle.fill = resolveDefaultFill(undefined, themeCategorical, colorScheme, undefined, categoryIndexMap)
+        baseStyle.fill = resolveDefaultFill(undefined, setup.themeCategorical, colorScheme, undefined, categoryIndexMap)
       }
       return baseStyle
     }
-  }, [colorBy, colorByDepth, colorScale, themeCategorical, colorScheme, categoryIndexMap])
+  }, [colorBy, colorByDepth, setup.colorScale, setup.themeCategorical, colorScheme, categoryIndexMap])
 
   // Overlay top-level primitive props (stroke/strokeWidth/opacity) on nodeStyleFn
   // before selection wrapping, so they land on every node.
@@ -200,12 +199,12 @@ export function Treemap<TNode extends Datum = Datum>(props: TreemapProps<TNode>)
 
   // Wrap node style with selection — unwrap hierarchy .data for predicate matching
   const nodeStyle = useMemo(() => {
-    if (!activeSelectionHook) return nodeStyleFnWithPrimitives
+    if (!setup.activeSelectionHook) return nodeStyleFnWithPrimitives
     return (d: Datum) => {
       const style = { ...nodeStyleFnWithPrimitives(d) }
-      if (activeSelectionHook.isActive) {
+      if (setup.activeSelectionHook!.isActive) {
         const datum = d.data || d
-        const matches = activeSelectionHook.predicate(datum)
+        const matches = setup.activeSelectionHook!.predicate(datum)
         if (matches) {
           if (resolvedSelection?.selectedStyle) Object.assign(style, resolvedSelection.selectedStyle)
         } else {
@@ -218,7 +217,7 @@ export function Treemap<TNode extends Datum = Datum>(props: TreemapProps<TNode>)
       }
       return style
     }
-  }, [nodeStyleFnWithPrimitives, activeSelectionHook, resolvedSelection])
+  }, [nodeStyleFnWithPrimitives, setup.activeSelectionHook, resolvedSelection])
 
   const hierarchySumFn = useMemo(() => {
     return resolveHierarchySum(valueAccessor)
@@ -228,15 +227,12 @@ export function Treemap<TNode extends Datum = Datum>(props: TreemapProps<TNode>)
     ? paddingTopProp
     : (showLabels && (labelMode === "parent" || labelMode === "all") ? 18 : undefined)
 
-  // Margin
-  const margin = { ...resolved.marginDefaults, ...(typeof userMargin === "number" ? { top: userMargin, bottom: userMargin, left: userMargin, right: userMargin } : userMargin) }
-
   // Validate
   const error = validateObjectData({ componentName: "Treemap", data })
   if (error) return <ChartError componentName="Treemap" message={error} width={width} height={height} />
 
   // ── Loading guard (deferred to after all hooks) ────────────────────────
-  if (loadingEl) return loadingEl
+  if (setup.loadingEl) return setup.loadingEl
 
   return (<SafeRender componentName="Treemap" width={width} height={height}>
     <StreamNetworkFrame
@@ -245,7 +241,7 @@ export function Treemap<TNode extends Datum = Datum>(props: TreemapProps<TNode>)
       size={[width, height]}
       responsiveWidth={props.responsiveWidth}
       responsiveHeight={props.responsiveHeight}
-      margin={margin}
+      margin={setup.margin}
       nodeIDAccessor={nodeIdAccessor}
       childrenAccessor={childrenAccessor}
       hierarchySum={hierarchySumFn}
@@ -253,7 +249,7 @@ export function Treemap<TNode extends Datum = Datum>(props: TreemapProps<TNode>)
       paddingTop={resolvedPaddingTop}
       nodeStyle={nodeStyle}
       colorBy={colorBy}
-      colorScheme={effectivePalette}
+      colorScheme={setup.effectivePalette}
       colorByDepth={colorByDepth}
       nodeLabel={showLabels ? (nodeLabel || nodeIdAccessor) : undefined}
       showLabels={showLabels}
@@ -261,12 +257,12 @@ export function Treemap<TNode extends Datum = Datum>(props: TreemapProps<TNode>)
       enableHover={enableHover}
       tooltipContent={tooltip === false ? () => null : (normalizeTooltip(tooltip) || undefined)}
       {...((linkedHover || onObservation || onClick) && { customHoverBehavior })}
-      {...((onObservation || onClick) && { customClickBehavior })}
+      {...((onObservation || onClick) && { customClickBehavior: setup.customClickBehavior })}
       {...(legendInteraction && legendInteraction !== "none" && {
-        legendHoverBehavior: legendState.onLegendHover,
-        legendClickBehavior: legendState.onLegendClick,
-        legendHighlightedCategory: legendState.highlightedCategory,
-        legendIsolatedCategories: legendState.isolatedCategories,
+        legendHoverBehavior: setup.legendState.onLegendHover,
+        legendClickBehavior: setup.legendState.onLegendClick,
+        legendHighlightedCategory: setup.legendState.highlightedCategory,
+        legendIsolatedCategories: setup.legendState.isolatedCategories,
       })}
       className={className}
       title={title}

--- a/src/components/charts/ordinal/BarChart.test.tsx
+++ b/src/components/charts/ordinal/BarChart.test.tsx
@@ -694,4 +694,71 @@ describe("BarChart", () => {
       expect(frameProps().gradientFill).toEqual(stops)
     })
   })
+
+  // ── regression prop ────────────────────────────────────────────────────
+  // Sugar over the `trend` annotation. The HOC prepends a trend-typed
+  // annotation to the user's annotations array; the annotation handler
+  // detects the ordinal frame and treats the categorical axis as a
+  // category-index for regression input. See annotationRules.tsx.
+  describe("regression prop", () => {
+    it("does not inject a trend annotation when omitted", () => {
+      render(
+        <TooltipProvider>
+          <BarChart data={sampleData} />
+        </TooltipProvider>
+      )
+      expect(frameProps().annotations).toBeUndefined()
+    })
+
+    it("`regression` injects a default linear trend annotation", () => {
+      render(
+        <TooltipProvider>
+          <BarChart data={sampleData} regression />
+        </TooltipProvider>
+      )
+      const ann = frameProps().annotations
+      expect(ann).toHaveLength(1)
+      expect(ann[0]).toEqual({ type: "trend", method: "linear" })
+    })
+
+    it("`regression='loess'` picks the LOESS method", () => {
+      render(
+        <TooltipProvider>
+          <BarChart data={sampleData} regression="loess" />
+        </TooltipProvider>
+      )
+      expect(frameProps().annotations[0]).toEqual({ type: "trend", method: "loess" })
+    })
+
+    it("forwards a full RegressionConfig object", () => {
+      render(
+        <TooltipProvider>
+          <BarChart
+            data={sampleData}
+            regression={{ method: "polynomial", order: 2, color: "#ef4444", label: "Quad" }}
+          />
+        </TooltipProvider>
+      )
+      expect(frameProps().annotations[0]).toEqual({
+        type: "trend",
+        method: "polynomial",
+        order: 2,
+        color: "#ef4444",
+        label: "Quad",
+      })
+    })
+
+    it("prepends the trend annotation in front of user annotations (z-order)", () => {
+      const userAnn = { type: "label", x: 1, y: 10, note: "hi" }
+      render(
+        <TooltipProvider>
+          <BarChart data={sampleData} regression annotations={[userAnn]} />
+        </TooltipProvider>
+      )
+      const ann = frameProps().annotations
+      expect(ann).toHaveLength(2)
+      expect(ann[0].type).toBe("trend")
+      expect(ann[1]).toBe(userAnn)
+    })
+  })
 })

--- a/src/components/charts/ordinal/BarChart.tsx
+++ b/src/components/charts/ordinal/BarChart.tsx
@@ -6,20 +6,19 @@ import * as React from "react"
 import { useMemo, forwardRef, useRef } from "react"
 import StreamOrdinalFrame from "../../stream/StreamOrdinalFrame"
 import type { StreamOrdinalFrameProps, StreamOrdinalFrameHandle } from "../../stream/ordinalTypes"
-import { getColor } from "../shared/colorUtils"
-import { useSortedData, useChartMode, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { useSortedData, useChartMode, useThemeCategorical } from "../shared/hooks"
 import type { LegendInteractionMode } from "../shared/hooks"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
 import type { BaseChartProps, ChartAccessor, CategoryFormatFn } from "../shared/types"
 import { type TooltipProp } from "../../Tooltip/Tooltip"
 import { buildOrdinalTooltip } from "../shared/tooltipUtils"
 import ChartError from "../shared/ChartError"
 import { SafeRender, warnMissingField } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { wrapStyleWithSelection } from "../shared/selectionUtils"
 import type { RealtimeFrameHandle } from "../../realtime/types"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useOrdinalStreaming } from "../shared/useOrdinalStreaming"
+import { useOrdinalPieceStyle } from "../shared/useOrdinalPieceStyle"
+import { buildRegressionAnnotation, type RegressionProp } from "../shared/regressionUtils"
 
 /**
  * BarChart component props
@@ -98,6 +97,17 @@ export interface BarChartProps<TDatum extends Datum = Datum> extends BaseChartPr
   legendPosition?: "right" | "left" | "top" | "bottom"
   tooltip?: TooltipProp
   annotations?: Datum[]
+  /**
+   * Overlay a regression line through the bar tops. Accepts `true`
+   * (linear), a method name (`"linear"` | `"polynomial"` | `"loess"`),
+   * or a full `RegressionConfig`. The regression treats categories
+   * as a numeric category-index for fit input; pixel positions are
+   * resolved through the band scale, so the line passes through bar
+   * centers. Best for ordered categories (months, quarters, score
+   * buckets) where a slope reads as a meaningful trend. Sugar over
+   * the `trend` annotation.
+   */
+  regression?: RegressionProp
   /** Custom formatter for category tick labels */
   categoryFormat?: CategoryFormatFn
   /** Fixed value-axis domain `[min, max]`. Either bound may be `undefined` to leave that side data-derived. */
@@ -220,6 +230,7 @@ export const BarChart = forwardRef(function BarChart<TDatum extends Datum = Datu
     baselinePadding = false,
     tooltip,
     annotations,
+    regression,
     valueExtent,
     frameProps = {},
     selection,
@@ -290,35 +301,17 @@ export const BarChart = forwardRef(function BarChart<TDatum extends Datum = Datu
   const themeCategorical = useThemeCategorical()
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [safeData])
 
-  const basePieceStyle = useMemo(() => {
-    return (d: Datum, _category?: string) => {
-      const baseStyle: Record<string, string | number> = {}
-      if (colorBy) {
-        baseStyle.fill = getColor(d, colorBy, setup.colorScale)
-      } else {
-        baseStyle.fill = resolveDefaultFill(color, themeCategorical, colorScheme, undefined, categoryIndexMap)
-      }
-      return baseStyle
-    }
-  }, [colorBy, setup.colorScale, color, themeCategorical, colorScheme, categoryIndexMap])
-
-  const mergedPieceStyle = useMemo(() => {
-    const userPieceStyle = frameProps?.pieceStyle
-    const baseWithUser = (!userPieceStyle || typeof userPieceStyle !== "function")
-      ? basePieceStyle
-      : (d: Datum, category?: string) => ({
-        ...basePieceStyle(d, category),
-        ...((userPieceStyle as ((...args: any[]) => any))(d, category) || {}),
-      })
-    // Top-level primitive props (stroke/strokeWidth/opacity) applied LAST so
-    // they win over both HOC base style and user-supplied frameProps.pieceStyle.
-    return mergeShapeStyle(baseWithUser, { stroke, strokeWidth, opacity })
-  }, [basePieceStyle, frameProps, stroke, strokeWidth, opacity])
-
-  const pieceStyle = useMemo(
-    () => wrapStyleWithSelection(mergedPieceStyle, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [mergedPieceStyle, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
+  // Consolidated piece-style — base fill, user overlay, primitive
+  // props, and selection wrap all happen inside the shared hook.
+  // Each ordinal HOC drops ~25 lines of recipe by calling this.
+  const pieceStyle = useOrdinalPieceStyle({
+    colorBy, colorScale: setup.colorScale,
+    color, themeCategorical, colorScheme, categoryIndexMap,
+    userPieceStyle: frameProps?.pieceStyle,
+    stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+  })
 
   // Default tooltip — pass valueFormat so the tooltip matches the value axis.
   const defaultTooltipContent = useMemo(
@@ -339,6 +332,14 @@ export const BarChart = forwardRef(function BarChart<TDatum extends Datum = Datu
     accessors: { categoryAccessor, valueAccessor },
   })
   if (error) return <ChartError componentName="BarChart" message={error} width={width} height={height} />
+
+  // Splice the `regression` sugar into annotations as a `trend`
+  // annotation. Trend goes first so user-supplied annotations paint
+  // above it.
+  const trendAnn = buildRegressionAnnotation(regression)
+  const resolvedAnnotations = trendAnn
+    ? [trendAnn, ...(annotations || [])]
+    : annotations
 
   const streamProps: StreamOrdinalFrameProps = {
     chartType: "bar",
@@ -380,7 +381,7 @@ export const BarChart = forwardRef(function BarChart<TDatum extends Datum = Datu
       customHoverBehavior: setup.customHoverBehavior,
       customClickBehavior: setup.customClickBehavior,
     }),
-    ...(annotations && annotations.length > 0 && { annotations }),
+    ...(resolvedAnnotations && resolvedAnnotations.length > 0 && { annotations: resolvedAnnotations }),
     ...(valueExtent && { rExtent: valueExtent }),
     // frameProps spread last for escape hatch, but pieceStyle is excluded
     // to prevent clobbering the HOC's color-resolved, selection-wrapped style.

--- a/src/components/charts/ordinal/BoxPlot.tsx
+++ b/src/components/charts/ordinal/BoxPlot.tsx
@@ -6,16 +6,14 @@ import * as React from "react"
 import { useMemo, forwardRef, useRef } from "react"
 import StreamOrdinalFrame from "../../stream/StreamOrdinalFrame"
 import type { StreamOrdinalFrameProps, StreamOrdinalFrameHandle } from "../../stream/ordinalTypes"
-import { getColor } from "../shared/colorUtils"
-import { useChartMode, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { useChartMode, useThemeCategorical } from "../shared/hooks"
 import type { LegendInteractionMode, LegendPosition } from "../shared/hooks"
 import type { BaseChartProps, ChartAccessor, CategoryFormatFn } from "../shared/types"
 import { type TooltipProp } from "../../Tooltip/Tooltip"
 import ChartError from "../shared/ChartError"
 import { SafeRender } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { wrapStyleWithSelection } from "../shared/selectionUtils"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
+import { useOrdinalPieceStyle } from "../shared/useOrdinalPieceStyle"
 import type { RealtimeFrameHandle } from "../../realtime/types"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
@@ -153,22 +151,20 @@ export const BoxPlot = forwardRef(function BoxPlot<TDatum extends Datum = Datum>
   const themeCategorical = useThemeCategorical()
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [safeData])
 
-  const baseSummaryStyle = useMemo(() => {
-    return (d: Datum) => {
-      const resolvedColor = colorBy ? getColor(d, colorBy, setup.colorScale) : resolveDefaultFill(colorProp, themeCategorical, colorScheme, undefined, categoryIndexMap)
-      return { fill: resolvedColor, stroke: resolvedColor, fillOpacity: 0.8 }
-    }
-  }, [colorBy, setup.colorScale, colorProp, themeCategorical, colorScheme, categoryIndexMap])
-
-  const baseSummaryStyleWithPrimitives = useMemo(
-    () => mergeShapeStyle(baseSummaryStyle, { stroke, strokeWidth, opacity }),
-    [baseSummaryStyle, stroke, strokeWidth, opacity]
-  )
-
-  const summaryStyle = useMemo(
-    () => wrapStyleWithSelection(baseSummaryStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [baseSummaryStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
+  // Consolidated summary-style. `linkStrokeToFill` mirrors the
+  // pre-migration "stroke equals fill" behavior so the box outline
+  // matches the box body. fillOpacity is a static extra.
+  const summaryStyle = useOrdinalPieceStyle({
+    colorBy,
+    colorScale: setup.colorScale,
+    color: colorProp, themeCategorical, colorScheme, categoryIndexMap,
+    userPieceStyle: undefined,                  // BoxPlot doesn't expose summaryStyle through frameProps
+    stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+    baseStyleExtras: { fillOpacity: 0.8 },
+    linkStrokeToFill: true,
+  })
 
   const defaultTooltipContent = useMemo(() => buildStatsTooltip(), [])
 

--- a/src/components/charts/ordinal/DonutChart.tsx
+++ b/src/components/charts/ordinal/DonutChart.tsx
@@ -6,8 +6,7 @@ import * as React from "react"
 import { useMemo, forwardRef, useRef } from "react"
 import StreamOrdinalFrame from "../../stream/StreamOrdinalFrame"
 import type { StreamOrdinalFrameProps, StreamOrdinalFrameHandle } from "../../stream/ordinalTypes"
-import { getColor } from "../shared/colorUtils"
-import { useChartMode, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { useChartMode, useThemeCategorical } from "../shared/hooks"
 import type { LegendInteractionMode, LegendPosition } from "../shared/hooks"
 import type { BaseChartProps, ChartAccessor } from "../shared/types"
 import { type TooltipProp } from "../../Tooltip/Tooltip"
@@ -15,8 +14,7 @@ import { buildOrdinalTooltip } from "../shared/tooltipUtils"
 import ChartError from "../shared/ChartError"
 import { SafeRender } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { wrapStyleWithSelection } from "../shared/selectionUtils"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
+import { useOrdinalPieceStyle } from "../shared/useOrdinalPieceStyle"
 import type { RealtimeFrameHandle } from "../../realtime/types"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useOrdinalStreaming } from "../shared/useOrdinalStreaming"
@@ -160,36 +158,20 @@ export const DonutChart = forwardRef(function DonutChart<TDatum extends Datum = 
   const themeCategorical = useThemeCategorical()
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [safeData])
 
-  const fpPieceStyle = frameProps.pieceStyle as ((d: any, c?: string) => Datum) | undefined
-
-  const basePieceStyle = useMemo(() => {
-    return (d: Datum, category?: string) => {
-      let base: Datum
-      if (effectiveColorBy) {
-        if (setup.colorScale) base = { fill: getColor(d, effectiveColorBy, setup.colorScale) }
-        else base = {} // Let frame use its own color scheme (push API)
-      } else {
-        base = { fill: resolveDefaultFill(color, themeCategorical, colorScheme, category, categoryIndexMap) }
-      }
-      if (fpPieceStyle) {
-        const extra = fpPieceStyle(d, category)
-        if (extra.stroke) base.stroke = extra.stroke
-        if (extra.strokeWidth != null) base.strokeWidth = extra.strokeWidth
-        if (extra.strokeOpacity != null) base.strokeOpacity = extra.strokeOpacity
-      }
-      return base
-    }
-  }, [effectiveColorBy, setup.colorScale, color, themeCategorical, colorScheme, categoryIndexMap, fpPieceStyle])
-
-  const basePieceStyleWithPrimitives = useMemo(
-    () => mergeShapeStyle(basePieceStyle, { stroke, strokeWidth, opacity }),
-    [basePieceStyle, stroke, strokeWidth, opacity]
-  )
-
-  const pieceStyle = useMemo(
-    () => wrapStyleWithSelection(basePieceStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [basePieceStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
+  // Consolidated piece-style — same recipe as PieChart with
+  // per-slice color cycling enabled. Previously had a stroke-only
+  // user-overlay filter that diverged from PieChart's spread
+  // semantic; aligned with the helper.
+  const pieceStyle = useOrdinalPieceStyle({
+    colorBy: effectiveColorBy,
+    colorScale: setup.colorScale,
+    color, themeCategorical, colorScheme, categoryIndexMap,
+    userPieceStyle: frameProps?.pieceStyle,
+    stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+    cycleByCategory: true,
+  })
 
   const defaultTooltipContent = useMemo(
     () => buildOrdinalTooltip({

--- a/src/components/charts/ordinal/DotPlot.test.tsx
+++ b/src/components/charts/ordinal/DotPlot.test.tsx
@@ -233,4 +233,46 @@ describe("DotPlot", () => {
       expect(lastOrdinalFrameProps.tooltipContent({ category: "A", value: 10 })).toBeNull()
     })
   })
+
+  // ── regression prop ────────────────────────────────────────────────────
+  describe("regression prop", () => {
+    it("does not inject a trend annotation when omitted", () => {
+      render(
+        <TooltipProvider>
+          <DotPlot data={sampleData} />
+        </TooltipProvider>
+      )
+      expect(lastOrdinalFrameProps.annotations).toBeUndefined()
+    })
+
+    it("`regression` injects a default linear trend annotation", () => {
+      render(
+        <TooltipProvider>
+          <DotPlot data={sampleData} regression />
+        </TooltipProvider>
+      )
+      expect(lastOrdinalFrameProps.annotations).toEqual([{ type: "trend", method: "linear" }])
+    })
+
+    it("forwards method shorthand", () => {
+      render(
+        <TooltipProvider>
+          <DotPlot data={sampleData} regression="loess" />
+        </TooltipProvider>
+      )
+      expect(lastOrdinalFrameProps.annotations[0]).toEqual({ type: "trend", method: "loess" })
+    })
+
+    it("prepends the trend annotation in front of user annotations", () => {
+      const userAnn = { type: "label", x: 1, y: 10, note: "hi" }
+      render(
+        <TooltipProvider>
+          <DotPlot data={sampleData} regression annotations={[userAnn]} />
+        </TooltipProvider>
+      )
+      expect(lastOrdinalFrameProps.annotations).toHaveLength(2)
+      expect(lastOrdinalFrameProps.annotations[0].type).toBe("trend")
+      expect(lastOrdinalFrameProps.annotations[1]).toBe(userAnn)
+    })
+  })
 })

--- a/src/components/charts/ordinal/DotPlot.tsx
+++ b/src/components/charts/ordinal/DotPlot.tsx
@@ -6,8 +6,7 @@ import * as React from "react"
 import { useMemo, forwardRef, useRef } from "react"
 import StreamOrdinalFrame from "../../stream/StreamOrdinalFrame"
 import type { StreamOrdinalFrameProps, StreamOrdinalFrameHandle } from "../../stream/ordinalTypes"
-import { getColor } from "../shared/colorUtils"
-import { useSortedData, useChartMode, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { useSortedData, useChartMode, useThemeCategorical } from "../shared/hooks"
 import type { LegendInteractionMode, LegendPosition } from "../shared/hooks"
 import type { BaseChartProps, ChartAccessor, CategoryFormatFn } from "../shared/types"
 import { type TooltipProp } from "../../Tooltip/Tooltip"
@@ -15,11 +14,11 @@ import { buildOrdinalTooltip } from "../shared/tooltipUtils"
 import ChartError from "../shared/ChartError"
 import { SafeRender } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { wrapStyleWithSelection } from "../shared/selectionUtils"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
+import { useOrdinalPieceStyle } from "../shared/useOrdinalPieceStyle"
 import type { RealtimeFrameHandle } from "../../realtime/types"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
+import { buildRegressionAnnotation, type RegressionProp } from "../shared/regressionUtils"
 
 export interface DotPlotProps<TDatum extends Datum = Datum> extends BaseChartProps {
   data?: TDatum[]
@@ -50,6 +49,14 @@ export interface DotPlotProps<TDatum extends Datum = Datum> extends BaseChartPro
   legendPosition?: LegendPosition
   tooltip?: TooltipProp
   annotations?: Datum[]
+  /**
+   * Overlay a regression line through the dots. Same shape as
+   * Scatterplot's regression prop — accepts boolean, method-string,
+   * or full `RegressionConfig`. Pixel positions resolve through the
+   * band scale, so the line passes through dot centers. Sugar over
+   * the `trend` annotation.
+   */
+  regression?: RegressionProp
   /** Custom formatter for category tick labels */
   categoryFormat?: CategoryFormatFn
   /** Fixed value-axis domain `[min, max]`. Either bound may be `undefined` to leave that side data-derived. */
@@ -113,7 +120,7 @@ export const DotPlot = forwardRef(function DotPlot<TDatum extends Datum = Datum>
     categoryAccessor = "category", valueAccessor = "value",
     orientation = "horizontal", valueFormat,
     colorBy, colorScheme, sort = "auto", dotRadius = 5,
-    categoryPadding = 10, tooltip, annotations, valueExtent, frameProps = {}, selection, linkedHover,
+    categoryPadding = 10, tooltip, annotations, regression, valueExtent, frameProps = {}, selection, linkedHover,
     onObservation, onClick, hoverHighlight, chartId,
     loading, emptyContent,
     legendInteraction,
@@ -161,31 +168,20 @@ export const DotPlot = forwardRef(function DotPlot<TDatum extends Datum = Datum>
   const themeCategorical = useThemeCategorical()
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [safeData])
 
-  const fpPieceStyle = frameProps.pieceStyle as ((d: any, c?: string) => Datum) | undefined
-
-  const basePieceStyle = useMemo(() => {
-    return (d: Datum, category?: string) => {
-      const base: Record<string, string | number> = { r: dotRadius, fillOpacity: 0.8 }
-      base.fill = colorBy ? getColor(d, colorBy, setup.colorScale) : resolveDefaultFill(color, themeCategorical, colorScheme, undefined, categoryIndexMap)
-      if (fpPieceStyle) {
-        const extra = fpPieceStyle(d, category)
-        if (extra.stroke) base.stroke = extra.stroke
-        if (extra.strokeWidth != null) base.strokeWidth = extra.strokeWidth
-        if (extra.strokeOpacity != null) base.strokeOpacity = extra.strokeOpacity
-      }
-      return base
-    }
-  }, [colorBy, setup.colorScale, dotRadius, color, themeCategorical, colorScheme, categoryIndexMap, fpPieceStyle])
-
-  const basePieceStyleWithPrimitives = useMemo(
-    () => mergeShapeStyle(basePieceStyle, { stroke, strokeWidth, opacity }),
-    [basePieceStyle, stroke, strokeWidth, opacity]
-  )
-
-  const pieceStyle = useMemo(
-    () => wrapStyleWithSelection(basePieceStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [basePieceStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
+  // Consolidated piece-style. `r` and `fillOpacity` are mark-shape
+  // defaults flowed in via `baseStyleExtras` so they sit BEFORE the
+  // color resolution (and the user can override them via
+  // frameProps.pieceStyle / top-level primitive props).
+  const pieceStyle = useOrdinalPieceStyle({
+    colorBy,
+    colorScale: setup.colorScale,
+    color, themeCategorical, colorScheme, categoryIndexMap,
+    userPieceStyle: frameProps?.pieceStyle,
+    stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+    baseStyleExtras: { r: dotRadius, fillOpacity: 0.8 },
+  })
 
   const defaultTooltipContent = useMemo(
     () => buildOrdinalTooltip({ categoryAccessor, valueAccessor, valueFormat }),
@@ -197,6 +193,14 @@ export const DotPlot = forwardRef(function DotPlot<TDatum extends Datum = Datum>
     accessors: { categoryAccessor, valueAccessor },
   })
   if (error) return <ChartError componentName="DotPlot" message={error} width={width} height={height} />
+
+  // Splice the `regression` sugar into annotations as a `trend`
+  // annotation. Trend goes first so user-supplied annotations paint
+  // above it.
+  const trendAnn = buildRegressionAnnotation(regression)
+  const resolvedAnnotations = trendAnn
+    ? [trendAnn, ...(annotations || [])]
+    : annotations
 
   const streamProps: StreamOrdinalFrameProps = {
     chartType: "point",
@@ -227,7 +231,7 @@ export const DotPlot = forwardRef(function DotPlot<TDatum extends Datum = Datum>
       customHoverBehavior: setup.customHoverBehavior,
       customClickBehavior: setup.customClickBehavior,
     }),
-    ...(annotations && annotations.length > 0 && { annotations }),
+    ...(resolvedAnnotations && resolvedAnnotations.length > 0 && { annotations: resolvedAnnotations }),
     ...(valueExtent && { rExtent: valueExtent }),
     // frameProps spread last for escape hatch, but pieceStyle excluded to prevent
     // clobbering the HOC's color-resolved, selection-wrapped style function.

--- a/src/components/charts/ordinal/FunnelChart.tsx
+++ b/src/components/charts/ordinal/FunnelChart.tsx
@@ -5,16 +5,14 @@ import * as React from "react"
 import { useMemo, forwardRef, useRef } from "react"
 import StreamOrdinalFrame from "../../stream/StreamOrdinalFrame"
 import type { StreamOrdinalFrameProps, StreamOrdinalFrameHandle } from "../../stream/ordinalTypes"
-import { getColor } from "../shared/colorUtils"
-import { useChartMode, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { useChartMode, useThemeCategorical } from "../shared/hooks"
 import type { LegendInteractionMode } from "../shared/hooks"
 import type { BaseChartProps, ChartAccessor, CategoryFormatFn } from "../shared/types"
 import { normalizeTooltip, defaultTooltipStyle, type TooltipProp } from "../../Tooltip/Tooltip"
 import ChartError from "../shared/ChartError"
 import { SafeRender, warnMissingField } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { wrapStyleWithSelection } from "../shared/selectionUtils"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
+import { useOrdinalPieceStyle } from "../shared/useOrdinalPieceStyle"
 import type { RealtimeFrameHandle } from "../../realtime/types"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
@@ -216,38 +214,21 @@ export const FunnelChart = forwardRef(function FunnelChart<TDatum extends Datum 
     return "#4e79a7"
   }, [isSingleColor, color, themeCategorical, colorScheme])
 
-  const fpPieceStyle = frameProps.pieceStyle as ((d: any, c?: string) => Datum) | undefined
-
-  const basePieceStyle = useMemo(() => {
-    return (d: Datum, category?: string) => {
-      const base: Record<string, string | number> = {}
-      if (uniformFill) {
-        // Single-category: every step gets the same color
-        base.fill = uniformFill
-      } else if (effectiveColorBy) {
-        base.fill = getColor(d, effectiveColorBy, setup.colorScale)
-      } else {
-        base.fill = resolveDefaultFill(color, themeCategorical, colorScheme, category, categoryIndexMap)
-      }
-      if (fpPieceStyle) {
-        const extra = fpPieceStyle(d, category)
-        if (extra.stroke) base.stroke = extra.stroke
-        if (extra.strokeWidth != null) base.strokeWidth = extra.strokeWidth
-        if (extra.strokeOpacity != null) base.strokeOpacity = extra.strokeOpacity
-      }
-      return base
-    }
-  }, [uniformFill, effectiveColorBy, setup.colorScale, color, themeCategorical, colorScheme, categoryIndexMap, fpPieceStyle])
-
-  const basePieceStyleWithPrimitives = useMemo(
-    () => mergeShapeStyle(basePieceStyle, { stroke, strokeWidth, opacity }),
-    [basePieceStyle, stroke, strokeWidth, opacity]
-  )
-
-  const pieceStyle = useMemo(
-    () => wrapStyleWithSelection(basePieceStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [basePieceStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
+  // Consolidated piece-style. Single-category funnels override
+  // colorBy and feed the uniform color in via `color`, which the
+  // helper passes to `resolveDefaultFill` — every step lands on the
+  // same fill. cycleByCategory stays false for the bar-style
+  // semantic (consistent with BarChart/StackedBar).
+  const pieceStyle = useOrdinalPieceStyle({
+    colorBy: uniformFill ? undefined : effectiveColorBy,
+    colorScale: setup.colorScale,
+    color: uniformFill ?? color,
+    themeCategorical, colorScheme, categoryIndexMap,
+    userPieceStyle: frameProps?.pieceStyle,
+    stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+  })
 
   // Default tooltip showing step, value, and percentage
   const defaultTooltipContent = useMemo(() => {

--- a/src/components/charts/ordinal/GroupedBarChart.tsx
+++ b/src/components/charts/ordinal/GroupedBarChart.tsx
@@ -6,8 +6,7 @@ import * as React from "react"
 import { useMemo, forwardRef, useRef } from "react"
 import StreamOrdinalFrame from "../../stream/StreamOrdinalFrame"
 import type { StreamOrdinalFrameProps, StreamOrdinalFrameHandle } from "../../stream/ordinalTypes"
-import { getColor } from "../shared/colorUtils"
-import { useChartMode, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { useChartMode, useThemeCategorical } from "../shared/hooks"
 import type { LegendInteractionMode } from "../shared/hooks"
 import type { BaseChartProps, ChartAccessor, CategoryFormatFn } from "../shared/types"
 import { type TooltipProp } from "../../Tooltip/Tooltip"
@@ -15,8 +14,7 @@ import { buildOrdinalTooltip } from "../shared/tooltipUtils"
 import ChartError from "../shared/ChartError"
 import { SafeRender } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { wrapStyleWithSelection } from "../shared/selectionUtils"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
+import { useOrdinalPieceStyle } from "../shared/useOrdinalPieceStyle"
 import type { RealtimeFrameHandle } from "../../realtime/types"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useOrdinalStreaming } from "../shared/useOrdinalStreaming"
@@ -162,36 +160,22 @@ export const GroupedBarChart = forwardRef(function GroupedBarChart<TDatum extend
   const themeCategorical = useThemeCategorical()
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [safeData])
 
-  // Merge frameProps.pieceStyle (stroke/strokeWidth for themed borders) with
-  // the HOC's color-resolved fill. The HOC keeps control of fill; users can add borders.
-  const fpPieceStyle = frameProps.pieceStyle as ((d: any, c?: string) => Datum) | undefined
-
-  const basePieceStyle = useMemo(() => {
-    return (d: Datum, category?: string) => {
-      const base: Datum = effectiveColorBy
-        ? (setup.colorScale ? { fill: getColor(d, effectiveColorBy, setup.colorScale) } : {})
-        : { fill: resolveDefaultFill(color, themeCategorical, colorScheme, category, categoryIndexMap) }
-      if (fpPieceStyle) {
-        const extra = fpPieceStyle(d, category)
-        if (extra.stroke) base.stroke = extra.stroke
-        if (extra.strokeWidth != null) base.strokeWidth = extra.strokeWidth
-        if (extra.strokeOpacity != null) base.strokeOpacity = extra.strokeOpacity
-      }
-      return base
-    }
-  }, [effectiveColorBy, setup.colorScale, color, themeCategorical, colorScheme, categoryIndexMap, fpPieceStyle])
-
-  // Overlay top-level primitive props (stroke/strokeWidth/opacity) last so they
-  // win over basePieceStyle + user frameProps.pieceStyle merge.
-  const basePieceStyleWithPrimitives = useMemo(
-    () => mergeShapeStyle(basePieceStyle, { stroke, strokeWidth, opacity }),
-    [basePieceStyle, stroke, strokeWidth, opacity]
-  )
-
-  const pieceStyle = useMemo(
-    () => wrapStyleWithSelection(basePieceStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [basePieceStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
+  // Consolidated piece-style — same recipe as BarChart/StackedBarChart
+  // (base fill, user overlay, primitive props, selection wrap).
+  // GroupedBarChart previously had a stroke-only filter on
+  // frameProps.pieceStyle (it ignored user-supplied fills); aligning
+  // with the helper means users can override fill via
+  // `frameProps.pieceStyle: () => ({ fill: ... })` — consistent with
+  // BarChart and the rest of the bar family.
+  const pieceStyle = useOrdinalPieceStyle({
+    colorBy: effectiveColorBy,
+    colorScale: setup.colorScale,
+    color, themeCategorical, colorScheme, categoryIndexMap,
+    userPieceStyle: frameProps.pieceStyle,
+    stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+  })
 
   const defaultTooltipContent = useMemo(
     () => buildOrdinalTooltip({

--- a/src/components/charts/ordinal/Histogram.tsx
+++ b/src/components/charts/ordinal/Histogram.tsx
@@ -6,16 +6,14 @@ import * as React from "react"
 import { useMemo, forwardRef, useRef } from "react"
 import StreamOrdinalFrame from "../../stream/StreamOrdinalFrame"
 import type { StreamOrdinalFrameProps, StreamOrdinalFrameHandle } from "../../stream/ordinalTypes"
-import { getColor } from "../shared/colorUtils"
-import { useChartMode, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { useChartMode, useThemeCategorical } from "../shared/hooks"
 import type { LegendInteractionMode, LegendPosition } from "../shared/hooks"
 import type { BaseChartProps, ChartAccessor, CategoryFormatFn } from "../shared/types"
 import { defaultTooltipStyle, type TooltipProp } from "../../Tooltip/Tooltip"
 import ChartError from "../shared/ChartError"
 import { SafeRender } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { wrapStyleWithSelection } from "../shared/selectionUtils"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
+import { useOrdinalPieceStyle } from "../shared/useOrdinalPieceStyle"
 import type { RealtimeFrameHandle } from "../../realtime/types"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
@@ -243,22 +241,19 @@ export const Histogram = forwardRef(function Histogram<TDatum extends Datum = Da
   const themeCategorical = useThemeCategorical()
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [safeData])
 
-  const baseSummaryStyle = useMemo(() => {
-    return (d: Datum) => {
-      const resolvedColor = colorBy ? getColor(d, colorBy, setup.colorScale) : resolveDefaultFill(colorProp, themeCategorical, colorScheme, undefined, categoryIndexMap)
-      return { fill: resolvedColor, stroke: resolvedColor, fillOpacity: 0.8 }
-    }
-  }, [colorBy, setup.colorScale, colorProp, themeCategorical, colorScheme, categoryIndexMap])
-
-  const baseSummaryStyleWithPrimitives = useMemo(
-    () => mergeShapeStyle(baseSummaryStyle, { stroke, strokeWidth, opacity }),
-    [baseSummaryStyle, stroke, strokeWidth, opacity]
-  )
-
-  const summaryStyle = useMemo(
-    () => wrapStyleWithSelection(baseSummaryStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [baseSummaryStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
+  // Consolidated summary-style — same recipe as BoxPlot/ViolinPlot/
+  // RidgelinePlot.
+  const summaryStyle = useOrdinalPieceStyle({
+    colorBy,
+    colorScale: setup.colorScale,
+    color: colorProp, themeCategorical, colorScheme, categoryIndexMap,
+    userPieceStyle: undefined,
+    stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+    baseStyleExtras: { fillOpacity: 0.8 },
+    linkStrokeToFill: true,
+  })
 
   const defaultTooltipContent = useMemo(() => {
     return (d: Datum) => {

--- a/src/components/charts/ordinal/LikertChart.tsx
+++ b/src/components/charts/ordinal/LikertChart.tsx
@@ -11,8 +11,7 @@ import { normalizeTooltip, defaultTooltipStyle, type TooltipProp } from "../../T
 import ChartError from "../shared/ChartError"
 import { SafeRender } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { wrapStyleWithSelection } from "../shared/selectionUtils"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
+import { useOrdinalPieceStyle } from "../shared/useOrdinalPieceStyle"
 import type { RealtimeFrameHandle } from "../../realtime/types"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useStreamingLegend } from "../shared/useStreamingLegend"
@@ -326,40 +325,35 @@ export const LikertChart = forwardRef(function LikertChart<TDatum extends Datum 
   }, [levels, levelColorMap])
 
   // ── Piece style ──────────────────────────────────────────────────────
-  const fpPieceStyle = frameProps.pieceStyle as ((d: any, c?: string) => Datum) | undefined
-
-  const basePieceStyle = useMemo(() => {
-    return (d: Datum, category?: string) => {
+  // LikertChart's color model is level-keyed (a `levelColorMap` per
+  // diverging step), so the fill comes through `baseStyleExtras` as
+  // a function. The helper detects that extras supplied a fill and
+  // skips its standard color-resolution path; user pieceStyle and
+  // primitive props still merge over the level fill normally.
+  const pieceStyle = useOrdinalPieceStyle({
+    // colorBy/colorScheme are unused since extras supplies fill
+    // directly — pass undefined so the helper's fallback paths
+    // don't accidentally fire.
+    colorBy: undefined,
+    colorScale: undefined,
+    color: undefined,
+    themeCategorical: undefined,
+    colorScheme: undefined,
+    categoryIndexMap: new Map<string, number>(),  // unused since extras supplies fill
+    userPieceStyle: frameProps?.pieceStyle,
+    stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+    baseStyleExtras: (d) => {
       const label = d.__likertLevelLabel || d.data?.__likertLevelLabel
       const level = d.__likertLevel || d.data?.__likertLevel
-      let base: Datum
-      if (level === NEUTRAL_NEG || level === NEUTRAL_POS) {
-        base = { fill: neutralColor }
-      } else {
-        const key = label || level
-        base = (key && levelColorMap.has(key))
-          ? { fill: levelColorMap.get(key)! }
-          : { fill: "#888" }
-      }
-      if (fpPieceStyle) {
-        const extra = fpPieceStyle(d, category)
-        if (extra.stroke) base.stroke = extra.stroke
-        if (extra.strokeWidth != null) base.strokeWidth = extra.strokeWidth
-        if (extra.strokeOpacity != null) base.strokeOpacity = extra.strokeOpacity
-      }
-      return base
-    }
-  }, [levelColorMap, neutralColor, fpPieceStyle])
-
-  const basePieceStyleWithPrimitives = useMemo(
-    () => mergeShapeStyle(basePieceStyle, { stroke, strokeWidth, opacity }),
-    [basePieceStyle, stroke, strokeWidth, opacity]
-  )
-
-  const pieceStyle = useMemo(
-    () => wrapStyleWithSelection(basePieceStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [basePieceStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
+      if (level === NEUTRAL_NEG || level === NEUTRAL_POS) return { fill: neutralColor }
+      const key = label || level
+      return (key && levelColorMap.has(key))
+        ? { fill: levelColorMap.get(key)! }
+        : { fill: "#888" }
+    },
+  })
 
   // ── Tooltip ──────────────────────────────────────────────────────────
   const neutralLevelName = useMemo(() => {

--- a/src/components/charts/ordinal/LikertChart.tsx
+++ b/src/components/charts/ordinal/LikertChart.tsx
@@ -22,6 +22,14 @@ import {
   NEUTRAL_POS,
 } from "../shared/useLikertAggregation"
 
+// Stable empty map for `useOrdinalPieceStyle.categoryIndexMap`.
+// LikertChart drives fill from `baseStyleExtras` (level-keyed
+// palette) so the helper's category-cycling path never fires —
+// the map is genuinely unused. Keeping a single reference at
+// module scope avoids re-allocating on every render, which would
+// otherwise bust the helper's `basePieceStyle` memoization.
+const EMPTY_CATEGORY_INDEX_MAP = new Map<string, number>()
+
 /**
  * LikertChart — visualize Likert scale survey responses.
  *
@@ -339,7 +347,7 @@ export const LikertChart = forwardRef(function LikertChart<TDatum extends Datum 
     color: undefined,
     themeCategorical: undefined,
     colorScheme: undefined,
-    categoryIndexMap: new Map<string, number>(),  // unused since extras supplies fill
+    categoryIndexMap: EMPTY_CATEGORY_INDEX_MAP,  // stable; unused since extras supplies fill
     userPieceStyle: frameProps?.pieceStyle,
     stroke, strokeWidth, opacity,
     effectiveSelectionHook: setup.effectiveSelectionHook,

--- a/src/components/charts/ordinal/PieChart.tsx
+++ b/src/components/charts/ordinal/PieChart.tsx
@@ -6,8 +6,7 @@ import * as React from "react"
 import { useMemo, forwardRef, useRef } from "react"
 import StreamOrdinalFrame from "../../stream/StreamOrdinalFrame"
 import type { StreamOrdinalFrameProps, StreamOrdinalFrameHandle } from "../../stream/ordinalTypes"
-import { getColor } from "../shared/colorUtils"
-import { useChartMode, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { useChartMode, useThemeCategorical } from "../shared/hooks"
 import type { LegendInteractionMode, LegendPosition } from "../shared/hooks"
 import type { BaseChartProps, ChartAccessor } from "../shared/types"
 import { type TooltipProp } from "../../Tooltip/Tooltip"
@@ -15,11 +14,10 @@ import { buildOrdinalTooltip } from "../shared/tooltipUtils"
 import ChartError from "../shared/ChartError"
 import { SafeRender } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { wrapStyleWithSelection } from "../shared/selectionUtils"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
 import type { RealtimeFrameHandle } from "../../realtime/types"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useOrdinalStreaming } from "../shared/useOrdinalStreaming"
+import { useOrdinalPieceStyle } from "../shared/useOrdinalPieceStyle"
 
 /**
  * PieChart component props
@@ -195,31 +193,24 @@ export const PieChart = forwardRef(function PieChart<TDatum extends Datum = Datu
   const themeCategorical = useThemeCategorical()
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [safeData])
 
-  const basePieceStyle = useMemo(() => {
-    return (d: Datum, category?: string) => {
-      if (effectiveColorBy) {
-        if (setup.colorScale) return { fill: getColor(d, effectiveColorBy, setup.colorScale) }
-        return {} // Let frame use its own color scheme (push API)
-      }
-      return { fill: resolveDefaultFill(color, themeCategorical, colorScheme, category, categoryIndexMap) }
-    }
-  }, [effectiveColorBy, setup.colorScale, color, themeCategorical, colorScheme, categoryIndexMap])
-
-  const mergedPieceStyle = useMemo(() => {
-    const userPieceStyle = frameProps?.pieceStyle
-    const baseWithUser = (!userPieceStyle || typeof userPieceStyle !== "function")
-      ? basePieceStyle
-      : (d: Datum, category?: string) => ({
-        ...basePieceStyle(d, category),
-        ...((userPieceStyle as ((...args: any[]) => any))(d, category) || {}),
-      })
-    return mergeShapeStyle(baseWithUser, { stroke, strokeWidth, opacity })
-  }, [basePieceStyle, frameProps, stroke, strokeWidth, opacity])
-
-  const pieceStyle = useMemo(
-    () => wrapStyleWithSelection(mergedPieceStyle, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [mergedPieceStyle, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
+  // PieChart's `effectiveColorBy` may differ from the raw `colorBy`
+  // prop (e.g. when it derives from `categoryAccessor` for the
+  // standard one-color-per-slice case). The shared piece-style
+  // helper handles the push-mode colorScale-undefined branch
+  // identically to the previous hand-rolled basePieceStyle.
+  const pieceStyle = useOrdinalPieceStyle({
+    colorBy: effectiveColorBy,
+    colorScale: setup.colorScale,
+    color, themeCategorical, colorScheme, categoryIndexMap,
+    userPieceStyle: frameProps?.pieceStyle,
+    stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+    // Each slice gets its own scheme color when colorBy is unset —
+    // PieChart's "categoryAccessor implicitly differentiates slices"
+    // semantics.
+    cycleByCategory: true,
+  })
 
   const defaultTooltipContent = useMemo(
     () => buildOrdinalTooltip({

--- a/src/components/charts/ordinal/RidgelinePlot.tsx
+++ b/src/components/charts/ordinal/RidgelinePlot.tsx
@@ -6,16 +6,14 @@ import * as React from "react"
 import { useMemo, forwardRef, useRef } from "react"
 import StreamOrdinalFrame from "../../stream/StreamOrdinalFrame"
 import type { StreamOrdinalFrameProps, StreamOrdinalFrameHandle } from "../../stream/ordinalTypes"
-import { getColor } from "../shared/colorUtils"
-import { useChartMode, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { useChartMode, useThemeCategorical } from "../shared/hooks"
 import type { LegendInteractionMode, LegendPosition } from "../shared/hooks"
 import type { BaseChartProps, ChartAccessor, CategoryFormatFn } from "../shared/types"
 import { type TooltipProp } from "../../Tooltip/Tooltip"
 import ChartError from "../shared/ChartError"
 import { SafeRender } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { wrapStyleWithSelection } from "../shared/selectionUtils"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
+import { useOrdinalPieceStyle } from "../shared/useOrdinalPieceStyle"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
 import type { RealtimeFrameHandle } from "../../realtime/types"
@@ -156,22 +154,20 @@ export const RidgelinePlot = forwardRef(function RidgelinePlot<TDatum extends Da
   const themeCategorical = useThemeCategorical()
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [safeData])
 
-  const baseSummaryStyle = useMemo(() => {
-    return (d: Datum) => {
-      const resolvedColor = colorBy ? getColor(d, colorBy, setup.colorScale) : resolveDefaultFill(colorProp, themeCategorical, colorScheme, undefined, categoryIndexMap)
-      return { fill: resolvedColor, stroke: resolvedColor, fillOpacity: 0.5 }
-    }
-  }, [colorBy, setup.colorScale, colorProp, themeCategorical, colorScheme, categoryIndexMap])
-
-  const baseSummaryStyleWithPrimitives = useMemo(
-    () => mergeShapeStyle(baseSummaryStyle, { stroke, strokeWidth, opacity }),
-    [baseSummaryStyle, stroke, strokeWidth, opacity]
-  )
-
-  const summaryStyle = useMemo(
-    () => wrapStyleWithSelection(baseSummaryStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [baseSummaryStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
+  // Consolidated summary-style — same recipe as BoxPlot/ViolinPlot/
+  // Histogram. Lower fillOpacity (0.5) since ridges stack and
+  // overlap.
+  const summaryStyle = useOrdinalPieceStyle({
+    colorBy,
+    colorScale: setup.colorScale,
+    color: colorProp, themeCategorical, colorScheme, categoryIndexMap,
+    userPieceStyle: undefined,
+    stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+    baseStyleExtras: { fillOpacity: 0.5 },
+    linkStrokeToFill: true,
+  })
 
   const defaultTooltipContent = useMemo(() => buildStatsTooltip(), [])
 

--- a/src/components/charts/ordinal/StackedBarChart.tsx
+++ b/src/components/charts/ordinal/StackedBarChart.tsx
@@ -6,8 +6,7 @@ import * as React from "react"
 import { useMemo, forwardRef, useRef } from "react"
 import StreamOrdinalFrame from "../../stream/StreamOrdinalFrame"
 import type { StreamOrdinalFrameProps, StreamOrdinalFrameHandle } from "../../stream/ordinalTypes"
-import { getColor } from "../shared/colorUtils"
-import { useChartMode, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { useChartMode, useThemeCategorical } from "../shared/hooks"
 import type { LegendInteractionMode } from "../shared/hooks"
 import type { BaseChartProps, ChartAccessor, CategoryFormatFn } from "../shared/types"
 import { type TooltipProp } from "../../Tooltip/Tooltip"
@@ -15,11 +14,10 @@ import { buildOrdinalTooltip } from "../shared/tooltipUtils"
 import ChartError from "../shared/ChartError"
 import { SafeRender } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { wrapStyleWithSelection } from "../shared/selectionUtils"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
 import type { RealtimeFrameHandle } from "../../realtime/types"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useOrdinalStreaming } from "../shared/useOrdinalStreaming"
+import { useOrdinalPieceStyle } from "../shared/useOrdinalPieceStyle"
 
 export interface StackedBarChartProps<TDatum extends Datum = Datum> extends BaseChartProps {
   data?: TDatum[]
@@ -163,34 +161,17 @@ export const StackedBarChart = forwardRef(function StackedBarChart<TDatum extend
   const themeCategorical = useThemeCategorical()
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [safeData])
 
-  const basePieceStyle = useMemo(() => {
-    return (d: Datum, category?: string) => {
-      if (effectiveColorBy) {
-        if (setup.colorScale) return { fill: getColor(d, effectiveColorBy, setup.colorScale) }
-        return {} // Let frame use its own color scheme (push API)
-      }
-      return { fill: resolveDefaultFill(color, themeCategorical, colorScheme, category, categoryIndexMap) }
-    }
-  }, [effectiveColorBy, setup.colorScale, color, themeCategorical, colorScheme, categoryIndexMap])
-
-  // Merge user frameProps.pieceStyle (for stroke etc.) into the HOC's color-resolved style,
-  // then overlay top-level primitive props (stroke/strokeWidth/opacity) last so they win.
-  const mergedPieceStyle = useMemo(() => {
-    const userPieceStyle = frameProps?.pieceStyle
-    const baseWithUser = (!userPieceStyle || typeof userPieceStyle !== "function")
-      ? basePieceStyle
-      : (d: Datum, category?: string) => {
-        const base = basePieceStyle(d, category)
-        const user = (userPieceStyle as ((...args: any[]) => any))(d, category) || {}
-        return { ...base, ...user }
-      }
-    return mergeShapeStyle(baseWithUser, { stroke, strokeWidth, opacity })
-  }, [basePieceStyle, frameProps, stroke, strokeWidth, opacity])
-
-  const pieceStyle = useMemo(
-    () => wrapStyleWithSelection(mergedPieceStyle, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [mergedPieceStyle, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
+  // Consolidated piece-style — same recipe as BarChart/PieChart
+  // (base fill, user overlay, primitive props, selection wrap).
+  const pieceStyle = useOrdinalPieceStyle({
+    colorBy: effectiveColorBy,
+    colorScale: setup.colorScale,
+    color, themeCategorical, colorScheme, categoryIndexMap,
+    userPieceStyle: frameProps?.pieceStyle,
+    stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+  })
 
   const defaultTooltipContent = useMemo(
     () => buildOrdinalTooltip({

--- a/src/components/charts/ordinal/SwarmPlot.tsx
+++ b/src/components/charts/ordinal/SwarmPlot.tsx
@@ -6,8 +6,8 @@ import * as React from "react"
 import { useMemo, forwardRef, useRef } from "react"
 import StreamOrdinalFrame from "../../stream/StreamOrdinalFrame"
 import type { StreamOrdinalFrameProps, StreamOrdinalFrameHandle } from "../../stream/ordinalTypes"
-import { getColor, getSize } from "../shared/colorUtils"
-import { useChartMode, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { getSize } from "../shared/colorUtils"
+import { useChartMode, useThemeCategorical } from "../shared/hooks"
 import type { LegendInteractionMode, LegendPosition } from "../shared/hooks"
 import type { BaseChartProps, ChartAccessor, CategoryFormatFn } from "../shared/types"
 import { type TooltipProp } from "../../Tooltip/Tooltip"
@@ -15,8 +15,7 @@ import { buildOrdinalTooltip } from "../shared/tooltipUtils"
 import ChartError from "../shared/ChartError"
 import { SafeRender } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { wrapStyleWithSelection } from "../shared/selectionUtils"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
+import { useOrdinalPieceStyle } from "../shared/useOrdinalPieceStyle"
 import type { RealtimeFrameHandle } from "../../realtime/types"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
@@ -177,32 +176,22 @@ export const SwarmPlot = forwardRef(function SwarmPlot<TDatum extends Datum = Da
   const themeCategorical = useThemeCategorical()
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [safeData])
 
-  const fpPieceStyle = frameProps.pieceStyle as ((d: any, c?: string) => Datum) | undefined
-
-  const basePieceStyle = useMemo(() => {
-    return (d: Datum, category?: string) => {
-      const base: Record<string, string | number> = { fillOpacity: pointOpacity }
-      base.fill = colorBy ? getColor(d, colorBy, setup.colorScale) : resolveDefaultFill(color, themeCategorical, colorScheme, undefined, categoryIndexMap)
-      base.r = sizeBy ? getSize(d, sizeBy, sizeRange, sizeDomain) : pointRadius
-      if (fpPieceStyle) {
-        const extra = fpPieceStyle(d, category)
-        if (extra.stroke) base.stroke = extra.stroke
-        if (extra.strokeWidth != null) base.strokeWidth = extra.strokeWidth
-        if (extra.strokeOpacity != null) base.strokeOpacity = extra.strokeOpacity
-      }
-      return base
-    }
-  }, [colorBy, setup.colorScale, sizeBy, sizeRange, sizeDomain, pointRadius, pointOpacity, color, themeCategorical, colorScheme, categoryIndexMap, fpPieceStyle])
-
-  const basePieceStyleWithPrimitives = useMemo(
-    () => mergeShapeStyle(basePieceStyle, { stroke, strokeWidth, opacity }),
-    [basePieceStyle, stroke, strokeWidth, opacity]
-  )
-
-  const pieceStyle = useMemo(
-    () => wrapStyleWithSelection(basePieceStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [basePieceStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
+  // Consolidated piece-style. The size encoding (`r` from sizeBy)
+  // is per-datum, so it flows through `baseStyleExtras` as a
+  // function form. fillOpacity is constant.
+  const pieceStyle = useOrdinalPieceStyle({
+    colorBy,
+    colorScale: setup.colorScale,
+    color, themeCategorical, colorScheme, categoryIndexMap,
+    userPieceStyle: frameProps?.pieceStyle,
+    stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+    baseStyleExtras: (d) => ({
+      fillOpacity: pointOpacity,
+      r: sizeBy ? getSize(d, sizeBy, sizeRange, sizeDomain) : pointRadius,
+    }),
+  })
 
   const defaultTooltipContent = useMemo(
     () => buildOrdinalTooltip({

--- a/src/components/charts/ordinal/SwimlaneChart.tsx
+++ b/src/components/charts/ordinal/SwimlaneChart.tsx
@@ -6,8 +6,7 @@ import * as React from "react"
 import { useMemo, forwardRef, useRef } from "react"
 import StreamOrdinalFrame from "../../stream/StreamOrdinalFrame"
 import type { StreamOrdinalFrameProps, StreamOrdinalFrameHandle } from "../../stream/ordinalTypes"
-import { getColor } from "../shared/colorUtils"
-import { useChartMode, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { useChartMode, useThemeCategorical } from "../shared/hooks"
 import type { LegendInteractionMode } from "../shared/hooks"
 import type { BaseChartProps, ChartAccessor, CategoryFormatFn } from "../shared/types"
 import { type TooltipProp } from "../../Tooltip/Tooltip"
@@ -15,8 +14,7 @@ import { buildOrdinalTooltip } from "../shared/tooltipUtils"
 import ChartError from "../shared/ChartError"
 import { SafeRender } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { wrapStyleWithSelection } from "../shared/selectionUtils"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
+import { useOrdinalPieceStyle } from "../shared/useOrdinalPieceStyle"
 import type { RealtimeFrameHandle } from "../../realtime/types"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useOrdinalBrush } from "../shared/useOrdinalBrush"
@@ -239,34 +237,19 @@ export const SwimlaneChart = forwardRef(function SwimlaneChart<TDatum extends Da
   const themeCategorical = useThemeCategorical()
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [safeData])
 
-  // Merge frameProps.pieceStyle (stroke/strokeWidth for themed borders) with
-  // the HOC's color-resolved fill. The HOC keeps control of fill; users can add borders.
-  const fpPieceStyle = frameProps.pieceStyle as ((d: any, c?: string) => Datum) | undefined
-
-  const basePieceStyle = useMemo(() => {
-    return (d: Datum, category?: string) => {
-      const base: Datum = effectiveColorBy
-        ? (setup.colorScale ? { fill: getColor(d, effectiveColorBy, setup.colorScale) } : {})
-        : { fill: resolveDefaultFill(color, themeCategorical, colorScheme, category, categoryIndexMap) }
-      if (fpPieceStyle) {
-        const extra = fpPieceStyle(d, category)
-        if (extra.stroke) base.stroke = extra.stroke
-        if (extra.strokeWidth != null) base.strokeWidth = extra.strokeWidth
-        if (extra.strokeOpacity != null) base.strokeOpacity = extra.strokeOpacity
-      }
-      return base
-    }
-  }, [effectiveColorBy, setup.colorScale, color, themeCategorical, colorScheme, categoryIndexMap, fpPieceStyle])
-
-  const basePieceStyleWithPrimitives = useMemo(
-    () => mergeShapeStyle(basePieceStyle, { stroke, strokeWidth, opacity }),
-    [basePieceStyle, stroke, strokeWidth, opacity]
-  )
-
-  const pieceStyle = useMemo(
-    () => wrapStyleWithSelection(basePieceStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [basePieceStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
+  // Consolidated piece-style. SwimlaneChart uses per-category color
+  // cycling so each lane gets its own scheme color when colorBy
+  // (= subcategoryAccessor by default) isn't explicitly set.
+  const pieceStyle = useOrdinalPieceStyle({
+    colorBy: effectiveColorBy,
+    colorScale: setup.colorScale,
+    color, themeCategorical, colorScheme, categoryIndexMap,
+    userPieceStyle: frameProps?.pieceStyle,
+    stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+    cycleByCategory: true,
+  })
 
   const defaultTooltipContent = useMemo(
     () => buildOrdinalTooltip({

--- a/src/components/charts/ordinal/ViolinPlot.tsx
+++ b/src/components/charts/ordinal/ViolinPlot.tsx
@@ -6,16 +6,14 @@ import * as React from "react"
 import { useMemo, forwardRef, useRef } from "react"
 import StreamOrdinalFrame from "../../stream/StreamOrdinalFrame"
 import type { StreamOrdinalFrameProps, StreamOrdinalFrameHandle } from "../../stream/ordinalTypes"
-import { getColor } from "../shared/colorUtils"
-import { useChartMode, useThemeCategorical, resolveDefaultFill } from "../shared/hooks"
+import { useChartMode, useThemeCategorical } from "../shared/hooks"
 import type { LegendInteractionMode, LegendPosition } from "../shared/hooks"
 import type { BaseChartProps, ChartAccessor, CategoryFormatFn } from "../shared/types"
 import { type TooltipProp } from "../../Tooltip/Tooltip"
 import ChartError from "../shared/ChartError"
 import { SafeRender } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { wrapStyleWithSelection } from "../shared/selectionUtils"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
+import { useOrdinalPieceStyle } from "../shared/useOrdinalPieceStyle"
 import type { RealtimeFrameHandle } from "../../realtime/types"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
@@ -167,22 +165,20 @@ export const ViolinPlot = forwardRef(function ViolinPlot<TDatum extends Datum = 
   const themeCategorical = useThemeCategorical()
   const categoryIndexMap = useMemo(() => new Map<string, number>(), [safeData])
 
-  const baseSummaryStyle = useMemo(() => {
-    return (d: Datum) => {
-      const resolvedColor = colorBy ? getColor(d, colorBy, setup.colorScale) : resolveDefaultFill(colorProp, themeCategorical, colorScheme, undefined, categoryIndexMap)
-      return { fill: resolvedColor, stroke: resolvedColor, fillOpacity: 0.6 }
-    }
-  }, [colorBy, setup.colorScale, colorProp, themeCategorical, colorScheme, categoryIndexMap])
-
-  const baseSummaryStyleWithPrimitives = useMemo(
-    () => mergeShapeStyle(baseSummaryStyle, { stroke, strokeWidth, opacity }),
-    [baseSummaryStyle, stroke, strokeWidth, opacity]
-  )
-
-  const summaryStyle = useMemo(
-    () => wrapStyleWithSelection(baseSummaryStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [baseSummaryStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
+  // Consolidated summary-style — same recipe as BoxPlot/Histogram/
+  // RidgelinePlot. fillOpacity slightly lower than BoxPlot since the
+  // curved outline is thicker.
+  const summaryStyle = useOrdinalPieceStyle({
+    colorBy,
+    colorScale: setup.colorScale,
+    color: colorProp, themeCategorical, colorScheme, categoryIndexMap,
+    userPieceStyle: undefined,
+    stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+    baseStyleExtras: { fillOpacity: 0.6 },
+    linkStrokeToFill: true,
+  })
 
   const defaultTooltipContent = useMemo(() => buildStatsTooltip({ valueAccessor }), [valueAccessor])
 

--- a/src/components/charts/shared/annotationRules.trend.test.tsx
+++ b/src/components/charts/shared/annotationRules.trend.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Tests for the `trend` annotation handler — specifically the
+ * ordinal-frame branch that projects category-index regression
+ * output back through the band scale. The XY branch is exercised
+ * implicitly by the docs LiveExample on Scatterplot/BubbleChart.
+ */
+import { describe, it, expect } from "vitest"
+import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { createDefaultAnnotationRules } from "./annotationRules"
+import type { AnnotationContext } from "../../realtime/types"
+
+// Simple linear scales for tests — d3 scales would work but we don't
+// need their interpolation: a function that maps domain → range is
+// the entire shape the trend handler reads.
+function makeLinearScale(domain: [number, number], range: [number, number]) {
+  const [d0, d1] = domain
+  const [r0, r1] = range
+  // Cast to `any` so we can stash a function into the slot the
+  // shared type narrows to ScaleLinear<number, number>.
+  return ((v: number) => r0 + ((v - d0) / (d1 - d0)) * (r1 - r0)) as any
+}
+
+// Band-style category-name → pixel-center scale, mirroring
+// OrdinalSVGOverlay's `oCentered`. Stable category order is implied
+// by the input map.
+function makeBandScale(centers: Record<string, number>) {
+  return ((name: string) => centers[name]) as any
+}
+
+const rules = createDefaultAnnotationRules("ordinal")
+
+describe("trend annotation — ordinal frame", () => {
+  // Vertical projection: categories on x (band scale), values on y
+  // (linear). Trend regresses (categoryIndex, value) and projects
+  // back through scale.x for x-pixel and scale.y for y-pixel.
+  describe("vertical projection", () => {
+    const ctx: AnnotationContext = {
+      data: [
+        { cat: "Q1", value: 10 },
+        { cat: "Q2", value: 20 },
+        { cat: "Q3", value: 30 },
+        { cat: "Q4", value: 40 },
+      ],
+      xAccessor: "cat",
+      yAccessor: "value",
+      frameType: "ordinal",
+      projection: "vertical",
+      width: 400,
+      height: 200,
+      scales: {
+        x: makeBandScale({ Q1: 50, Q2: 150, Q3: 250, Q4: 350 }),
+        y: makeLinearScale([0, 50], [200, 0]), // inverted Y (typical SVG)
+        o: undefined as any,
+      },
+    }
+
+    it("renders a trend polyline through ordinal categories", () => {
+      const result = rules({ type: "trend", method: "linear" }, 0, ctx)
+      expect(result).not.toBeNull()
+      const html = renderToStaticMarkup(result as React.ReactElement)
+      expect(html).toContain("<polyline")
+      // Linear regression on (0,10),(1,20),(2,30),(3,40) is y = 10x + 10.
+      // First trend point: index 0 → x = scaleX("Q1") = 50, y = scaleY(10) = 160.
+      // Last: index 3 → x = scaleX("Q4") = 350, y = scaleY(40) = 40.
+      expect(html).toContain("50,160")
+      expect(html).toContain("350,40")
+    })
+
+    it("renders a label at the line's right end when label is set", () => {
+      const result = rules({ type: "trend", method: "linear", label: "Trend" }, 0, ctx)
+      const html = renderToStaticMarkup(result as React.ReactElement)
+      expect(html).toContain("Trend")
+    })
+  })
+
+  // Horizontal projection: values on x (linear), categories on y
+  // (band scale). The handler swaps the categorical/value axes.
+  describe("horizontal projection", () => {
+    const ctx: AnnotationContext = {
+      data: [
+        { cat: "Low", value: 10 },
+        { cat: "Mid", value: 20 },
+        { cat: "High", value: 30 },
+      ],
+      // For horizontal: xAccessor reads value, yAccessor reads category.
+      xAccessor: "value",
+      yAccessor: "cat",
+      frameType: "ordinal",
+      projection: "horizontal",
+      width: 400,
+      height: 300,
+      scales: {
+        x: makeLinearScale([0, 30], [0, 400]),
+        y: makeBandScale({ Low: 100, Mid: 150, High: 200 }),
+        o: undefined as any,
+      },
+    }
+
+    it("regresses against the value axis and projects categories through scale.y", () => {
+      const result = rules({ type: "trend", method: "linear" }, 0, ctx)
+      expect(result).not.toBeNull()
+      const html = renderToStaticMarkup(result as React.ReactElement)
+      expect(html).toContain("<polyline")
+      // Regression input: (value=10, idx=0), (20, 1), (30, 2). y = 0.1x - 1
+      // (perfectly linear). First trend point: x=10 → scaleX(10)=133.33,
+      // y=0 → scaleY("Low")=100. Last: x=30 → scaleX(30)=400, y=2 →
+      // scaleY("High")=200.
+      expect(html).toMatch(/133\.\d+,100/)
+      expect(html).toContain("400,200")
+    })
+  })
+
+  describe("LOESS on ordinal frames", () => {
+    const ctx: AnnotationContext = {
+      data: [
+        { cat: "A", value: 5 },
+        { cat: "B", value: 8 },
+        { cat: "C", value: 6 },
+        { cat: "D", value: 12 },
+        { cat: "E", value: 10 },
+      ],
+      xAccessor: "cat",
+      yAccessor: "value",
+      frameType: "ordinal",
+      projection: "vertical",
+      width: 500,
+      height: 300,
+      scales: {
+        x: makeBandScale({ A: 50, B: 150, C: 250, D: 350, E: 450 }),
+        y: makeLinearScale([0, 15], [300, 0]),
+        o: undefined as any,
+      },
+    }
+
+    it("produces a smoothed polyline through every category", () => {
+      const result = rules({ type: "trend", method: "loess", bandwidth: 0.5 }, 0, ctx)
+      expect(result).not.toBeNull()
+      const html = renderToStaticMarkup(result as React.ReactElement)
+      expect(html).toContain("<polyline")
+      // 5 input points → 5 trend points → polyline spans 5 x,y pairs.
+      const pointsAttr = html.match(/points="([^"]*)"/)?.[1] ?? ""
+      const segments = pointsAttr.trim().split(/\s+/)
+      expect(segments.length).toBe(5)
+    })
+  })
+
+  describe("guards", () => {
+    const baseCtx: AnnotationContext = {
+      xAccessor: "cat",
+      yAccessor: "value",
+      frameType: "ordinal",
+      projection: "vertical",
+      width: 200,
+      height: 200,
+      scales: {
+        x: makeBandScale({ A: 50, B: 150 }),
+        y: makeLinearScale([0, 100], [200, 0]),
+        o: undefined as any,
+      },
+    }
+
+    it("returns null when fewer than 2 data points", () => {
+      const ctx = { ...baseCtx, data: [{ cat: "A", value: 1 }] }
+      expect(rules({ type: "trend" }, 0, ctx)).toBeNull()
+    })
+
+    it("returns null when scales aren't available", () => {
+      const ctx = { ...baseCtx, data: [{ cat: "A", value: 1 }, { cat: "B", value: 2 }], scales: null }
+      expect(rules({ type: "trend" }, 0, ctx)).toBeNull()
+    })
+  })
+})

--- a/src/components/charts/shared/annotationRules.trend.test.tsx
+++ b/src/components/charts/shared/annotationRules.trend.test.tsx
@@ -74,8 +74,14 @@ describe("trend annotation — ordinal frame", () => {
     })
   })
 
-  // Horizontal projection: values on x (linear), categories on y
-  // (band scale). The handler swaps the categorical/value axes.
+  // Horizontal projection: values on x-pixel-axis (linear),
+  // categories on y-pixel-axis (band scale). At the AnnotationContext
+  // level, xAccessor/yAccessor still map to oAccessor (category) /
+  // rAccessor (value) respectively — projection only changes pixel
+  // projection through scales.x / scales.y, NOT which data field is
+  // categorical vs numeric. This mirrors how StreamOrdinalFrame
+  // forwards accessors to OrdinalSVGOverlay (both projections pass
+  // xAccessor=oAccessor, yAccessor=rAccessor).
   describe("horizontal projection", () => {
     const ctx: AnnotationContext = {
       data: [
@@ -83,14 +89,17 @@ describe("trend annotation — ordinal frame", () => {
         { cat: "Mid", value: 20 },
         { cat: "High", value: 30 },
       ],
-      // For horizontal: xAccessor reads value, yAccessor reads category.
-      xAccessor: "value",
-      yAccessor: "cat",
+      xAccessor: "cat",
+      yAccessor: "value",
       frameType: "ordinal",
       projection: "horizontal",
       width: 400,
       height: 300,
       scales: {
+        // In horizontal projection scales.x is the linear value scale
+        // and scales.y is the band-centered category scale. The
+        // accessors above are still category/value — only the pixel
+        // axis flips.
         x: makeLinearScale([0, 30], [0, 400]),
         y: makeBandScale({ Low: 100, Mid: 150, High: 200 }),
         o: undefined as any,
@@ -102,10 +111,10 @@ describe("trend annotation — ordinal frame", () => {
       expect(result).not.toBeNull()
       const html = renderToStaticMarkup(result as React.ReactElement)
       expect(html).toContain("<polyline")
-      // Regression input: (value=10, idx=0), (20, 1), (30, 2). y = 0.1x - 1
-      // (perfectly linear). First trend point: x=10 → scaleX(10)=133.33,
-      // y=0 → scaleY("Low")=100. Last: x=30 → scaleX(30)=400, y=2 →
-      // scaleY("High")=200.
+      // Regression input: (catIdx=0, value=10), (1, 20), (2, 30). The
+      // perfect fit is value = 10*idx + 10. First trend point: idx=0
+      // → scaleY("Low")=100, value=10 → scaleX(10)=133.33. Last:
+      // idx=2 → scaleY("High")=200, value=30 → scaleX(30)=400.
       expect(html).toMatch(/133\.\d+,100/)
       expect(html).toContain("400,200")
     })

--- a/src/components/charts/shared/annotationRules.trend.test.tsx
+++ b/src/components/charts/shared/annotationRules.trend.test.tsx
@@ -120,6 +120,48 @@ describe("trend annotation — ordinal frame", () => {
     })
   })
 
+  // The trend handler reads `data[xAccessor]` / `data[yAccessor]`
+  // with string keys. When the chart's user accessor is a function,
+  // StreamOrdinalFrame bakes the resolved value under a synthetic
+  // string key (via `annotationAccessorResolver`) and forwards that
+  // synthetic key as the annotation context's xAccessor — so this
+  // handler works against the synthetic-keyed shape uniformly.
+  // This test pins the integration: a synthetic key correctly
+  // surfaces into the trend regression path.
+  describe("function accessor → synthetic key path", () => {
+    const ctx: AnnotationContext = {
+      // What StreamOrdinalFrame produces when categoryAccessor is
+      // function-valued: synthetic keys, baked values.
+      data: [
+        { __semiotic_resolvedO: "Q1", __semiotic_resolvedR: 10 },
+        { __semiotic_resolvedO: "Q2", __semiotic_resolvedR: 20 },
+        { __semiotic_resolvedO: "Q3", __semiotic_resolvedR: 30 },
+      ],
+      xAccessor: "__semiotic_resolvedO",
+      yAccessor: "__semiotic_resolvedR",
+      frameType: "ordinal",
+      projection: "vertical",
+      width: 400,
+      height: 200,
+      scales: {
+        x: makeBandScale({ Q1: 50, Q2: 200, Q3: 350 }),
+        y: makeLinearScale([0, 50], [200, 0]),
+        o: undefined as any,
+      },
+    }
+
+    it("regresses through synthetic-keyed annotation data", () => {
+      const result = rules({ type: "trend", method: "linear" }, 0, ctx)
+      expect(result).not.toBeNull()
+      const html = renderToStaticMarkup(result as React.ReactElement)
+      expect(html).toContain("<polyline")
+      // First trend point: idx=0 → x=50, y=10 → 160. Last:
+      // idx=2 → x=350, y=30 → 80.
+      expect(html).toContain("50,160")
+      expect(html).toContain("350,80")
+    })
+  })
+
   describe("LOESS on ordinal frames", () => {
     const ctx: AnnotationContext = {
       data: [

--- a/src/components/charts/shared/annotationRules.tsx
+++ b/src/components/charts/shared/annotationRules.tsx
@@ -340,19 +340,120 @@ export function createDefaultAnnotationRules(
       }
 
       // ── Trend (regression line) ───────────────────────────────────────
+      //
+      // Supports both XY (continuous-axis) and ordinal frames. For
+      // ordinal frames the categorical axis is treated as a numeric
+      // category-index for regression input; pixel positions are
+      // resolved through the band scale via category-name lookup
+      // (with linear interpolation between band centers for
+      // fractional LOESS indices).
       case "trend": {
         const data = context.data || []
         if (data.length < 2) return null
         const xAcc = context.xAccessor || "x"
         const yAcc = context.yAccessor || "y"
-        const points: [number, number][] = data
-          .map((d) => [d[xAcc], d[yAcc]] as [number, number])
-          .filter((p) => p[0] != null && p[1] != null)
+
+        const isOrdinal = context.frameType === "ordinal"
+        const isHoriz = context.projection === "horizontal"
+
+        // Resolve which axis carries the categorical value for
+        // ordinal frames. Vertical projection: categories on x
+        // (using the o-centered scale.x); horizontal: categories on
+        // y (using scale.y). For XY the categorical concept doesn't
+        // apply — both axes are continuous.
+        const categoricalAccessor = isOrdinal ? (isHoriz ? yAcc : xAcc) : null
+        const valueAccessor = isOrdinal ? (isHoriz ? xAcc : yAcc) : null
+
+        // Build regression input + record category order so we can
+        // map regression x-output back to the band scale at render
+        // time.
+        let points: [number, number][]
+        const categoryNames: string[] = []
+        const indexByCategory = new Map<string, number>()
+
+        if (isOrdinal && categoricalAccessor && valueAccessor) {
+          // Walk data to assign each unique category an index in
+          // first-seen order. Regression uses the index as a stand-in
+          // for the discrete band position.
+          for (const d of data) {
+            const cat = d[categoricalAccessor]
+            if (cat == null) continue
+            const key = String(cat)
+            if (!indexByCategory.has(key)) {
+              indexByCategory.set(key, categoryNames.length)
+              categoryNames.push(key)
+            }
+          }
+          points = data
+            .map((d) => {
+              const cat = d[categoricalAccessor]
+              const v = d[valueAccessor]
+              if (cat == null || v == null) return null
+              const idx = indexByCategory.get(String(cat))
+              return idx != null ? ([idx, +v] as [number, number]) : null
+            })
+            .filter((p): p is [number, number] => p !== null)
+        } else {
+          // XY path — direct accessor read.
+          points = data
+            .map((d) => [d[xAcc], d[yAcc]] as [number, number])
+            .filter((p) => p[0] != null && p[1] != null)
+        }
         if (points.length < 2) return null
 
+        // Resolve the pair of axis scales we'll project trend points
+        // through. For XY both are linear and read directly. For
+        // ordinal, the categorical scale takes a category-name
+        // string → pixel; we wrap it in an interpolator that accepts
+        // fractional indices (for LOESS, which produces one trend
+        // point per input index).
         const scaleX = context.scales?.x ?? context.scales?.time
         const scaleY = context.scales?.y ?? context.scales?.value
         if (!scaleX || !scaleY) return null
+
+        const interpolateBandScale = (bandScale: (k: string) => number) => (idx: number) => {
+          const i0 = Math.max(0, Math.floor(idx))
+          const i1 = Math.min(categoryNames.length - 1, i0 + 1)
+          const t = idx - i0
+          const p0 = bandScale(categoryNames[i0])
+          const p1 = bandScale(categoryNames[i1])
+          return p0 + (p1 - p0) * t
+        }
+
+        // Build (xPixel, yPixel) projector for regression output.
+        // The cast through `unknown` is intentional: ordinal frames
+        // place a `(category-name) => pixel` function in `scales.x`
+        // (or `scales.y` when projection="horizontal"), but the
+        // shared type narrows to `ScaleLinear<number, number>`. At
+        // this branch we know the runtime shape from
+        // `frameType === "ordinal"` + projection.
+        //
+        // For ordinal regression, points are always
+        // `[categoryIndex, value]` regardless of projection. The
+        // projection-aware mapping back to pixels is
+        // - vertical: xPixel from band-scale on x, yPixel from
+        //   linear value scale on y
+        // - horizontal: xPixel from linear value scale on x (using
+        //   `value`), yPixel from band-scale on y (using
+        //   `categoryIndex`).
+        const sxAny = scaleX as unknown as (k: any) => number
+        const syAny = scaleY as unknown as (k: any) => number
+        let project: (regressionX: number, regressionY: number) => [number, number]
+        if (isOrdinal) {
+          if (isHoriz) {
+            // regressionX = categoryIndex → through band-scale (y axis)
+            // regressionY = value → through linear scale (x axis)
+            const yProject = interpolateBandScale(syAny)
+            project = (catIdx, value) => [sxAny(value), yProject(catIdx)]
+          } else {
+            // regressionX = categoryIndex → through band-scale (x axis)
+            // regressionY = value → through linear scale (y axis)
+            const xProject = interpolateBandScale(sxAny)
+            project = (catIdx, value) => [xProject(catIdx), syAny(value)]
+          }
+        } else {
+          project = (x, y) => [sxAny(x), syAny(y)]
+        }
 
         const method = ann.method || "linear"
         let trendPoints: [number, number][]
@@ -370,9 +471,14 @@ export function createDefaultAnnotationRules(
         }
 
         const linePoints = trendPoints
-          .map(([x, y]) => `${scaleX(x)},${scaleY(y)}`)
+          .map(([x, y]) => {
+            const [px, py] = project(x, y)
+            return `${px},${py}`
+          })
           .join(" ")
         const color = ann.color || "#6366f1"
+        const last = trendPoints[trendPoints.length - 1]
+        const [labelPx, labelPy] = project(last[0], last[1])
         return (
           <g key={`ann-${index}`}>
             <polyline
@@ -384,8 +490,8 @@ export function createDefaultAnnotationRules(
             />
             {ann.label && (
               <text
-                x={scaleX(trendPoints[trendPoints.length - 1][0]) + 4}
-                y={scaleY(trendPoints[trendPoints.length - 1][1]) - 4}
+                x={labelPx + 4}
+                y={labelPy - 4}
                 fill={color}
                 fontSize={11}
               >

--- a/src/components/charts/shared/annotationRules.tsx
+++ b/src/components/charts/shared/annotationRules.tsx
@@ -356,13 +356,16 @@ export function createDefaultAnnotationRules(
         const isOrdinal = context.frameType === "ordinal"
         const isHoriz = context.projection === "horizontal"
 
-        // Resolve which axis carries the categorical value for
-        // ordinal frames. Vertical projection: categories on x
-        // (using the o-centered scale.x); horizontal: categories on
-        // y (using scale.y). For XY the categorical concept doesn't
-        // apply — both axes are continuous.
-        const categoricalAccessor = isOrdinal ? (isHoriz ? yAcc : xAcc) : null
-        const valueAccessor = isOrdinal ? (isHoriz ? xAcc : yAcc) : null
+        // In ordinal frames, the annotation context's
+        // xAccessor/yAccessor always map to oAccessor/rAccessor
+        // (category/value) regardless of projection — see
+        // StreamOrdinalFrame.tsx where OrdinalSVGOverlay receives
+        // `xAccessor=oAccessor, yAccessor=rAccessor` for both
+        // horizontal and vertical projections. Projection only
+        // changes pixel projection (via scales.x / scales.y), not
+        // which data field is categorical vs numeric.
+        const categoricalAccessor = isOrdinal ? xAcc : null
+        const valueAccessor = isOrdinal ? yAcc : null
 
         // Build regression input + record category order so we can
         // map regression x-output back to the band scale at render

--- a/src/components/charts/shared/chartSpecs.ts
+++ b/src/components/charts/shared/chartSpecs.ts
@@ -37,6 +37,78 @@ export type PropType = "string" | "number" | "boolean" | "array" | "object" | "f
 export type DataShape = "array" | "object" | "network" | "realtime" | "none"
 export type ChartCategory = "xy" | "ordinal" | "network" | "geo" | "realtime"
 
+/**
+ * Capability tags for runtime behavior. Driven by the
+ * `hoc-frame-architecture-audit` Phase 1: each chart declares which
+ * features it actually supports so docs, AI/MCP tools, and CI gates
+ * can read structured truth instead of inferring it from the source.
+ *
+ * All fields are required so a new chart entry can't omit them
+ * silently — the audit's anti-goal "Do not make registry metadata
+ * aspirational. It should describe real runtime behavior and be
+ * checked." applies here.
+ */
+export interface ChartCapabilities {
+  /**
+   * Render pipeline. `canvas` for Stream-Frame-driven charts that
+   * paint to canvas with SVG overlays for chrome (the common case).
+   * `svg` for charts that are pure SVG (none today, but reserved).
+   * `hybrid` for charts that use both — currently every Stream-Frame
+   * HOC qualifies as hybrid; reserve `canvas` for any future
+   * canvas-only fallback.
+   */
+  renderModes: Array<"canvas" | "svg" | "hybrid">
+
+  /** Renders a legend swatch column when `colorBy` (or equivalent)
+   *  resolves to non-empty categories. */
+  supportsLegend: boolean
+  /** Reads from a `selection` prop and dims/highlights matching
+   *  marks via `wrapStyleWithSelection` or equivalent. */
+  supportsSelection: boolean
+  /** Produces a hover-driven selection (used by linked crosshair /
+   *  cross-filter patterns) via `linkedHover`. */
+  supportsLinkedHover: boolean
+  /** Exposes a ref handle (`push`, `pushMany`, etc.) so consumers
+   *  can mutate the data list without re-rendering. Hierarchy
+   *  charts (Treemap/CirclePack/TreeDiagram/OrbitDiagram) and
+   *  pure-synthetic charts (GaugeChart) declare false. */
+  supportsPush: boolean
+  /** Renders to a static SVG via `renderChart()` from `semiotic/server`
+   *  through a registered entry in `serverChartConfigs.ts`. SSR-only
+   *  charts (none yet) and HOC-SSR exclusions also declare false. */
+  supportsSSR: boolean
+
+  /**
+   * How color is consumed by the chart's data marks.
+   * - `categorical`: discrete buckets, paired with a `colorBy` accessor.
+   * - `sequential`: continuous scale (heatmap intensity, choropleth value).
+   * - `threshold`: stepped scale with explicit breakpoints (gauge zones).
+   * - `continuous`: smooth interpolation along a 1-D path (gradient fill).
+   * - `none`: chart doesn't use color encoding (sparkline, pure layout).
+   */
+  colorModel: "categorical" | "sequential" | "threshold" | "continuous" | "none"
+
+  /**
+   * Where the geometry comes from.
+   * - `plugin`: a built-in plugin in the frame (sankey/force/chord/tree
+   *   for network; bar/pie/swarm/etc. for ordinal; line/area/etc. for XY).
+   * - `custom`: emitted via the frame's customLayout escape hatch
+   *   (ProcessSankey via `customNetworkLayout`, NetworkCustomChart,
+   *   XYCustomChart, OrdinalCustomChart).
+   * - `synthetic`: no layout — the chart constructs its scene from
+   *   the input value(s) directly (GaugeChart computes arc geometry).
+   */
+  layoutMode: "plugin" | "custom" | "synthetic"
+
+  /**
+   * Free-form tag list for opt-in features that don't fit the
+   * boolean shape — e.g. "particles", "forecast", "anomaly", "brush",
+   * "streamgraph", "minimap". Used by docs feature tables and
+   * potential capability-driven AI suggestions.
+   */
+  specialFeatures: string[]
+}
+
 export interface ChartPropSpec {
   /** Allowed runtime types. May be a single value or a union. */
   type: PropType | PropType[]
@@ -74,6 +146,14 @@ export interface ChartSpec {
   propBags: ReadonlyArray<keyof typeof PROP_BAGS>
   /** Chart-specific prop spec, overlaid on top of the composed bags. */
   ownProps: Record<string, ChartPropSpec>
+  /**
+   * Capability matrix — declarative facts about runtime behavior.
+   * Drives docs feature tables, capability-aware AI/MCP tools, and
+   * the `check:capabilities` drift gate (which verifies, e.g., that
+   * a chart claiming `supportsSSR: true` has a matching entry in
+   * `serverChartConfigs.ts`).
+   */
+  capabilities: ChartCapabilities
 }
 
 // ---------------------------------------------------------------------------
@@ -209,6 +289,17 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       // hand-curation oversight. Phase 3 can re-baseline schema with it
       // exposed; for now match the canonical surface.
       roundedTop: { type: "number", omitFromSchema: true },
+      regression: {
+        type: ["boolean", "string", "object"],
+        description: "Overlay a regression line through the bar tops. Accepts true (linear), a method ('linear' | 'polynomial' | 'loess'), or a full RegressionConfig. Pixels resolve through the band scale.",
+      },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["regression-overlay"],
     },
   },
 
@@ -233,6 +324,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       // Canonical schema flags `true` for stacked bars to surface the legend.
       showLegend: { type: "boolean", default: true },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["stack"],
+    },
   },
 
   GroupedBarChart: {
@@ -254,6 +352,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       roundedTop: { type: "number", omitFromSchema: true },
       // Canonical schema flags `true` for grouped bars to surface the legend.
       showLegend: { type: "boolean", default: true },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: [],
     },
   },
 
@@ -280,6 +385,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       onBrush: { type: "function", omitFromSchema: true },
       linkedBrush: { type: ["string", "object"], omitFromSchema: true },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: [],
+    },
   },
 
   BoxPlot: {
@@ -298,6 +410,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       showOutliers: { type: "boolean", default: true, description: "Show outlier points" },
       outlierRadius: { type: "number", default: 3 },
       categoryPadding: { type: "number", default: 20 },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["statistical"],
     },
   },
 
@@ -319,6 +438,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       brush: { type: "boolean", omitFromSchema: true },
       onBrush: { type: "function", omitFromSchema: true },
       linkedBrush: { type: ["string", "object"], omitFromSchema: true },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: [],
     },
   },
 
@@ -343,6 +469,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       onBrush: { type: "function", omitFromSchema: true },
       linkedBrush: { type: ["string", "object"], omitFromSchema: true },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["statistical"],
+    },
   },
 
   RidgelinePlot: {
@@ -360,6 +493,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       bins: { type: "number", description: "Number of bins for density estimation" },
       amplitude: { type: "number", default: 1.5, description: "Unitless multiplier of row height (>1 creates overlap)" },
       categoryPadding: { type: "number", omitFromSchema: true },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: [],
     },
   },
 
@@ -382,6 +522,17 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       // Canonical schema flags showGrid `true` for DotPlot — grid lines help
       // readers eyeball values along the value axis.
       showGrid: { type: "boolean", default: true },
+      regression: {
+        type: ["boolean", "string", "object"],
+        description: "Overlay a regression line through the dots. Same shape as Scatterplot's regression prop.",
+      },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["regression-overlay"],
     },
   },
 
@@ -404,6 +555,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       startAngle: { type: "number", default: 0, description: "Starting angle in radians" },
       cornerRadius: { type: "number", omitFromSchema: true },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: [],
+    },
   },
 
   DonutChart: {
@@ -422,6 +580,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       centerContent: { type: ["object", "string", "number"], description: "React node to render in the center of the donut (accepts string key or JSX)" },
       startAngle: { type: "number", default: 0 },
       cornerRadius: { type: "number", omitFromSchema: true },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: [],
     },
   },
 
@@ -452,6 +617,17 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       showScaleLabels: { type: "boolean", default: true },
       backgroundColor: { type: "string", omitFromSchema: true },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: false, supportsSelection: false, supportsLinkedHover: false,
+      // Single-scalar `value` prop — push API is fundamentally
+      // array-append. Drive realtime via `value={state}` + setInterval
+      // / external store updates, exactly the controlled-prop pattern
+      // the docs streaming demo uses.
+      supportsPush: false, supportsSSR: true,
+      colorModel: "threshold", layoutMode: "synthetic",
+      specialFeatures: ["threshold-zones", "value-only", "controlled-prop-streaming"],
+    },
   },
 
   FunnelChart: {
@@ -472,6 +648,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       showCategoryTicks: { type: "boolean", default: false, description: "Show category tick labels on ordinal axis" },
       responsiveWidth: { type: "boolean" },
       legendPosition: { type: "string", enum: LEGEND_POSITION_ENUM },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: [],
     },
   },
 
@@ -496,6 +679,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       showCategoryTicks: { type: "boolean", description: "Show lane labels on the category axis" },
       responsiveWidth: { type: "boolean" },
       legendPosition: { type: "string", enum: LEGEND_POSITION_ENUM },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["brush"],
     },
   },
 
@@ -523,6 +713,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       orientation: { type: "string", enum: ORIENTATION_ENUM, default: "horizontal" },
       barPadding: { type: "number", default: 20 },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: [],
+    },
   },
 
   // ─── XY family ────────────────────────────────────────────────────────
@@ -548,6 +745,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       fillArea: { type: "boolean", default: false, description: "Fill the area under the line" },
       areaOpacity: { type: "number", default: 0.3, description: "Opacity of the filled area (0-1)" },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["forecast", "anomaly", "gap-handling", "direct-labels", "endpoint-labels"],
+    },
   },
 
   AreaChart: {
@@ -568,6 +772,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       areaOpacity: { type: "number", default: 0.7, description: "Area fill opacity (0-1)" },
       showLine: { type: "boolean", default: true, description: "Show stroke line on top of area" },
       lineWidth: { type: "number", default: 2 },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: [],
     },
   },
 
@@ -591,6 +802,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       lineWidth: { type: "number", default: 2 },
       normalize: { type: "boolean", default: false, description: "Normalize stacks to 100%" },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["stack", "streamgraph"],
+    },
   },
 
   Scatterplot: {
@@ -609,6 +827,17 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       sizeRange: { type: "array", default: [3, 15], description: "Min and max radius for sizeBy scaling" },
       pointRadius: { type: "number", default: 5, description: "Fixed point radius" },
       pointOpacity: { type: "number", default: 0.8 },
+      regression: {
+        type: ["boolean", "string", "object"],
+        description: "Overlay a regression line. true = linear, 'linear' | 'polynomial' | 'loess' = method, or full RegressionConfig object. Sugar over the trend annotation.",
+      },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["regression-overlay"],
     },
   },
 
@@ -629,6 +858,17 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       bubbleOpacity: { type: "number", default: 0.6 },
       bubbleStrokeWidth: { type: "number", default: 1 },
       bubbleStrokeColor: { type: "string", default: "white" },
+      regression: {
+        type: ["boolean", "string", "object"],
+        description: "Overlay a regression line on the bubbles. Same shape as Scatterplot's regression prop.",
+      },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["size-encoding", "streaming-domain", "regression-overlay"],
     },
   },
 
@@ -659,6 +899,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       cellBorderWidth: { type: "number", default: 1 },
       legendPosition: { type: "string", enum: LEGEND_POSITION_ENUM, default: "right", description: "Position of the gradient legend" },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "sequential", layoutMode: "plugin",
+      specialFeatures: [],
+    },
   },
 
   QuadrantChart: {
@@ -686,6 +933,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       pointRadius: { type: "number", default: 5 },
       pointOpacity: { type: "number", default: 0.8 },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: false,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["quadrants", "hoc-ssr-only"],
+    },
   },
 
   MultiAxisLineChart: {
@@ -704,6 +958,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       colorScheme: { type: ["string", "array"] },
       curve: { type: "string", default: "monotoneX" },
       lineWidth: { type: "number", default: 2 },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: false,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["dual-axis", "hoc-ssr-only"],
     },
   },
 
@@ -725,6 +986,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       candlestickStyle: { type: "object", description: "Style overrides." },
       mode: { type: "string", enum: CHART_MODE_ENUM },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["ohlc"],
+    },
   },
 
   ConnectedScatterplot: {
@@ -743,6 +1011,17 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       orderLabel: { type: "string", description: "Label for the ordering metric in tooltips" },
       pointRadius: { type: "number", default: 4, description: "Point radius" },
       pointIdAccessor: { type: ["string", "function"], description: "Accessor for unique point IDs, used by point-anchored annotations" },
+      regression: {
+        type: ["boolean", "string", "object"],
+        description: "Overlay a regression line under the connected path. Same shape as Scatterplot's regression prop.",
+      },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["regression-overlay"],
     },
   },
 
@@ -758,6 +1037,16 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       data: { type: "array" },
       fields: { type: "array" },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      // Composite chart — selection / linkedHover / push all flow
+      // through the inner Scatterplots, not this top-level wrapper.
+      // Consumers wire those features on the cells they configure.
+      supportsLegend: true, supportsSelection: false, supportsLinkedHover: false,
+      supportsPush: false, supportsSSR: false,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["matrix", "brush", "composite-delegates-interaction", "hoc-ssr-only"],
+    },
   },
 
   MinimapChart: {
@@ -770,6 +1059,17 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
     propBags: ["common"],
     ownProps: {
       data: { type: "array" },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      // Interactive composite — wraps an inner XY chart with a brush
+      // overview. Selection / linkedHover / push all flow through the
+      // wrapped chart's own ref and props; this wrapper doesn't
+      // wire them at its level.
+      supportsLegend: true, supportsSelection: false, supportsLinkedHover: false,
+      supportsPush: false, supportsSSR: false,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["brush", "overview-detail", "composite-delegates-interaction", "hoc-ssr-only"],
     },
   },
 
@@ -799,6 +1099,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       forceStrength: { type: "number", default: 0.1 },
       showLabels: { type: "boolean", default: false },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["force-simulation"],
+    },
   },
 
   SankeyDiagram: {
@@ -826,6 +1133,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       edgeOpacity: { type: "number", default: 0.5 },
       // `edgeSort` is a comparator function — runtime-only.
       edgeSort: { type: "function", omitFromSchema: true },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: [],
     },
   },
 
@@ -871,6 +1185,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       particleDensity: { type: "number", default: 1 },
       particleMaxPerEdge: { type: "number", default: 40 },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "custom",
+      specialFeatures: ["temporal", "particles", "lane-reuse"],
+    },
   },
 
   ChordDiagram: {
@@ -897,6 +1218,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       showLabels: { type: "boolean", default: true },
       edgeOpacity: { type: "number", default: 0.5 },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: false, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: [],
+    },
   },
 
   TreeDiagram: {
@@ -920,6 +1248,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       showLabels: { type: "boolean", default: true },
       nodeSize: { type: "number", default: 5 },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: false, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: false, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["hierarchy"],
+    },
   },
 
   Treemap: {
@@ -938,6 +1273,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       colorByDepth: { type: "boolean", default: false },
       showLabels: { type: "boolean", default: true },
       nodeLabel: { type: ["string", "function"] },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: false, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: false, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["hierarchy"],
     },
   },
 
@@ -958,6 +1300,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       showLabels: { type: "boolean", default: true },
       nodeLabel: { type: ["string", "function"] },
       circleOpacity: { type: "number", default: 0.7 },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: false, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: false, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["hierarchy"],
     },
   },
 
@@ -988,6 +1337,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       // pass-through), runtime-only.
       foregroundGraphics: { type: "object", omitFromSchema: true },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: false, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: false, supportsSSR: false,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["hierarchy", "animated", "hoc-ssr-only"],
+    },
   },
 
   // ─── Geo family ──────────────────────────────────────────────────────
@@ -1006,6 +1362,19 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       colorScheme: { type: ["string", "array"] },
       projection: { type: "string", default: "equalEarth" },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      // Values live on `feature.properties` — streaming is per-region
+      // value updates (`mergeData(features, liveRows, { featureKey })`)
+      // re-passed through the `areas` prop. The shared array-append
+      // push API doesn't fit this property-keyed update pattern; the
+      // controlled-prop pattern is the natural realtime API. See the
+      // docs streaming demo on `/charts/choropleth-map`.
+      supportsPush: false, supportsSSR: true,
+      colorModel: "sequential", layoutMode: "plugin",
+      specialFeatures: ["controlled-prop-streaming"],
+    },
   },
 
   ProportionalSymbolMap: {
@@ -1023,6 +1392,15 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       sizeBy: { type: ["string", "function"] },
       areas: { type: ["array", "string"] },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      // Points are array-shaped — push appends to the displayed
+      // points list via `useFrameImperativeHandle({ variant: "geo-points" })`.
+      supportsPush: true, supportsSSR: true,
+      colorModel: "sequential", layoutMode: "plugin",
+      specialFeatures: [],
+    },
   },
 
   FlowMap: {
@@ -1037,6 +1415,17 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       flows: { type: "array" },
       nodes: { type: "array" },
       valueAccessor: { type: ["string", "function"] },
+      lineIdAccessor: { type: ["string", "function"] },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      // Push API translates flow → resolved-line through nodeLookup HOC-side,
+      // then forwards to the frame's `pushLine`/`pushManyLines` via the
+      // `geo-lines` variant in `useFrameImperativeHandle`.
+      supportsPush: true, supportsSSR: true,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["particles"],
     },
   },
 
@@ -1052,6 +1441,15 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       points: { type: "array" },
       center: { type: "array" },
       costAccessor: { type: ["string", "function"] },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      // Points are array-shaped — push appends to the displayed
+      // points list. Cost-driven distortion re-runs on each push.
+      supportsPush: true, supportsSSR: false,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["distortion", "hoc-ssr-only"],
     },
   },
 
@@ -1073,6 +1471,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       strokeWidth: { type: "number" },
       strokeDasharray: { type: "string" },
       transition: { type: "object", description: "Transition config: { duration, easing }" },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: false,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["live-stream"],
     },
   },
 
@@ -1097,6 +1502,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       linkedBrush: { type: ["string", "object"], description: "Cross-chart brush coordination via LinkedCharts. String: selection name. Object: { name, xField, yField }." },
       transition: { type: "object", description: "Transition config: { duration, easing }" },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: false,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["live-stream", "brush"],
+    },
   },
 
   RealtimeSwarmChart: {
@@ -1116,6 +1528,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       stroke: { type: "string" },
       strokeWidth: { type: "number" },
       transition: { type: "object", description: "Transition config: { duration, easing }" },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: false,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["live-stream"],
     },
   },
 
@@ -1137,6 +1556,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       strokeWidth: { type: "number" },
       transition: { type: "object", description: "Transition config: { duration, easing }" },
     },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: false,
+      colorModel: "categorical", layoutMode: "plugin",
+      specialFeatures: ["live-stream"],
+    },
   },
 
   RealtimeHeatmap: {
@@ -1151,6 +1577,13 @@ export const CHART_SPECS: Record<string, ChartSpec> = {
       heatmapXBins: { type: "number" },
       heatmapYBins: { type: "number" },
       aggregation: { type: "string", enum: ["count", "sum", "mean"] as const },
+    },
+    capabilities: {
+      renderModes: ["hybrid"],
+      supportsLegend: true, supportsSelection: true, supportsLinkedHover: true,
+      supportsPush: true, supportsSSR: false,
+      colorModel: "sequential", layoutMode: "plugin",
+      specialFeatures: ["live-stream"],
     },
   },
 }

--- a/src/components/charts/shared/regressionUtils.test.ts
+++ b/src/components/charts/shared/regressionUtils.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest"
+import { buildRegressionAnnotation } from "./regressionUtils"
+
+describe("buildRegressionAnnotation", () => {
+  it("returns undefined for falsy props", () => {
+    expect(buildRegressionAnnotation(undefined)).toBeUndefined()
+    expect(buildRegressionAnnotation(false)).toBeUndefined()
+  })
+
+  it("turns `true` into a default linear trend annotation", () => {
+    const ann = buildRegressionAnnotation(true)
+    expect(ann).toEqual({ type: "trend", method: "linear" })
+  })
+
+  it("turns a method-string into a trend annotation with that method", () => {
+    expect(buildRegressionAnnotation("loess")).toEqual({ type: "trend", method: "loess" })
+    expect(buildRegressionAnnotation("polynomial")).toEqual({ type: "trend", method: "polynomial" })
+    expect(buildRegressionAnnotation("linear")).toEqual({ type: "trend", method: "linear" })
+  })
+
+  it("forwards full config (method + styling) through", () => {
+    const ann = buildRegressionAnnotation({
+      method: "loess",
+      bandwidth: 0.5,
+      color: "#ff0000",
+      strokeWidth: 3,
+      strokeDasharray: "4,4",
+      label: "Trend",
+    })
+    expect(ann).toEqual({
+      type: "trend",
+      method: "loess",
+      bandwidth: 0.5,
+      color: "#ff0000",
+      strokeWidth: 3,
+      strokeDasharray: "4,4",
+      label: "Trend",
+    })
+  })
+
+  it("defaults method to linear when only styling is supplied", () => {
+    const ann = buildRegressionAnnotation({ color: "#000", label: "L" })
+    expect(ann).toEqual({ type: "trend", method: "linear", color: "#000", label: "L" })
+  })
+
+  it("forwards order for polynomial", () => {
+    const ann = buildRegressionAnnotation({ method: "polynomial", order: 3 })
+    expect(ann).toEqual({ type: "trend", method: "polynomial", order: 3 })
+  })
+
+  it("omits unset config keys (no nullish leakage)", () => {
+    const ann = buildRegressionAnnotation({ method: "linear" })
+    expect(ann).toEqual({ type: "trend", method: "linear" })
+    expect(Object.keys(ann!)).toEqual(["type", "method"])
+  })
+})

--- a/src/components/charts/shared/regressionUtils.ts
+++ b/src/components/charts/shared/regressionUtils.ts
@@ -1,0 +1,85 @@
+/**
+ * regressionUtils — sugar for the `trend` annotation.
+ *
+ * The `trend` annotation type (see annotationRules.tsx) already
+ * computes and renders linear / polynomial / LOESS regression lines
+ * for any chart that exposes x/y scales. This module wraps that into
+ * a chart-prop ergonomic — `regression={true}`, `regression="loess"`,
+ * or a full config object — so users don't have to author an
+ * annotation object by hand for the most common cases.
+ *
+ * Mirrors the shape of LineChart's `forecast` and `anomaly` props,
+ * which are likewise sugar over annotation-side work.
+ */
+import type { Datum } from "./datumTypes"
+
+/** Regression methods supported by the trend annotation. */
+export type RegressionMethod = "linear" | "polynomial" | "loess"
+
+/**
+ * Full regression configuration. All visual props mirror the
+ * underlying `trend` annotation; users dropping into the `annotations`
+ * array directly can pass the same shape.
+ */
+export interface RegressionConfig {
+  /** Regression method. @default "linear" */
+  method?: RegressionMethod
+  /** LOESS bandwidth (0–1). Lower = more local detail. @default 0.3 */
+  bandwidth?: number
+  /** Polynomial order (only for `method: "polynomial"`). @default 2 */
+  order?: number
+  /** Stroke color for the regression line. @default "#6366f1" */
+  color?: string
+  /** Stroke width. @default 2 */
+  strokeWidth?: number
+  /** Dash pattern. @default "6,3" */
+  strokeDasharray?: string
+  /** Optional label rendered at the line's right end. */
+  label?: string
+}
+
+/**
+ * Prop shape on chart HOCs. The boolean form gives users a
+ * "just draw a regression line" toggle; the string form picks the
+ * method with default styling; the object form opens up the full
+ * configuration. Mirrors `forecast` / `anomaly` on LineChart.
+ */
+export type RegressionProp = boolean | RegressionMethod | RegressionConfig
+
+/**
+ * Convert a `regression` prop value into the trend-annotation object
+ * to splice into the chart's annotations array. Returns `undefined`
+ * when the prop is falsy so callers can skip the spread.
+ *
+ * @example
+ * ```ts
+ * const trendAnn = buildRegressionAnnotation(regression)
+ * const annotations = [
+ *   ...(trendAnn ? [trendAnn] : []),
+ *   ...(userAnnotations || []),
+ * ]
+ * ```
+ */
+export function buildRegressionAnnotation(
+  regression: RegressionProp | undefined,
+): Datum | undefined {
+  if (!regression) return undefined
+
+  const config: RegressionConfig =
+    typeof regression === "boolean"
+      ? {}
+      : typeof regression === "string"
+        ? { method: regression }
+        : regression
+
+  return {
+    type: "trend",
+    method: config.method ?? "linear",
+    ...(config.bandwidth != null && { bandwidth: config.bandwidth }),
+    ...(config.order != null && { order: config.order }),
+    ...(config.color != null && { color: config.color }),
+    ...(config.strokeWidth != null && { strokeWidth: config.strokeWidth }),
+    ...(config.strokeDasharray != null && { strokeDasharray: config.strokeDasharray }),
+    ...(config.label != null && { label: config.label }),
+  }
+}

--- a/src/components/charts/shared/useAreaSeriesSetup.test.tsx
+++ b/src/components/charts/shared/useAreaSeriesSetup.test.tsx
@@ -1,0 +1,258 @@
+import { describe, it, expect } from "vitest"
+import React from "react"
+import { renderHook } from "@testing-library/react"
+import { useAreaSeriesSetup } from "./useAreaSeriesSetup"
+import { TooltipProvider } from "../../store/TooltipStore"
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  <TooltipProvider>{children}</TooltipProvider>
+
+const baseInput = {
+  lineDataAccessor: "coordinates",
+  colorScale: undefined as ((v: string) => string) | undefined,
+  effectiveSelectionHook: null,
+  resolvedSelection: undefined,
+  areaOpacity: 0.7,
+  showLine: true,
+  lineWidth: 2,
+  showPoints: false,
+  pointRadius: 3,
+  xAccessor: "x",
+  yAccessor: "y",
+}
+
+describe("useAreaSeriesSetup", () => {
+  describe("flattenedData", () => {
+    it("returns empty array when no `data` prop (push mode)", () => {
+      const { result } = renderHook(
+        () => useAreaSeriesSetup({
+          ...baseInput,
+          safeData: [],
+          data: undefined,
+        }),
+        { wrapper },
+      )
+      expect(result.current.flattenedData).toEqual([])
+    })
+
+    it("passes flat data through unchanged when no areaBy and not pre-grouped", () => {
+      const data = [{ x: 1, y: 10 }, { x: 2, y: 20 }]
+      const { result } = renderHook(
+        () => useAreaSeriesSetup({
+          ...baseInput,
+          safeData: data,
+          data,
+        }),
+        { wrapper },
+      )
+      expect(result.current.flattenedData).toBe(data)
+    })
+
+    it("groups by areaBy then re-flattens, re-injecting the areaBy key", () => {
+      const data = [
+        { x: 1, y: 10, cat: "A" },
+        { x: 2, y: 20, cat: "A" },
+        { x: 1, y: 5, cat: "B" },
+      ]
+      const { result } = renderHook(
+        () => useAreaSeriesSetup({
+          ...baseInput,
+          safeData: data,
+          data,
+          areaBy: "cat",
+        }),
+        { wrapper },
+      )
+      const flat = result.current.flattenedData
+      expect(flat).toHaveLength(3)
+      // Each row carries the cat key
+      expect(flat.every((d) => "cat" in d)).toBe(true)
+      // Group A has 2 rows, group B has 1
+      expect(flat.filter((d) => d.cat === "A")).toHaveLength(2)
+      expect(flat.filter((d) => d.cat === "B")).toHaveLength(1)
+    })
+
+    it("flattens pre-grouped area-object format", () => {
+      const data: any[] = [
+        { coordinates: [{ x: 1, y: 10 }, { x: 2, y: 20 }] },
+        { coordinates: [{ x: 1, y: 5 }] },
+      ]
+      const { result } = renderHook(
+        () => useAreaSeriesSetup({
+          ...baseInput,
+          safeData: data,
+          data,
+        }),
+        { wrapper },
+      )
+      expect(result.current.flattenedData).toHaveLength(3)
+    })
+  })
+
+  describe("lineStyle", () => {
+    it("resolves fill+stroke from colorBy + colorScale", () => {
+      const colorScale = (v: string) => ({ A: "#aaa", B: "#bbb" }[v] || "#000")
+      const { result } = renderHook(
+        () => useAreaSeriesSetup({
+          ...baseInput,
+          safeData: [],
+          data: [],
+          colorBy: "cat",
+          colorScale,
+        }),
+        { wrapper },
+      )
+      const style = result.current.lineStyle({ cat: "A" } as any)
+      expect(style.fill).toBe("#aaa")
+      expect(style.stroke).toBe("#aaa")
+      expect(style.strokeWidth).toBe(2)
+    })
+
+    it("falls back to color || DEFAULT_COLOR when colorBy unset", () => {
+      const { result } = renderHook(
+        () => useAreaSeriesSetup({
+          ...baseInput,
+          safeData: [],
+          data: [],
+          color: "tomato",
+        }),
+        { wrapper },
+      )
+      const style = result.current.lineStyle({} as any)
+      expect(style.fill).toBe("tomato")
+      expect(style.stroke).toBe("tomato")
+    })
+
+    it("returns empty style when colorBy set but colorScale undefined (push mode)", () => {
+      const { result } = renderHook(
+        () => useAreaSeriesSetup({
+          ...baseInput,
+          safeData: [],
+          data: [],
+          colorBy: "cat",
+          colorScale: undefined,
+        }),
+        { wrapper },
+      )
+      const style = result.current.lineStyle({ cat: "A" } as any)
+      // No fill / stroke — frame paints from its own palette
+      expect(style.fill).toBeUndefined()
+      expect(style.stroke).toBeUndefined()
+    })
+
+    it("sets stroke=\"none\" when showLine=false", () => {
+      const { result } = renderHook(
+        () => useAreaSeriesSetup({
+          ...baseInput,
+          safeData: [],
+          data: [],
+          showLine: false,
+        }),
+        { wrapper },
+      )
+      const style = result.current.lineStyle({} as any)
+      expect(style.stroke).toBe("none")
+      expect(style.strokeWidth).toBeUndefined()
+    })
+
+    it("respects areaOpacity through fillOpacity", () => {
+      const { result } = renderHook(
+        () => useAreaSeriesSetup({
+          ...baseInput,
+          safeData: [],
+          data: [],
+          areaOpacity: 0.4,
+        }),
+        { wrapper },
+      )
+      const style = result.current.lineStyle({} as any)
+      expect(style.fillOpacity).toBe(0.4)
+    })
+
+    it("primitive props (stroke/strokeWidth/opacity) win over base", () => {
+      const { result } = renderHook(
+        () => useAreaSeriesSetup({
+          ...baseInput,
+          safeData: [],
+          data: [],
+          color: "#aaa",
+          stroke: "purple",
+          strokeWidth: 7,
+          opacity: 0.3,
+        }),
+        { wrapper },
+      )
+      const style = result.current.lineStyle({} as any)
+      expect(style.stroke).toBe("purple")
+      expect(style.strokeWidth).toBe(7)
+      expect(style.opacity).toBe(0.3)
+    })
+  })
+
+  describe("pointStyle", () => {
+    it("returns undefined when showPoints=false", () => {
+      const { result } = renderHook(
+        () => useAreaSeriesSetup({
+          ...baseInput,
+          safeData: [],
+          data: [],
+          showPoints: false,
+        }),
+        { wrapper },
+      )
+      expect(result.current.pointStyle).toBeUndefined()
+    })
+
+    it("returns a fn that emits r=pointRadius when showPoints=true", () => {
+      const { result } = renderHook(
+        () => useAreaSeriesSetup({
+          ...baseInput,
+          safeData: [],
+          data: [],
+          showPoints: true,
+          pointRadius: 5,
+        }),
+        { wrapper },
+      )
+      const ps = result.current.pointStyle!
+      const style = ps({} as any)
+      expect(style.r).toBe(5)
+      expect(style.fillOpacity).toBe(1)
+    })
+
+    it("uses parentLine for color when present (stacked-area row)", () => {
+      const colorScale = (v: string) => `c-${v}`
+      const { result } = renderHook(
+        () => useAreaSeriesSetup({
+          ...baseInput,
+          safeData: [],
+          data: [],
+          showPoints: true,
+          colorBy: "cat",
+          colorScale,
+        }),
+        { wrapper },
+      )
+      const ps = result.current.pointStyle!
+      // Row carries parentLine with the group key
+      const style = ps({ x: 1, y: 2, parentLine: { cat: "A" } } as any)
+      expect(style.fill).toBe("c-A")
+    })
+
+    it("falls back to color || DEFAULT_COLOR when colorBy unset", () => {
+      const { result } = renderHook(
+        () => useAreaSeriesSetup({
+          ...baseInput,
+          safeData: [],
+          data: [],
+          showPoints: true,
+          color: "tomato",
+        }),
+        { wrapper },
+      )
+      const ps = result.current.pointStyle!
+      const style = ps({} as any)
+      expect(style.fill).toBe("tomato")
+    })
+  })
+})

--- a/src/components/charts/shared/useAreaSeriesSetup.ts
+++ b/src/components/charts/shared/useAreaSeriesSetup.ts
@@ -1,0 +1,249 @@
+/**
+ * useAreaSeriesSetup — shared series construction for area-shaped XY HOCs.
+ *
+ * AreaChart and StackedAreaChart both follow the same recipe to turn a
+ * flat data array (or pre-grouped area objects) into the props
+ * `StreamXYFrame` expects:
+ *
+ *   1. **Area-format detection + grouping** — if `data[0][lineDataAccessor]`
+ *      is set, the input is already in `{ [groupKey]: rows[] }` shape;
+ *      otherwise group by `areaBy` (or wrap in a single-area object
+ *      when neither is supplied).
+ *   2. **Flatten back** — `StreamXYFrame` consumes a flat array; we
+ *      re-flatten the grouped form, re-injecting the `areaBy` field so
+ *      the frame's group accessor can re-derive series.
+ *   3. **Line style** — fill/stroke from `colorBy`+`colorScale` or
+ *      uniform-`color` fallback, `fillOpacity = areaOpacity`,
+ *      stroke/lineWidth gated on `showLine`. Push-mode with `colorBy`
+ *      but no `colorScale` returns an empty style so the frame can
+ *      paint from its own palette.
+ *   4. **Primitive overlay + selection wrap** — top-level
+ *      `stroke`/`strokeWidth`/`opacity` win via `mergeShapeStyle`;
+ *      then `wrapStyleWithSelection` dims unmatched series when a
+ *      selection is active.
+ *   5. **Optional point style** — same color resolution as line style
+ *      but with `r: pointRadius, fillOpacity: 1`. Skipped when
+ *      `showPoints` is false.
+ *   6. **Default tooltip content** — `buildDefaultTooltip` rows for
+ *      x / y / group with `xFormat`/`yFormat` cascading through.
+ *
+ * This hook collapses those six steps into one call. Adopters drop
+ * ~70 lines of recipe per HOC.
+ */
+"use client"
+import { useMemo } from "react"
+import type { ReactNode } from "react"
+import type { Datum } from "./datumTypes"
+import type { Accessor, ChartAccessor } from "./types"
+import type { SelectionHookResult } from "./selectionUtils"
+import { wrapStyleWithSelection } from "./selectionUtils"
+import { mergeShapeStyle } from "./mergeShapeStyle"
+import { getColor } from "./colorUtils"
+import { DEFAULT_COLOR } from "./hooks"
+import { buildDefaultTooltip, accessorName } from "./tooltipUtils"
+import type { HoverData } from "../../stream/types"
+
+export interface AreaSeriesSetupOptions<TDatum extends Datum = Datum> {
+  /** Sparse-filtered data array (the HOC's `safeData`). */
+  safeData: TDatum[]
+  /** Original `data` prop — used to short-circuit to push-mode flatten. */
+  data: TDatum[] | undefined
+  /** Group accessor (`areaBy` on the HOC). When set, flat data is
+   *  grouped into one series per distinct value. */
+  areaBy?: ChartAccessor<TDatum, string>
+  /** Field on grouped objects that contains the coordinate array.
+   *  Convention: `"coordinates"`. Pre-grouped input is detected by
+   *  presence of this field on the first row. */
+  lineDataAccessor: string
+  /** Effective color accessor (already resolved by HOC: AreaChart =
+   *  `colorBy`; StackedAreaChart = `colorBy || areaBy`). */
+  colorBy?: Accessor<string> | ChartAccessor<TDatum, string>
+  /** Resolved categorical color scale from `useChartSetup`. */
+  colorScale: ((v: string) => string) | undefined
+  /** Top-level uniform `color` prop. */
+  color?: string
+  /** Top-level primitive props — applied last so they win over
+   *  HOC base + (future) user style. */
+  stroke?: string
+  strokeWidth?: number
+  opacity?: number
+  /** Selection hook output (`setup.effectiveSelectionHook`). */
+  effectiveSelectionHook: SelectionHookResult | null | undefined
+  /** Resolved selection config (`setup.resolvedSelection`). */
+  resolvedSelection: import("./types").SelectionConfig | undefined
+  /** Area fillOpacity. @default 0.7 */
+  areaOpacity: number
+  /** Render line on top of fill. @default true */
+  showLine: boolean
+  /** Line stroke width. @default 2 */
+  lineWidth: number
+  /** Render points along the line. @default false */
+  showPoints: boolean
+  /** Point radius when `showPoints`. @default 3 */
+  pointRadius: number
+  // ── Tooltip pieces ────────────────────────────────────────────
+  xAccessor: ChartAccessor<TDatum, number>
+  yAccessor: ChartAccessor<TDatum, number>
+  xLabel?: string
+  yLabel?: string
+  /** Tooltip-side x formatter — same signature as `AxisConfig.xFormat`
+   *  so the HOC can forward the prop verbatim. ReactNode return is OK. */
+  xFormat?: (d: number | Date | string, index?: number, allTicks?: number[]) => string | ReactNode
+  yFormat?: (d: number | Date | string) => string | ReactNode
+  /** Field used to label the series row in the default tooltip.
+   *  Typically `areaBy ?? colorBy`. */
+  groupField?: Accessor<string> | ChartAccessor<TDatum, string>
+}
+
+export interface AreaSeriesSetupResult<TDatum extends Datum = Datum> {
+  /** Flat data array ready for `<StreamXYFrame data={…} />`. Empty
+   *  when the HOC is in push mode (no `data` prop). */
+  flattenedData: TDatum[]
+  /** Selection-aware line/area style fn. */
+  lineStyle: (d: Datum) => Record<string, string | number>
+  /** Selection-aware point style fn — `undefined` when `showPoints`
+   *  is false so the HOC can spread it conditionally. */
+  pointStyle: ((d: Datum) => Record<string, string | number>) | undefined
+  /** Default tooltip content fn for the chart. */
+  defaultTooltipContent: (hover: HoverData) => ReactNode
+}
+
+/**
+ * Build the area-series pieces for an area-shaped XY HOC.
+ * The HOC still owns chart-specific frame props (chartType,
+ * gradientFill, normalize, baseline, stackOrder) and all the
+ * passthrough wiring; this hook covers the part both shared
+ * verbatim before extraction.
+ */
+export function useAreaSeriesSetup<TDatum extends Datum = Datum>(
+  options: AreaSeriesSetupOptions<TDatum>,
+): AreaSeriesSetupResult<TDatum> {
+  const {
+    safeData,
+    data,
+    areaBy,
+    lineDataAccessor,
+    colorBy,
+    colorScale,
+    color,
+    stroke,
+    strokeWidth,
+    opacity,
+    effectiveSelectionHook,
+    resolvedSelection,
+    areaOpacity,
+    showLine,
+    lineWidth,
+    showPoints,
+    pointRadius,
+    xAccessor,
+    yAccessor,
+    xLabel,
+    yLabel,
+    xFormat,
+    yFormat,
+    groupField,
+  } = options
+
+  // 1 — detect pre-grouped area-object format
+  const isAreaObjectFormat = safeData[0]?.[lineDataAccessor] !== undefined
+
+  // 2 — areaData (intermediate) → flattenedData (frame-ready)
+  const flattenedData = useMemo(() => {
+    if (data == null) return [] as TDatum[]
+    if (!isAreaObjectFormat && !areaBy) return safeData
+
+    let groupedAreas: Datum[]
+    if (isAreaObjectFormat) {
+      groupedAreas = safeData
+    } else {
+      // areaBy is non-null here (guarded by the early return above)
+      const grouped = safeData.reduce((acc, d) => {
+        const key = typeof areaBy === "function" ? (areaBy as any)(d) : d[areaBy as string]
+        if (!acc[key]) {
+          const areaObj: Datum = { [lineDataAccessor]: [] }
+          if (typeof areaBy === "string") areaObj[areaBy] = key
+          acc[key] = areaObj
+        }
+        acc[key][lineDataAccessor].push(d)
+        return acc
+      }, {} as Record<string, Datum>)
+      groupedAreas = Object.values(grouped)
+    }
+
+    return groupedAreas.flatMap((area: Datum) => {
+      const coords: TDatum[] = area[lineDataAccessor] || []
+      if (areaBy && typeof areaBy === "string") {
+        return coords.map((c: TDatum) => ({ ...c, [areaBy]: area[areaBy] }))
+      }
+      return coords
+    })
+  }, [data, safeData, areaBy, lineDataAccessor, isAreaObjectFormat])
+
+  // 3 — base line/area style
+  const baseLineStyle = useMemo(() => {
+    return (d: Datum) => {
+      const baseStyle: Record<string, string | number> = {}
+
+      if (colorBy) {
+        // Push-mode initial state — `colorBy` set but no scale yet.
+        // Return empty so the frame paints from its own palette.
+        if (colorScale) {
+          const resolvedColor = getColor(d, colorBy, colorScale)
+          baseStyle.fill = resolvedColor
+          if (showLine) {
+            baseStyle.stroke = resolvedColor
+            baseStyle.strokeWidth = lineWidth
+          } else {
+            baseStyle.stroke = "none"
+          }
+        }
+      } else {
+        const uniformColor = color || DEFAULT_COLOR
+        baseStyle.fill = uniformColor
+        if (showLine) {
+          baseStyle.stroke = uniformColor
+          baseStyle.strokeWidth = lineWidth
+        } else {
+          baseStyle.stroke = "none"
+        }
+      }
+      baseStyle.fillOpacity = areaOpacity
+      return baseStyle
+    }
+  }, [colorBy, colorScale, color, areaOpacity, showLine, lineWidth])
+
+  // 4 — primitive overlay + selection wrap
+  const baseLineStyleWithPrimitives = useMemo(
+    () => mergeShapeStyle(baseLineStyle, { stroke, strokeWidth, opacity }),
+    [baseLineStyle, stroke, strokeWidth, opacity],
+  )
+
+  const lineStyle = useMemo(
+    () => wrapStyleWithSelection(baseLineStyleWithPrimitives, effectiveSelectionHook ?? null, resolvedSelection),
+    [baseLineStyleWithPrimitives, effectiveSelectionHook, resolvedSelection],
+  )
+
+  // 5 — optional point style
+  const pointStyle = useMemo(() => {
+    if (!showPoints) return undefined
+    return (d: Datum) => {
+      const baseStyle: Record<string, string | number> = { r: pointRadius, fillOpacity: 1 }
+      if (colorBy) {
+        if (colorScale) baseStyle.fill = getColor(d.parentLine || d, colorBy, colorScale)
+      } else {
+        baseStyle.fill = color || DEFAULT_COLOR
+      }
+      return baseStyle
+    }
+  }, [showPoints, pointRadius, colorBy, colorScale, color])
+
+  // 6 — default tooltip content
+  const defaultTooltipContent = useMemo(() => buildDefaultTooltip([
+    { label: xLabel || accessorName(xAccessor), accessor: xAccessor, role: "x", format: xFormat },
+    { label: yLabel || accessorName(yAccessor), accessor: yAccessor, role: "y", format: yFormat },
+    ...(groupField ? [{ label: accessorName(groupField), accessor: groupField, role: "group" as const }] : []),
+  ]), [xAccessor, yAccessor, xLabel, yLabel, groupField, xFormat, yFormat])
+
+  return { flattenedData, lineStyle, pointStyle, defaultTooltipContent }
+}

--- a/src/components/charts/shared/useFrameImperativeHandle.ts
+++ b/src/components/charts/shared/useFrameImperativeHandle.ts
@@ -60,7 +60,16 @@ interface GeoPointsFrameLike {
   getData(): Datum[]
 }
 
-type FrameVariant = "xy" | "network" | "geo-points"
+/** Minimal shape the helper expects of a geo (line/flow) frame ref. */
+interface GeoLinesFrameLike {
+  pushLine(line: Datum): void
+  pushManyLines(lines: Datum[]): void
+  removeLine(id: string | string[]): Datum[]
+  getLines(): Datum[]
+  clear(): void
+}
+
+type FrameVariant = "xy" | "network" | "geo-points" | "geo-lines"
 
 interface Options {
   /**
@@ -177,24 +186,48 @@ function makeVariantDefaults(
         (r.current?.getTopology()?.nodes?.map((n) => n.data) as Datum[] | undefined) ?? [],
     }
   }
-  // variant === "geo-points"
-  // Same rationale as the network variant: pre-migration geo HOCs
-  // (`ProportionalSymbolMap`, `DistanceCartogram`) omitted `getScales`
-  // entirely, so the helper does too.
-  const r = frameRef as RefObject<GeoPointsFrameLike | null>
+  if (variant === "geo-points") {
+    // Same rationale as the network variant: pre-migration geo HOCs
+    // (`ProportionalSymbolMap`, `DistanceCartogram`) omitted `getScales`
+    // entirely, so the helper does too.
+    const r = frameRef as RefObject<GeoPointsFrameLike | null>
+    return {
+      push: (point) => r.current?.push(point),
+      pushMany: (points) => r.current?.pushMany(points),
+      remove: (id) => r.current?.removePoint(id) ?? [],
+      update: (id, updater) => {
+        // Geo frames don't expose a native in-place update — emulate via
+        // remove-then-push of the updater result. Mirrors the inline
+        // pattern in ProportionalSymbolMap.
+        const removed = r.current?.removePoint(id) ?? []
+        for (const old of removed) r.current?.push(updater(old))
+        return removed
+      },
+      clear: () => r.current?.clear(),
+      getData: () => r.current?.getData() ?? [],
+    }
+  }
+  // variant === "geo-lines"
+  // Mirrors `geo-points` but for line/flow records. FlowMap uses this
+  // variant with a `push` / `pushMany` override that resolves
+  // source/target through its `nodeLookup` before forwarding to
+  // `pushLine` / `pushManyLines`. Other line-shaped geo HOCs
+  // (potential future additions) can use the variant defaults
+  // directly when their push payload already carries resolved
+  // coordinates.
+  const r = frameRef as RefObject<GeoLinesFrameLike | null>
   return {
-    push: (point) => r.current?.push(point),
-    pushMany: (points) => r.current?.pushMany(points),
-    remove: (id) => r.current?.removePoint(id) ?? [],
+    push: (line) => r.current?.pushLine(line),
+    pushMany: (lines) => r.current?.pushManyLines(lines),
+    remove: (id) => r.current?.removeLine(id) ?? [],
     update: (id, updater) => {
-      // Geo frames don't expose a native in-place update — emulate via
-      // remove-then-push of the updater result. Mirrors the inline
-      // pattern in ProportionalSymbolMap.
-      const removed = r.current?.removePoint(id) ?? []
-      for (const old of removed) r.current?.push(updater(old))
+      // Same remove-then-push emulation pattern as geo-points — geo
+      // frames don't natively support in-place line updates.
+      const removed = r.current?.removeLine(id) ?? []
+      for (const old of removed) r.current?.pushLine(updater(old))
       return removed
     },
     clear: () => r.current?.clear(),
-    getData: () => r.current?.getData() ?? [],
+    getData: () => r.current?.getLines() ?? [],
   }
 }

--- a/src/components/charts/shared/useNetworkChartSetup.test.tsx
+++ b/src/components/charts/shared/useNetworkChartSetup.test.tsx
@@ -1,0 +1,244 @@
+import { describe, it, expect } from "vitest"
+import React from "react"
+import { renderHook } from "@testing-library/react"
+import { useNetworkChartSetup } from "./useNetworkChartSetup"
+import { TooltipProvider } from "../../store/TooltipStore"
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  <TooltipProvider>{children}</TooltipProvider>
+
+const baseInput = {
+  marginDefaults: { top: 50, bottom: 60, left: 70, right: 40 },
+  width: 600,
+  height: 400,
+  chartType: "TestNetwork",
+}
+
+describe("useNetworkChartSetup", () => {
+  it("infers nodes from edges when inferNodes=true and nodes is undefined", () => {
+    const edges = [
+      { source: "A", target: "B", value: 1 },
+      { source: "B", target: "C", value: 1 },
+    ]
+    const { result } = renderHook(
+      () => useNetworkChartSetup({
+        ...baseInput,
+        nodes: undefined,
+        edges,
+        inferNodes: true,
+        sourceAccessor: "source",
+        targetAccessor: "target",
+      }),
+      { wrapper },
+    )
+    expect(result.current.safeNodes.map((n) => n.id).sort()).toEqual(["A", "B", "C"])
+  })
+
+  it("does NOT infer nodes when inferNodes=false", () => {
+    const edges = [
+      { source: "A", target: "B", value: 1 },
+    ]
+    const { result } = renderHook(
+      () => useNetworkChartSetup({
+        ...baseInput,
+        nodes: undefined,
+        edges,
+        inferNodes: false,
+      }),
+      { wrapper },
+    )
+    expect(result.current.safeNodes).toEqual([])
+  })
+
+  it("filters sparse edges identity-preservingly when nothing dropped", () => {
+    const edges = [{ source: "A", target: "B", value: 1 }]
+    const { result } = renderHook(
+      () => useNetworkChartSetup({
+        ...baseInput,
+        nodes: [{ id: "A" }, { id: "B" }],
+        edges,
+      }),
+      { wrapper },
+    )
+    expect(result.current.safeEdges).toBe(edges)
+  })
+
+  it("drops null/non-object edges via filterSparseArray", () => {
+    const edges = [
+      { source: "A", target: "B", value: 1 },
+      null,
+      undefined,
+      { source: "B", target: "C", value: 1 },
+    ] as unknown[]
+    const { result } = renderHook(
+      () => useNetworkChartSetup({
+        ...baseInput,
+        nodes: [{ id: "A" }, { id: "B" }, { id: "C" }],
+        edges: edges as { source: string; target: string; value: number }[],
+      }),
+      { wrapper },
+    )
+    expect(result.current.safeEdges).toHaveLength(2)
+  })
+
+  it("derives distinct categories from colorBy + nodes", () => {
+    const nodes = [
+      { id: "a", category: "Alpha" },
+      { id: "b", category: "Beta" },
+      { id: "c", category: "Alpha" },
+    ]
+    const { result } = renderHook(
+      () => useNetworkChartSetup({
+        ...baseInput,
+        nodes,
+        edges: [],
+        inferNodes: false,
+        colorBy: "category",
+      }),
+      { wrapper },
+    )
+    expect(result.current.allCategories.sort()).toEqual(["Alpha", "Beta"])
+  })
+
+  it("returns no categories when colorBy is unset", () => {
+    const { result } = renderHook(
+      () => useNetworkChartSetup({
+        ...baseInput,
+        nodes: [{ id: "a" }],
+        edges: [],
+        inferNodes: false,
+      }),
+      { wrapper },
+    )
+    expect(result.current.allCategories).toEqual([])
+  })
+
+  it("resolves effectivePalette: array colorScheme passes through", () => {
+    const palette = ["#aaa", "#bbb", "#ccc"]
+    const { result } = renderHook(
+      () => useNetworkChartSetup({
+        ...baseInput,
+        nodes: [],
+        edges: [],
+        colorScheme: palette,
+      }),
+      { wrapper },
+    )
+    expect(result.current.effectivePalette).toBe(palette)
+  })
+
+  it("resolves effectivePalette: named scheme resolves to its array", () => {
+    const { result } = renderHook(
+      () => useNetworkChartSetup({
+        ...baseInput,
+        nodes: [],
+        edges: [],
+        colorScheme: "category10",
+      }),
+      { wrapper },
+    )
+    expect(Array.isArray(result.current.effectivePalette)).toBe(true)
+    expect(result.current.effectivePalette.length).toBeGreaterThan(0)
+  })
+
+  it("resolves effectivePalette: falls through to DEFAULT_COLORS when unknown", () => {
+    const { result } = renderHook(
+      () => useNetworkChartSetup({
+        ...baseInput,
+        nodes: [],
+        edges: [],
+        colorScheme: "definitely-not-a-real-scheme-xyz",
+      }),
+      { wrapper },
+    )
+    expect(Array.isArray(result.current.effectivePalette)).toBe(true)
+    expect(result.current.effectivePalette.length).toBeGreaterThan(0)
+  })
+
+  it("yields a loadingEl when loading=true", () => {
+    const { result } = renderHook(
+      () => useNetworkChartSetup({
+        ...baseInput,
+        nodes: [],
+        edges: [],
+        loading: true,
+      }),
+      { wrapper },
+    )
+    expect(result.current.loadingEl).not.toBeNull()
+    expect(result.current.emptyEl).toBeNull()
+  })
+
+  it("yields an emptyEl when edges is provided but empty after sparse-clean", () => {
+    const { result } = renderHook(
+      () => useNetworkChartSetup({
+        ...baseInput,
+        nodes: [],
+        edges: [],
+      }),
+      { wrapper },
+    )
+    expect(result.current.emptyEl).not.toBeNull()
+  })
+
+  it("does NOT yield an emptyEl when edges is undefined (push mode)", () => {
+    const { result } = renderHook(
+      () => useNetworkChartSetup({
+        ...baseInput,
+        nodes: undefined,
+        edges: undefined,
+      }),
+      { wrapper },
+    )
+    expect(result.current.emptyEl).toBeNull()
+  })
+
+  it("emptyDataKey='nodes' keys empty-state on safeInputNodes (ForceDirected shape)", () => {
+    // edges undefined → would normally bypass empty UI under default
+    // ("edges" key). With emptyDataKey="nodes" + supplied-but-empty
+    // nodes, empty UI should fire.
+    const { result } = renderHook(
+      () => useNetworkChartSetup({
+        ...baseInput,
+        nodes: [],
+        edges: undefined,
+        inferNodes: false,
+        emptyDataKey: "nodes",
+      }),
+      { wrapper },
+    )
+    expect(result.current.emptyEl).not.toBeNull()
+  })
+
+  it("emptyDataKey='nodes' + nodes=undefined yields no empty UI (push mode)", () => {
+    const { result } = renderHook(
+      () => useNetworkChartSetup({
+        ...baseInput,
+        nodes: undefined,
+        edges: undefined,
+        inferNodes: false,
+        emptyDataKey: "nodes",
+      }),
+      { wrapper },
+    )
+    expect(result.current.emptyEl).toBeNull()
+  })
+
+  it("expands right margin when legend renders to the right", () => {
+    const nodes = [{ id: "a", g: "X" }, { id: "b", g: "Y" }]
+    const { result } = renderHook(
+      () => useNetworkChartSetup({
+        ...baseInput,
+        nodes,
+        edges: [],
+        inferNodes: false,
+        colorBy: "g",
+        showLegend: true,
+        legendPosition: "right",
+      }),
+      { wrapper },
+    )
+    // legendAndMargin reserves at least 110 on right when legend is right
+    expect(result.current.margin.right).toBeGreaterThanOrEqual(110)
+  })
+})

--- a/src/components/charts/shared/useNetworkChartSetup.ts
+++ b/src/components/charts/shared/useNetworkChartSetup.ts
@@ -1,0 +1,345 @@
+/**
+ * useNetworkChartSetup — shared setup pipeline for all HOC network charts.
+ *
+ * The 8 network HOCs (ChordDiagram, CirclePack, ForceDirectedGraph,
+ * OrbitDiagram, ProcessSankey, SankeyDiagram, TreeDiagram, Treemap)
+ * each hand-roll the same pattern: sparse-filter nodes/edges,
+ * optionally infer nodes from edges, build a color scale, derive
+ * categories for legend interaction, resolve the effective palette,
+ * wire selection / linked-hover, compose margin + legend, and gate
+ * loading/empty UI. This hook does it once.
+ *
+ * Mirrors `useChartSetup` (the row-array equivalent for XY/ordinal
+ * HOCs) but accepts the network data model. Pure consolidation — no
+ * behavior change. Each adopter drops ~40-80 lines of orchestration.
+ *
+ * Dependencies:
+ *   hooks.ts            — useColorScale, useChartSelection,
+ *                         useChartLegendAndMargin, useLegendInteraction,
+ *                         useThemeCategorical
+ *   networkUtils.ts     — inferNodesFromEdges
+ *   sparseArray.ts      — filterSparseArray
+ *   colorUtils.ts       — COLOR_SCHEMES, DEFAULT_COLORS
+ *   withChartWrapper.tsx — renderEmptyState, renderLoadingState
+ *
+ * Consumed by: all network HOCs.
+ */
+"use client"
+import { useMemo } from "react"
+import type { ReactNode, ReactElement } from "react"
+import type { Datum } from "./datumTypes"
+import type { Accessor, ChartAccessor, SelectionConfig, LinkedHoverProp } from "./types"
+import type { OnObservationCallback } from "../../store/ObservationStore"
+import type { PartialMargin, MarginType } from "../../types/marginType"
+import {
+  useColorScale,
+  useChartSelection,
+  useChartLegendAndMargin,
+  useLegendInteraction,
+  useThemeCategorical,
+} from "./hooks"
+import type { LegendInteractionMode, LegendPosition, LegendInteractionState } from "./hooks"
+import { COLOR_SCHEMES, DEFAULT_COLORS } from "./colorUtils"
+import { inferNodesFromEdges } from "./networkUtils"
+import { filterSparseArray } from "./sparseArray"
+import { renderEmptyState, renderLoadingState } from "./withChartWrapper"
+
+export interface NetworkChartSetupInput<TNode extends Datum = Datum, TEdge extends Datum = Datum> {
+  /** Raw `nodes` prop (may be undefined). */
+  nodes: TNode[] | undefined
+  /** Raw `edges` prop (may be undefined). */
+  edges: TEdge[] | undefined
+  /**
+   * When `true`, missing nodes are inferred from edge endpoints via
+   * `inferNodesFromEdges`. Sankey/Chord set this; ForceDirected leaves
+   * it `false` and treats both as required. Default: `true`.
+   */
+  inferNodes?: boolean
+  /** Node id accessor for inference + tooltip identity. */
+  nodeIdAccessor?: ChartAccessor<TNode, string>
+  /** Edge source accessor (used by `inferNodesFromEdges`). */
+  sourceAccessor?: ChartAccessor<TEdge, string>
+  /** Edge target accessor (used by `inferNodesFromEdges`). */
+  targetAccessor?: ChartAccessor<TEdge, string>
+
+  // ── Color ────────────────────────────────────────────────────────
+  colorBy?: Accessor<string>
+  colorScheme?: string | string[]
+
+  // ── Legend ───────────────────────────────────────────────────────
+  /** `undefined` defaults to "auto" (on when colorBy is set). */
+  showLegend?: boolean
+  legendPosition?: LegendPosition
+  legendInteraction?: LegendInteractionMode
+
+  // ── Interaction ──────────────────────────────────────────────────
+  selection?: SelectionConfig
+  linkedHover?: LinkedHoverProp
+  onObservation?: OnObservationCallback
+  onClick?: (datum: Datum, event: { x: number; y: number }) => void
+  /** Used by useChartSelection for chart-type-stamped observation events. */
+  chartType: string
+  chartId?: string
+
+  // ── Layout ───────────────────────────────────────────────────────
+  /** Mode-resolved margin defaults from useChartMode. */
+  marginDefaults: MarginType
+  /** User-provided margin override. */
+  userMargin?: PartialMargin
+  width: number
+  height: number
+
+  // ── Loading / empty states ───────────────────────────────────────
+  loading?: boolean
+  emptyContent?: ReactNode | false
+  /**
+   * Which array drives the empty-state check. `"edges"` (default)
+   * fits Sankey/Chord/ProcessSankey where edges are the primary
+   * data shape and nodes are optional/inferred. `"nodes"` fits
+   * ForceDirectedGraph where both nodes and edges are required and
+   * empty-state should fire when the user supplied a sparse-only
+   * node list. The undefined-vs-empty distinction is preserved
+   * either way: undefined = push mode (don't show empty UI);
+   * present-but-empty = user supplied empty data (show empty UI).
+   */
+  emptyDataKey?: "edges" | "nodes"
+}
+
+export interface NetworkChartSetupResult {
+  /**
+   * Sparse-filtered nodes. When `inferNodes` was `true` and the
+   * caller didn't supply nodes, this is the inferred `[{id}]` array
+   * derived from edge endpoints. Otherwise it's just the input
+   * `nodes` with sparse holes removed.
+   */
+  safeNodes: Datum[]
+  /** Sparse-filtered edges. Identity-equal to input when nothing was dropped. */
+  safeEdges: Datum[]
+
+  /**
+   * Color scale built from `(safeNodes, colorBy, colorScheme)`.
+   * `undefined` when colorBy is unset.
+   */
+  colorScale: ((v: string) => string) | undefined
+  /**
+   * Effective palette array. Resolved as:
+   * 1. `colorScheme` if it's an array.
+   * 2. ThemeProvider categorical if non-empty.
+   * 3. Named scheme lookup in `COLOR_SCHEMES`.
+   * 4. `DEFAULT_COLORS` fallback.
+   *
+   * Pass this to the frame's `colorScheme` prop so its internal
+   * `getNodeColor` (used for particles, hover, interactions) matches
+   * what the HOC's nodeStyle resolves.
+   */
+  effectivePalette: string[]
+  themeCategorical: string[] | undefined
+
+  /** Distinct category values from `(safeNodes, colorBy)`, for legend interaction. */
+  allCategories: string[]
+  legendState: LegendInteractionState
+
+  // ── Frame chrome ─────────────────────────────────────────────────
+  legend: ReturnType<typeof useChartLegendAndMargin>["legend"]
+  margin: MarginType
+  legendPosition: LegendPosition
+
+  // ── Interaction ──────────────────────────────────────────────────
+  customHoverBehavior: ReturnType<typeof useChartSelection>["customHoverBehavior"]
+  customClickBehavior: ReturnType<typeof useChartSelection>["customClickBehavior"]
+  /**
+   * The full selection-hook output. Most network HOCs only need the
+   * resolved hover/click behaviors above, but hierarchy charts
+   * (Treemap, CirclePack, TreeDiagram, OrbitDiagram) wrap node styles
+   * with selection state via `activeSelectionHook.isActive` /
+   * `.predicate`. Passed through verbatim so those charts don't need
+   * a parallel `useChartSelection` call.
+   */
+  activeSelectionHook: ReturnType<typeof useChartSelection>["activeSelectionHook"]
+  hoverSelectionHook: ReturnType<typeof useChartSelection>["hoverSelectionHook"]
+  crosshairSourceId: ReturnType<typeof useChartSelection>["crosshairSourceId"]
+
+  // ── Render gates ─────────────────────────────────────────────────
+  /** When non-null, render this element instead of the chart. */
+  loadingEl: ReactElement | null
+  /** When non-null, render this element instead of the chart. */
+  emptyEl: ReactElement | null
+}
+
+/**
+ * Run the consolidated network-HOC setup pipeline. Call this once
+ * after `useChartMode` and before any chart-specific logic. The
+ * returned `loadingEl`/`emptyEl` are early-exit slots — when either
+ * is non-null, return it before the frame.
+ *
+ * @example
+ * ```tsx
+ * const setup = useNetworkChartSetup({
+ *   nodes, edges,
+ *   inferNodes: true,
+ *   nodeIdAccessor, sourceAccessor, targetAccessor,
+ *   colorBy, colorScheme, showLegend, legendPosition, legendInteraction,
+ *   selection, linkedHover, onObservation, onClick,
+ *   chartType: "SankeyDiagram", chartId,
+ *   marginDefaults, userMargin, width, height,
+ *   loading, emptyContent,
+ * })
+ * if (setup.loadingEl) return setup.loadingEl
+ * if (setup.emptyEl) return setup.emptyEl
+ * return (
+ *   <StreamNetworkFrame
+ *     nodes={setup.safeNodes}
+ *     edges={setup.safeEdges}
+ *     colorScheme={setup.effectivePalette}
+ *     legend={setup.legend}
+ *     legendPosition={setup.legendPosition}
+ *     margin={setup.margin}
+ *     customHoverBehavior={setup.customHoverBehavior}
+ *     customClickBehavior={setup.customClickBehavior}
+ *     ...
+ *   />
+ * )
+ * ```
+ */
+export function useNetworkChartSetup<TNode extends Datum = Datum, TEdge extends Datum = Datum>(
+  input: NetworkChartSetupInput<TNode, TEdge>,
+): NetworkChartSetupResult {
+  const {
+    nodes,
+    edges,
+    inferNodes = true,
+    sourceAccessor = "source",
+    targetAccessor = "target",
+    colorBy,
+    colorScheme,
+    showLegend,
+    legendPosition: legendPositionProp,
+    legendInteraction,
+    selection,
+    linkedHover,
+    onObservation,
+    onClick,
+    chartType,
+    chartId,
+    marginDefaults,
+    userMargin,
+    width,
+    height,
+    loading,
+    emptyContent,
+    emptyDataKey = "edges",
+  } = input
+
+  // ── Sparse data filtering ───────────────────────────────────────
+  // Identity-preserving: when nothing's dropped, the returned array
+  // is === to the input so downstream memo caches stay warm.
+  const safeEdges = useMemo(() => filterSparseArray(edges), [edges])
+  const safeInputNodes = useMemo(() => filterSparseArray(nodes), [nodes])
+
+  // ── Loading / empty states ──────────────────────────────────────
+  // Computed up front so the caller can early-return AFTER all hooks.
+  const loadingEl = renderLoadingState(loading, width, height)
+  // Empty state defaults to keying off edges (Sankey/Chord/PSankey
+  // shape) but switches to nodes for charts where node presence is
+  // the user-data signal (ForceDirectedGraph). The undefined-vs-empty
+  // distinction is preserved: undefined raw prop = push mode (no
+  // empty UI), sparse-cleaned-to-zero = user supplied empty.
+  const emptyEl = !loadingEl
+    ? renderEmptyState(
+        emptyDataKey === "nodes"
+          ? (nodes === undefined ? undefined : safeInputNodes)
+          : (edges === undefined ? undefined : safeEdges),
+        width, height, emptyContent,
+      )
+    : null
+
+  // ── Node resolution ─────────────────────────────────────────────
+  // When `inferNodes`, a missing/empty `nodes` prop derives stubs
+  // from edge endpoints. Sankey/Chord rely on this; ForceDirected
+  // requires explicit nodes and disables inference.
+  const safeNodes = useMemo<Datum[]>(() => {
+    if (!inferNodes) return safeInputNodes as Datum[]
+    return inferNodesFromEdges(
+      safeInputNodes as Datum[],
+      safeEdges as Datum[],
+      sourceAccessor as string | ((d: Datum) => string),
+      targetAccessor as string | ((d: Datum) => string),
+    ) as Datum[]
+  }, [inferNodes, safeInputNodes, safeEdges, sourceAccessor, targetAccessor])
+
+  // ── Color scale + theme ─────────────────────────────────────────
+  const colorScale = useColorScale(safeNodes, colorBy, colorScheme)
+  const themeCategorical = useThemeCategorical()
+
+  const effectivePalette = useMemo<string[]>(() => {
+    if (Array.isArray(colorScheme)) return colorScheme
+    if (themeCategorical && themeCategorical.length > 0) return themeCategorical
+    if (typeof colorScheme === "string") {
+      const named = COLOR_SCHEMES[colorScheme as keyof typeof COLOR_SCHEMES]
+      if (Array.isArray(named) && named.length > 0) return named as string[]
+    }
+    return DEFAULT_COLORS as unknown as string[]
+  }, [colorScheme, themeCategorical])
+
+  // ── Categories for legend interaction ───────────────────────────
+  const allCategories = useMemo<string[]>(() => {
+    if (!colorBy) return []
+    const vals = new Set<string>()
+    for (const d of safeNodes) {
+      const v = typeof colorBy === "function" ? colorBy(d) : d[colorBy as string]
+      if (v != null) vals.add(String(v))
+    }
+    return Array.from(vals)
+  }, [safeNodes, colorBy])
+
+  const legendState = useLegendInteraction(legendInteraction, colorBy, allCategories)
+
+  // ── Legend + margin ─────────────────────────────────────────────
+  const { legend, margin, legendPosition } = useChartLegendAndMargin({
+    data: safeNodes,
+    colorBy,
+    colorScale,
+    showLegend,
+    legendPosition: legendPositionProp,
+    userMargin,
+    defaults: marginDefaults,
+    categories: allCategories,
+  })
+
+  // ── Selection / linked hover ────────────────────────────────────
+  // Pass the full selection result through; hierarchy charts read
+  // `activeSelectionHook` to wrap node styles with selected/dimmed
+  // overlays, which the `customHoverBehavior` shorthand alone doesn't
+  // expose.
+  const selectionResult = useChartSelection({
+    selection,
+    linkedHover,
+    fallbackFields: colorBy ? [typeof colorBy === "string" ? colorBy : ""] : [],
+    unwrapData: true,           // deprecated / no-op since hooks.ts:207, kept for clarity
+    onObservation,
+    onClick,
+    chartType,
+    chartId,
+  })
+  const { customHoverBehavior, customClickBehavior, activeSelectionHook, hoverSelectionHook, crosshairSourceId } = selectionResult
+
+  return {
+    safeNodes,
+    safeEdges: safeEdges as Datum[],
+    colorScale,
+    effectivePalette,
+    themeCategorical,
+    allCategories,
+    legendState,
+    legend,
+    margin,
+    legendPosition,
+    customHoverBehavior,
+    customClickBehavior,
+    activeSelectionHook,
+    hoverSelectionHook,
+    crosshairSourceId,
+    loadingEl,
+    emptyEl,
+  }
+}

--- a/src/components/charts/shared/useOrdinalPieceStyle.test.tsx
+++ b/src/components/charts/shared/useOrdinalPieceStyle.test.tsx
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest"
+import React from "react"
+import { renderHook } from "@testing-library/react"
+import { useOrdinalPieceStyle } from "./useOrdinalPieceStyle"
+import { TooltipProvider } from "../../store/TooltipStore"
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  <TooltipProvider>{children}</TooltipProvider>
+
+const baseInput = {
+  themeCategorical: undefined,
+  categoryIndexMap: new Map<string, number>(),
+  effectiveSelectionHook: null,
+  resolvedSelection: undefined,
+}
+
+describe("useOrdinalPieceStyle", () => {
+  it("returns base fill from getColor when colorBy is set", () => {
+    // colorScale that maps category names to specific colors
+    const colorScale = (v: string) => ({ A: "#aaa", B: "#bbb" }[v] || "#000")
+    const { result } = renderHook(
+      () => useOrdinalPieceStyle({
+        ...baseInput,
+        colorBy: "category",
+        colorScale,
+        colorScheme: undefined,
+      }),
+      { wrapper },
+    )
+    const style = result.current({ category: "A", value: 5 } as Record<string, unknown>)
+    expect(style.fill).toBe("#aaa")
+  })
+
+  it("falls back to resolveDefaultFill when colorBy is unset", () => {
+    const { result } = renderHook(
+      () => useOrdinalPieceStyle({
+        ...baseInput,
+        colorBy: undefined,
+        colorScale: undefined,
+        colorScheme: ["#abc"],
+      }),
+      { wrapper },
+    )
+    const style = result.current({ category: "A", value: 5 } as Record<string, unknown>)
+    expect(style.fill).toBeDefined()
+  })
+
+  it("merges user pieceStyle (function form) over base", () => {
+    const { result } = renderHook(
+      () => useOrdinalPieceStyle({
+        ...baseInput,
+        colorBy: "category",
+        colorScale: () => "#000",
+        userPieceStyle: (d: Record<string, unknown>) => ({ stroke: `cat-${d.category}` }),
+      }),
+      { wrapper },
+    )
+    const style = result.current({ category: "X" } as Record<string, unknown>)
+    expect(style.fill).toBe("#000")
+    expect(style.stroke).toBe("cat-X")
+  })
+
+  it("merges user pieceStyle (object form) over base", () => {
+    const { result } = renderHook(
+      () => useOrdinalPieceStyle({
+        ...baseInput,
+        colorBy: "category",
+        colorScale: () => "#000",
+        userPieceStyle: { stroke: "user-stroke" },
+      }),
+      { wrapper },
+    )
+    const style = result.current({ category: "X" } as Record<string, unknown>)
+    expect(style.stroke).toBe("user-stroke")
+  })
+
+  it("primitive props win over both base and user pieceStyle", () => {
+    const { result } = renderHook(
+      () => useOrdinalPieceStyle({
+        ...baseInput,
+        colorBy: "category",
+        colorScale: () => "#000",
+        userPieceStyle: { stroke: "user-stroke" },
+        stroke: "primitive-stroke",
+        strokeWidth: 2,
+        opacity: 0.5,
+      }),
+      { wrapper },
+    )
+    const style = result.current({ category: "X" } as Record<string, unknown>)
+    // Top-level primitive props applied via mergeShapeStyle — they
+    // overlay onto whatever the base + user produced.
+    expect(style.stroke).toBe("primitive-stroke")
+    expect(style.strokeWidth).toBe(2)
+    expect(style.opacity).toBe(0.5)
+  })
+
+  it("returns a stable function reference when inputs don't change", () => {
+    const colorScale = () => "#000"
+    const idxMap = new Map<string, number>()
+    const { result, rerender } = renderHook(
+      (props: Record<string, unknown>) => useOrdinalPieceStyle({
+        ...baseInput,
+        colorBy: "category",
+        colorScale,
+        categoryIndexMap: idxMap,
+        ...props,
+      }),
+      { wrapper, initialProps: {} },
+    )
+    const first = result.current
+    rerender({})
+    expect(result.current).toBe(first)
+  })
+
+  it("preserves baseStyleExtras through the merge pipeline", () => {
+    // Charts like DotPlot / SwarmPlot pass `r` / `fillOpacity`
+    // intrinsic defaults — those must survive the color/user/primitive
+    // overlays.
+    const { result } = renderHook(
+      () => useOrdinalPieceStyle({
+        ...baseInput,
+        colorBy: "category",
+        colorScale: () => "#000",
+        baseStyleExtras: { r: 5, fillOpacity: 0.7 },
+      }),
+      { wrapper },
+    )
+    const style = result.current({ category: "A" } as Record<string, unknown>)
+    expect(style.r).toBe(5)
+    expect(style.fillOpacity).toBe(0.7)
+    expect(style.fill).toBe("#000")
+  })
+
+  it("baseStyleExtras returns alone when colorBy set but colorScale undefined (push mode)", () => {
+    // Frame-fallback branch — only the extras flow through.
+    const { result } = renderHook(
+      () => useOrdinalPieceStyle({
+        ...baseInput,
+        colorBy: "category",
+        colorScale: undefined,
+        baseStyleExtras: { r: 5 },
+      }),
+      { wrapper },
+    )
+    const style = result.current({ category: "A" } as Record<string, unknown>)
+    expect(style.r).toBe(5)
+    expect(style.fill).toBeUndefined()
+  })
+
+  it("user pieceStyle can override baseStyleExtras", () => {
+    const { result } = renderHook(
+      () => useOrdinalPieceStyle({
+        ...baseInput,
+        colorBy: "category",
+        colorScale: () => "#000",
+        baseStyleExtras: { r: 5 },
+        userPieceStyle: { r: 10 },
+      }),
+      { wrapper },
+    )
+    const style = result.current({ category: "A" } as Record<string, unknown>)
+    expect(style.r).toBe(10)
+  })
+
+  it("rebuilds when colorScale changes", () => {
+    let scale: (v: string) => string = () => "#aaa"
+    const { result, rerender } = renderHook(
+      () => useOrdinalPieceStyle({
+        ...baseInput,
+        colorBy: "category",
+        colorScale: scale,
+      }),
+      { wrapper },
+    )
+    const first = result.current({ category: "X" } as Record<string, unknown>).fill
+    expect(first).toBe("#aaa")
+    scale = () => "#bbb"
+    rerender()
+    const second = result.current({ category: "X" } as Record<string, unknown>).fill
+    expect(second).toBe("#bbb")
+  })
+})

--- a/src/components/charts/shared/useOrdinalPieceStyle.ts
+++ b/src/components/charts/shared/useOrdinalPieceStyle.ts
@@ -1,0 +1,218 @@
+/**
+ * useOrdinalPieceStyle — shared piece-style construction for ordinal HOCs.
+ *
+ * Every ordinal HOC that paints "pieces" (BarChart, StackedBarChart,
+ * GroupedBarChart, PieChart, DonutChart, FunnelChart, BoxPlot,
+ * ViolinPlot, RidgelinePlot, DotPlot, SwimlaneChart, SwarmPlot…)
+ * builds `pieceStyle` through the same three-step recipe:
+ *
+ *   1. **Base style** — fill via `getColor(d, colorBy, colorScale)`
+ *      when `colorBy` is set, else `resolveDefaultFill(color, theme,
+ *      colorScheme, ...)`.
+ *   2. **User overlay** — merge `frameProps.pieceStyle` on top of
+ *      the base. Functions get composed; objects spread.
+ *   3. **Primitive props** — apply top-level `stroke` /
+ *      `strokeWidth` / `opacity` last so they win over both HOC
+ *      defaults and user-supplied frameProps overrides.
+ *   4. **Selection wrap** — `wrapStyleWithSelection` dims
+ *      non-matching pieces when a selection is active.
+ *
+ * This hook collapses those four steps into one call. Adopters drop
+ * ~25 lines of recipe per HOC.
+ */
+"use client"
+import { useMemo } from "react"
+import type { Datum } from "./datumTypes"
+import type { Accessor, ChartAccessor } from "./types"
+import type { SelectionHookResult } from "./selectionUtils"
+import { wrapStyleWithSelection } from "./selectionUtils"
+import { mergeShapeStyle } from "./mergeShapeStyle"
+import { getColor } from "./colorUtils"
+import { resolveDefaultFill } from "./hooks"
+
+export interface OrdinalPieceStyleOptions {
+  /** colorBy accessor — string field name or function */
+  colorBy?: Accessor<string> | ChartAccessor<Datum, string>
+  /** Resolved categorical color scale (typically from useChartSetup). */
+  colorScale: ((v: string) => string) | undefined
+  /** Top-level uniform `color` prop (BaseChartProps). Applied as a
+   *  default-fill primitive when `colorBy` is unset. */
+  color?: string
+  /** Theme categorical palette (from useThemeCategorical). */
+  themeCategorical: string[] | undefined
+  /** colorScheme prop — array or string scheme name. */
+  colorScheme?: string | string[]
+  /** Stable category-index map for default-fill cycling. */
+  categoryIndexMap: Map<string, number>
+  /** User-supplied `frameProps.pieceStyle`. Accepts the looser
+   *  Frame-side `Style` type (typed fields like `fill: string`) or a
+   *  function returning the same shape; we don't pin a stricter
+   *  contract here because every ordinal HOC re-types pieceStyle
+   *  via its own props interface. */
+  userPieceStyle?:
+    | ((d: Datum, category?: string) => Record<string, unknown>)
+    | Record<string, unknown>
+    | unknown
+  /** Top-level primitive props — applied last so they win over HOC base + user overlay. */
+  stroke?: string
+  strokeWidth?: number
+  opacity?: number
+  /**
+   * Chart-shape defaults applied BEFORE the color resolution and
+   * user overlay. Use for properties that are intrinsic to the
+   * chart's mark shape (point radius `r`, fillOpacity for swarms /
+   * dots, etc.). User-supplied `frameProps.pieceStyle` and top-level
+   * primitive props can still override them.
+   *
+   * Static object form for shape-constant defaults
+   * (`{ r: dotRadius, fillOpacity: 0.8 }` — DotPlot). Function form
+   * for per-datum derivation (`(d) => ({ r: sizeBy ? getSize(d, ...) :
+   * pointRadius })` — SwarmPlot's size-encoded points). The function
+   * receives the same `(d, category)` args as user pieceStyle.
+   */
+  baseStyleExtras?:
+    | Record<string, string | number | undefined>
+    | ((d: Datum, category?: string) => Record<string, string | number | undefined>)
+  /**
+   * After the base fill is resolved, also write it to `stroke`.
+   * Used by statistical-summary charts (BoxPlot / ViolinPlot /
+   * RidgelinePlot / Histogram) where the box outline should match
+   * the box fill rather than be a separate stroke. Top-level
+   * primitive `stroke` still wins via `mergeShapeStyle` if supplied.
+   */
+  linkStrokeToFill?: boolean
+  /**
+   * When `colorBy` is unset, pass the per-piece `category` to
+   * `resolveDefaultFill` so each piece cycles through the
+   * colorScheme's palette (Pie / Donut / Funnel / radial charts —
+   * each slice/wedge wants its own color).
+   *
+   * When `false` (default), the category arg is omitted and
+   * `resolveDefaultFill` returns the first scheme color uniformly
+   * (BarChart / StackedBarChart / GroupedBarChart — bars without
+   * `colorBy` should be one color, since the user picked
+   * `categoryAccessor` but explicitly didn't ask for category-driven
+   * coloring). Locked by `bugRepros.test.tsx` BR-2.
+   */
+  cycleByCategory?: boolean
+  /** Selection hook output (typically `setup.effectiveSelectionHook`). */
+  effectiveSelectionHook: SelectionHookResult | null | undefined
+  /** Resolved selection config (typically `setup.resolvedSelection`). */
+  resolvedSelection: import("./types").SelectionConfig | undefined
+}
+
+/**
+ * Build a memoized `pieceStyle` function that the chart can pass
+ * straight to `<StreamOrdinalFrame pieceStyle={…} />`. Composes the
+ * standard base-fill / user-overlay / primitive-prop / selection
+ * pipeline so each HOC doesn't re-derive it.
+ *
+ * @example
+ * ```tsx
+ * const pieceStyle = useOrdinalPieceStyle({
+ *   colorBy, colorScale: setup.colorScale,
+ *   color, themeCategorical, colorScheme, categoryIndexMap,
+ *   userPieceStyle: frameProps?.pieceStyle,
+ *   stroke, strokeWidth, opacity,
+ *   effectiveSelectionHook: setup.effectiveSelectionHook,
+ *   resolvedSelection: setup.resolvedSelection,
+ * })
+ * ```
+ */
+export function useOrdinalPieceStyle(
+  options: OrdinalPieceStyleOptions,
+): (d: Datum, category?: string) => Record<string, string | number | undefined> {
+  const {
+    colorBy,
+    colorScale,
+    color,
+    themeCategorical,
+    colorScheme,
+    categoryIndexMap,
+    userPieceStyle,
+    stroke,
+    strokeWidth,
+    opacity,
+    effectiveSelectionHook,
+    resolvedSelection,
+    cycleByCategory = false,
+    baseStyleExtras,
+    linkStrokeToFill = false,
+  } = options
+
+  // 1 — base fill from colorBy or theme/scheme fallback. When
+  // `colorBy` is set but the resolved `colorScale` is undefined
+  // (push-mode initial state — no data yet to derive a categorical
+  // domain), return an empty style so the frame falls back to its
+  // own palette. PieChart relies on this; other ordinal HOCs hit it
+  // identically in push mode.
+  const basePieceStyle = useMemo(() => {
+    return (d: Datum, category?: string) => {
+      // Start from chart-shape defaults. Function form runs per
+      // datum (SwarmPlot's size-encoded `r`, LikertChart's per-level
+      // fill); object form is static (DotPlot's constant radius).
+      const extras: Record<string, string | number | undefined> | undefined =
+        typeof baseStyleExtras === "function"
+          ? baseStyleExtras(d, category)
+          : baseStyleExtras
+      const baseStyle: Record<string, string | number | undefined> = extras ? { ...extras } : {}
+      // When extras already supplied a fill (LikertChart's
+      // level-keyed palette, future charts with bespoke color
+      // logic), respect it and skip the standard color resolution.
+      // Otherwise resolve from colorBy or theme/scheme fallback.
+      if (baseStyle.fill === undefined) {
+        if (colorBy) {
+          if (!colorScale) {
+            // Push-mode initial state — return only the extras so the
+            // frame can supply its own palette for fill.
+            return baseStyle
+          }
+          baseStyle.fill = getColor(d, colorBy, colorScale)
+        } else {
+          // Pass `category` only when the chart wants per-category
+          // cycling (Pie/Donut/Funnel). Bar-style charts pass
+          // `undefined` so all pieces resolve to colorScheme[0].
+          baseStyle.fill = resolveDefaultFill(
+            color, themeCategorical, colorScheme,
+            cycleByCategory ? category : undefined,
+            categoryIndexMap,
+          )
+        }
+      }
+      // Summary-style charts link the box outline to the fill so
+      // stroke and fill come from the same resolved color.
+      if (linkStrokeToFill && baseStyle.stroke === undefined && baseStyle.fill !== undefined) {
+        baseStyle.stroke = baseStyle.fill
+      }
+      return baseStyle
+    }
+  }, [colorBy, colorScale, color, themeCategorical, colorScheme, categoryIndexMap, cycleByCategory, baseStyleExtras, linkStrokeToFill])
+
+  // 2 — overlay user-supplied pieceStyle on top of base. Function form
+  // composes (call both, spread); object form spreads directly.
+  const mergedPieceStyle = useMemo(() => {
+    const baseWithUser = (() => {
+      if (!userPieceStyle) return basePieceStyle
+      if (typeof userPieceStyle === "function") {
+        return (d: Datum, category?: string) => ({
+          ...basePieceStyle(d, category),
+          ...(userPieceStyle as (d: Datum, category?: string) => Record<string, string | number | undefined>)(d, category) || {},
+        })
+      }
+      // Object form — spread the static overrides per call.
+      return (d: Datum, category?: string) => ({
+        ...basePieceStyle(d, category),
+        ...(userPieceStyle as Record<string, string | number | undefined>),
+      })
+    })()
+    // 3 — primitive props (stroke/strokeWidth/opacity) applied LAST.
+    return mergeShapeStyle(baseWithUser, { stroke, strokeWidth, opacity })
+  }, [basePieceStyle, userPieceStyle, stroke, strokeWidth, opacity])
+
+  // 4 — selection wrap. When active, dims pieces that don't match the
+  // selection predicate. No-op when no selection is set.
+  return useMemo(
+    () => wrapStyleWithSelection(mergedPieceStyle, effectiveSelectionHook ?? null, resolvedSelection),
+    [mergedPieceStyle, effectiveSelectionHook, resolvedSelection],
+  )
+}

--- a/src/components/charts/shared/useXYPointStyle.test.tsx
+++ b/src/components/charts/shared/useXYPointStyle.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest"
+import React from "react"
+import { renderHook } from "@testing-library/react"
+import { useXYPointStyle } from "./useXYPointStyle"
+import { TooltipProvider } from "../../store/TooltipStore"
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  <TooltipProvider>{children}</TooltipProvider>
+
+const baseInput = {
+  colorScale: undefined as ((v: string) => string) | undefined,
+  effectiveSelectionHook: null,
+  resolvedSelection: undefined,
+}
+
+describe("useXYPointStyle", () => {
+  it("resolves fill from colorBy + colorScale", () => {
+    const colorScale = (v: string) => ({ A: "#aaa", B: "#bbb" }[v] || "#000")
+    const { result } = renderHook(
+      () => useXYPointStyle({
+        ...baseInput,
+        colorBy: "cat",
+        colorScale,
+      }),
+      { wrapper },
+    )
+    const style = result.current({ cat: "A" } as any)
+    expect(style.fill).toBe("#aaa")
+  })
+
+  it("falls back to color || DEFAULT_COLOR when colorBy unset", () => {
+    const { result } = renderHook(
+      () => useXYPointStyle({
+        ...baseInput,
+        color: "tomato",
+      }),
+      { wrapper },
+    )
+    const style = result.current({} as any)
+    expect(style.fill).toBe("tomato")
+  })
+
+  it("returns no fill when colorBy set but colorScale undefined (push mode)", () => {
+    const { result } = renderHook(
+      () => useXYPointStyle({
+        ...baseInput,
+        colorBy: "cat",
+        colorScale: undefined,
+      }),
+      { wrapper },
+    )
+    const style = result.current({ cat: "A" } as any)
+    expect(style.fill).toBeUndefined()
+  })
+
+  it("uses fallbackFill when colorBy unset and fallback provided", () => {
+    const { result } = renderHook(
+      () => useXYPointStyle({
+        ...baseInput,
+        fallbackFill: (d) => `#q-${d.q}`,
+      }),
+      { wrapper },
+    )
+    const style = result.current({ q: "TR" } as any)
+    expect(style.fill).toBe("#q-TR")
+  })
+
+  it("uses fixed pointRadius when no radiusFn", () => {
+    const { result } = renderHook(
+      () => useXYPointStyle({
+        ...baseInput,
+        pointRadius: 8,
+      }),
+      { wrapper },
+    )
+    const style = result.current({} as any)
+    expect(style.r).toBe(8)
+  })
+
+  it("radiusFn wins over fixed pointRadius (sizeBy path)", () => {
+    const { result } = renderHook(
+      () => useXYPointStyle({
+        ...baseInput,
+        pointRadius: 5,
+        radiusFn: (d) => d.size as number,
+      }),
+      { wrapper },
+    )
+    const style = result.current({ size: 25 } as any)
+    expect(style.r).toBe(25)
+  })
+
+  it("applies fillOpacity default", () => {
+    const { result } = renderHook(
+      () => useXYPointStyle({
+        ...baseInput,
+        fillOpacity: 0.4,
+      }),
+      { wrapper },
+    )
+    const style = result.current({} as any)
+    expect(style.fillOpacity).toBe(0.4)
+  })
+
+  it("baseStyleExtras supplies static defaults like BubbleChart's stroke", () => {
+    const { result } = renderHook(
+      () => useXYPointStyle({
+        ...baseInput,
+        baseStyleExtras: { stroke: "#fff", strokeWidth: 1.5 },
+      }),
+      { wrapper },
+    )
+    const style = result.current({} as any)
+    expect(style.stroke).toBe("#fff")
+    expect(style.strokeWidth).toBe(1.5)
+  })
+
+  it("baseStyleExtras supplying fill bypasses standard color resolution (ConnectedScatterplot)", () => {
+    const { result } = renderHook(
+      () => useXYPointStyle({
+        ...baseInput,
+        colorBy: "cat",
+        colorScale: () => "#never",
+        baseStyleExtras: () => ({ fill: "#viridis-7" }),
+      }),
+      { wrapper },
+    )
+    const style = result.current({ cat: "A" } as any)
+    expect(style.fill).toBe("#viridis-7")
+  })
+
+  it("primitive props win over base + extras", () => {
+    const { result } = renderHook(
+      () => useXYPointStyle({
+        ...baseInput,
+        baseStyleExtras: { stroke: "#fff", strokeWidth: 1 },
+        stroke: "purple",
+        strokeWidth: 4,
+        opacity: 0.2,
+      }),
+      { wrapper },
+    )
+    const style = result.current({} as any)
+    expect(style.stroke).toBe("purple")
+    expect(style.strokeWidth).toBe(4)
+    expect(style.opacity).toBe(0.2)
+  })
+
+  it("colorDatumAccessor lets stacked-area-style points read parentLine", () => {
+    const colorScale = (v: string) => `c-${v}`
+    const { result } = renderHook(
+      () => useXYPointStyle({
+        ...baseInput,
+        colorBy: "cat",
+        colorScale,
+        colorDatumAccessor: (d) => d.parentLine || d,
+      }),
+      { wrapper },
+    )
+    const style = result.current({ x: 1, y: 2, parentLine: { cat: "A" } } as any)
+    expect(style.fill).toBe("c-A")
+  })
+})

--- a/src/components/charts/shared/useXYPointStyle.ts
+++ b/src/components/charts/shared/useXYPointStyle.ts
@@ -1,0 +1,187 @@
+/**
+ * useXYPointStyle — shared point-style construction for XY HOCs.
+ *
+ * Scatterplot, BubbleChart, QuadrantChart, and ConnectedScatterplot
+ * all build their `pointStyle` through the same three-step recipe:
+ *
+ *   1. **Base style** — fill via `getColor(d, colorBy, colorScale)`
+ *      when `colorBy` is set, else `color || DEFAULT_COLOR`. Plus
+ *      `r` (fixed `pointRadius` or `sizeBy`-derived) and
+ *      `fillOpacity`. Charts can supply additional shape-constant
+ *      defaults via `baseStyleExtras` (BubbleChart's default stroke,
+ *      ConnectedScatterplot's viridis fill + white stroke, etc.).
+ *   2. **Primitive overlay** — `mergeShapeStyle` applies top-level
+ *      `stroke` / `strokeWidth` / `opacity` last so they win over
+ *      both the HOC base and any per-datum color resolution.
+ *   3. **Selection wrap** — `wrapStyleWithSelection` dims
+ *      non-matching points when a selection is active.
+ *
+ * This hook collapses those three steps into one call. Adopters
+ * drop ~20 lines of recipe per HOC and keep the design symmetric
+ * with `useOrdinalPieceStyle` (its ordinal counterpart) so cognitive
+ * load stays low when working across families.
+ */
+"use client"
+import { useMemo } from "react"
+import type { Datum } from "./datumTypes"
+import type { Accessor, ChartAccessor } from "./types"
+import type { SelectionHookResult } from "./selectionUtils"
+import { wrapStyleWithSelection } from "./selectionUtils"
+import { mergeShapeStyle } from "./mergeShapeStyle"
+import { getColor } from "./colorUtils"
+import { DEFAULT_COLOR } from "./hooks"
+
+export interface XYPointStyleOptions {
+  /** colorBy accessor — string field name or function. */
+  colorBy?: Accessor<string> | ChartAccessor<Datum, string>
+  /** Resolved categorical color scale (typically from useChartSetup). */
+  colorScale: ((v: string) => string) | undefined
+  /** Top-level uniform `color` prop. Used as the fallback fill when
+   *  `colorBy` is unset. */
+  color?: string
+  /**
+   * Fixed point radius. When `radiusFn` is supplied, that wins
+   * (per-datum sizing for BubbleChart / Scatterplot's `sizeBy`).
+   * @default 5
+   */
+  pointRadius?: number
+  /** Per-datum radius resolver (e.g. wraps `getSize(d, sizeBy, …)`).
+   *  Ignored when undefined; HOCs with no `sizeBy` should pass it
+   *  unset and rely on `pointRadius`. */
+  radiusFn?: (d: Datum) => number
+  /** Default fillOpacity. Charts override this through their own
+   *  prop name (`pointOpacity`, `bubbleOpacity`). @default 1 */
+  fillOpacity?: number
+  /**
+   * Fallback fill resolver invoked when `colorBy` is unset. Used by
+   * QuadrantChart to pick a color from the quadrant the point lands
+   * in. When omitted, fallback is `color || DEFAULT_COLOR` (the
+   * standard Scatterplot/BubbleChart behavior).
+   */
+  fallbackFill?: (d: Datum) => string
+  /**
+   * Static or per-datum extra style applied BEFORE color resolution
+   * and primitive overlay. Use for shape-constant defaults
+   * (BubbleChart's `{ stroke: bubbleStrokeColor, strokeWidth: 1 }`).
+   * If extras supply a `fill`, the standard color resolution is
+   * skipped — same bypass as `useOrdinalPieceStyle`. Lets
+   * ConnectedScatterplot drop in its viridis-by-order fill.
+   */
+  baseStyleExtras?:
+    | Record<string, string | number | undefined>
+    | ((d: Datum) => Record<string, string | number | undefined>)
+  /** Top-level primitive props — applied last via `mergeShapeStyle`. */
+  stroke?: string
+  strokeWidth?: number
+  opacity?: number
+  /** Selection hook output (typically `setup.effectiveSelectionHook`). */
+  effectiveSelectionHook: SelectionHookResult | null | undefined
+  /** Resolved selection config (typically `setup.resolvedSelection`). */
+  resolvedSelection: import("./types").SelectionConfig | undefined
+  /**
+   * For ConnectedScatterplot-style charts whose color depends on the
+   * point's position in an ordered sequence, the resolver may need
+   * the point's parent line. Defaults to identity (`d => d`).
+   * Same hook BarChart's `parentLine` cascade uses.
+   */
+  colorDatumAccessor?: (d: Datum) => Datum
+}
+
+/**
+ * Build a memoized `pointStyle` function for an XY HOC.
+ *
+ * @example
+ * ```tsx
+ * // Scatterplot — sizeBy-driven radius, standard color fallback
+ * const pointStyle = useXYPointStyle({
+ *   colorBy, colorScale: setup.colorScale,
+ *   color, pointRadius, fillOpacity: pointOpacity,
+ *   radiusFn: sizeBy ? (d) => getSize(d, sizeBy, sizeRange, sizeDomain) : undefined,
+ *   stroke, strokeWidth, opacity,
+ *   effectiveSelectionHook: setup.effectiveSelectionHook,
+ *   resolvedSelection: setup.resolvedSelection,
+ * })
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // QuadrantChart — bespoke fallback fill from quadrant lookup
+ * const pointStyle = useXYPointStyle({
+ *   colorBy, colorScale: setup.colorScale, color,
+ *   pointRadius, fillOpacity: pointOpacity,
+ *   radiusFn: sizeBy ? (d) => getSize(d, sizeBy, sizeRange, sizeDomain) : undefined,
+ *   fallbackFill: (d) => quadrantColor(d, getXValue, getYValue, xCenter, yCenter, quadrants),
+ *   stroke, strokeWidth, opacity,
+ *   effectiveSelectionHook: setup.effectiveSelectionHook,
+ *   resolvedSelection: setup.resolvedSelection,
+ * })
+ * ```
+ */
+export function useXYPointStyle(
+  options: XYPointStyleOptions,
+): (d: Datum) => Record<string, string | number | undefined> {
+  const {
+    colorBy,
+    colorScale,
+    color,
+    pointRadius = 5,
+    radiusFn,
+    fillOpacity = 1,
+    fallbackFill,
+    baseStyleExtras,
+    stroke,
+    strokeWidth,
+    opacity,
+    effectiveSelectionHook,
+    resolvedSelection,
+    colorDatumAccessor,
+  } = options
+
+  // 1 — base style (extras → fill resolution → r + fillOpacity)
+  const basePointStyle = useMemo(() => {
+    return (d: Datum) => {
+      const extras = typeof baseStyleExtras === "function"
+        ? baseStyleExtras(d)
+        : baseStyleExtras
+      const baseStyle: Record<string, string | number | undefined> = extras ? { ...extras } : {}
+
+      // Default fillOpacity unless extras already set it.
+      if (baseStyle.fillOpacity === undefined) baseStyle.fillOpacity = fillOpacity
+
+      // Color resolution — skip if extras supplied a fill (lets
+      // ConnectedScatterplot's viridis-by-order palette through).
+      if (baseStyle.fill === undefined) {
+        if (colorBy) {
+          if (colorScale) {
+            const datum = colorDatumAccessor ? colorDatumAccessor(d) : d
+            baseStyle.fill = getColor(datum, colorBy, colorScale)
+          }
+          // else: leave unset — the frame paints from its own palette
+          // (push-mode initial state).
+        } else if (fallbackFill) {
+          baseStyle.fill = fallbackFill(d)
+        } else {
+          baseStyle.fill = color || DEFAULT_COLOR
+        }
+      }
+
+      // Radius — radiusFn wins over fixed pointRadius.
+      if (baseStyle.r === undefined) {
+        baseStyle.r = radiusFn ? radiusFn(d) : pointRadius
+      }
+      return baseStyle
+    }
+  }, [colorBy, colorScale, color, pointRadius, radiusFn, fillOpacity, fallbackFill, baseStyleExtras, colorDatumAccessor])
+
+  // 2 — primitive overlay
+  const baseWithPrimitives = useMemo(
+    () => mergeShapeStyle(basePointStyle, { stroke, strokeWidth, opacity }),
+    [basePointStyle, stroke, strokeWidth, opacity],
+  )
+
+  // 3 — selection wrap
+  return useMemo(
+    () => wrapStyleWithSelection(baseWithPrimitives, effectiveSelectionHook ?? null, resolvedSelection),
+    [baseWithPrimitives, effectiveSelectionHook, resolvedSelection],
+  )
+}

--- a/src/components/charts/shared/validationMap.ts
+++ b/src/components/charts/shared/validationMap.ts
@@ -133,6 +133,7 @@ export const VALIDATION_MAP: Record<string, ComponentSpec> = {
       sizeRange: { type: "array" },
       pointRadius: { type: "number" },
       pointOpacity: { type: "number" },
+      regression: { type: ["boolean", "string", "object"] },
     },
   },
 
@@ -151,6 +152,7 @@ export const VALIDATION_MAP: Record<string, ComponentSpec> = {
       bubbleOpacity: { type: "number" },
       bubbleStrokeWidth: { type: "number" },
       bubbleStrokeColor: { type: "string" },
+      regression: { type: ["boolean", "string", "object"] },
     },
   },
 
@@ -250,6 +252,7 @@ export const VALIDATION_MAP: Record<string, ComponentSpec> = {
       pointRadius: { type: "number" },
       pointIdAccessor: { type: ["string", "function"] },
       annotations: { type: "array" },
+      regression: { type: ["boolean", "string", "object"] },
     },
   },
 
@@ -268,6 +271,7 @@ export const VALIDATION_MAP: Record<string, ComponentSpec> = {
       sort: { type: ["boolean", "string", "function"] },
       barPadding: { type: "number" },
       roundedTop: { type: "number" },
+      regression: { type: ["boolean", "string", "object"] },
     },
   },
 
@@ -435,6 +439,7 @@ export const VALIDATION_MAP: Record<string, ComponentSpec> = {
       sort: { type: ["boolean", "string", "function"] },
       dotRadius: { type: "number" },
       categoryPadding: { type: "number" },
+      regression: { type: ["boolean", "string", "object"] },
     },
   },
 
@@ -976,6 +981,7 @@ export const VALIDATION_MAP: Record<string, ComponentSpec> = {
       flows: { type: "array" },
       nodes: { type: "array" },
       valueAccessor: { type: ["string", "function"] },
+      lineIdAccessor: { type: ["string", "function"] },
     },
   },
   DistanceCartogram: {

--- a/src/components/charts/xy/AreaChart.tsx
+++ b/src/components/charts/xy/AreaChart.tsx
@@ -7,19 +7,16 @@ import { useMemo, forwardRef, useRef } from "react"
 import StreamXYFrame from "../../stream/StreamXYFrame"
 import type { StreamXYFrameProps, StreamXYFrameHandle } from "../../stream/types"
 import type { RealtimeFrameHandle } from "../../realtime/types"
-import { getColor } from "../shared/colorUtils"
-import { useChartMode, DEFAULT_COLOR } from "../shared/hooks"
+import { useChartMode } from "../shared/hooks"
 import type { LegendInteractionMode, LegendPosition } from "../shared/hooks"
 import type { BaseChartProps, AxisConfig, ChartAccessor } from "../shared/types"
 import { MultiPointTooltip, type TooltipProp } from "../../Tooltip/Tooltip"
-import { buildDefaultTooltip, accessorName } from "../shared/tooltipUtils"
 import ChartError from "../shared/ChartError"
 import { SafeRender, warnMissingField } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { wrapStyleWithSelection } from "../shared/selectionUtils"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
+import { useAreaSeriesSetup } from "../shared/useAreaSeriesSetup"
 
 /**
  * AreaChart component props
@@ -327,41 +324,6 @@ export const AreaChart = forwardRef(function AreaChart<TDatum extends Datum = Da
   warnMissingField("AreaChart", safeData, "xAccessor", xAccessor)
   warnMissingField("AreaChart", safeData, "yAccessor", yAccessor)
 
-  // ── Core chart logic ───────────────────────────────────────────────────
-
-  // Check if data is in area objects format (has lineDataAccessor field)
-  const isAreaObjectFormat = safeData[0]?.[lineDataAccessor] !== undefined
-
-  // Transform data to line/area format if needed
-  const areaData = useMemo(() => {
-    if (isAreaObjectFormat) {
-      // Data is already in area objects format
-      return safeData
-    }
-
-    if (areaBy) {
-      // Group data by areaBy field
-      const grouped = safeData.reduce((acc, d) => {
-        const key = typeof areaBy === "function" ? areaBy(d) : d[areaBy]
-        if (!acc[key]) {
-          const areaObj: Datum = { [lineDataAccessor]: [] }
-          // Add the grouping field
-          if (typeof areaBy === "string") {
-            areaObj[areaBy] = key
-          }
-          acc[key] = areaObj
-        }
-        acc[key][lineDataAccessor].push(d)
-        return acc
-      }, {} as Record<string, Datum>)
-
-      return Object.values(grouped)
-    }
-
-    // Single area - wrap in area object
-    return [{ [lineDataAccessor]: safeData }]
-  }, [safeData, areaBy, lineDataAccessor, isAreaObjectFormat])
-
   // ── Shared setup (color, legend, selection, loading/empty) ────────────
   const setup = useChartSetup({
     data: safeData,
@@ -388,72 +350,18 @@ export const AreaChart = forwardRef(function AreaChart<TDatum extends Datum = Da
     height,
   })
 
-  // Area/line style function
-  const baseLineStyle = useMemo(() => {
-    return (d: Datum) => {
-      const baseStyle: Record<string, string | number> = {}
-
-      // Apply color — skip fill/stroke when colorScale unavailable (push API)
-      // so the frame's own color map can fill in
-      if (colorBy) {
-        if (setup.colorScale) {
-          const color = getColor(d, colorBy, setup.colorScale)
-          baseStyle.fill = color
-          if (showLine) {
-            baseStyle.stroke = color
-            baseStyle.strokeWidth = lineWidth
-          } else {
-            baseStyle.stroke = "none"
-          }
-        }
-      } else {
-        const uniformColor = color || DEFAULT_COLOR
-        baseStyle.fill = uniformColor
-        if (showLine) {
-          baseStyle.stroke = uniformColor
-          baseStyle.strokeWidth = lineWidth
-        } else {
-          baseStyle.stroke = "none"
-        }
-      }
-      baseStyle.fillOpacity = areaOpacity
-
-      return baseStyle
-    }
-  }, [colorBy, setup.colorScale, color, areaOpacity, showLine, lineWidth])
-
-  const baseLineStyleWithPrimitives = useMemo(
-    () => mergeShapeStyle(baseLineStyle, { stroke, strokeWidth, opacity }),
-    [baseLineStyle, stroke, strokeWidth, opacity]
-  )
-
-  const lineStyle = useMemo(
-    () => wrapStyleWithSelection(baseLineStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [baseLineStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
-
-  // Point style function (if showPoints is true)
-  const pointStyle = useMemo(() => {
-    if (!showPoints) return undefined
-    return (d: Datum) => {
-      const baseStyle: Record<string, string | number> = { r: pointRadius, fillOpacity: 1 }
-      if (colorBy) {
-        if (setup.colorScale) baseStyle.fill = getColor(d.parentLine || d, colorBy, setup.colorScale)
-      } else {
-        baseStyle.fill = DEFAULT_COLOR
-      }
-      return baseStyle
-    }
-  }, [showPoints, pointRadius, colorBy, setup.colorScale])
-
-  // Default tooltip showing all configured fields. `xFormat`/`yFormat`
-  // cascade from the HOC so the tooltip values read the same way as the axis.
-  const groupField = areaBy || colorBy
-  const defaultTooltipContent = useMemo(() => buildDefaultTooltip([
-    { label: xLabel || accessorName(xAccessor), accessor: xAccessor, role: "x", format: xFormat },
-    { label: yLabel || accessorName(yAccessor), accessor: yAccessor, role: "y", format: yFormat },
-    ...(groupField ? [{ label: accessorName(groupField), accessor: groupField, role: "group" as const }] : []),
-  ]), [xAccessor, yAccessor, xLabel, yLabel, groupField, xFormat, yFormat])
+  // ── Area-series construction (data shaping, line/point style, tooltip) ─
+  const { flattenedData, lineStyle, pointStyle, defaultTooltipContent } = useAreaSeriesSetup({
+    safeData, data,
+    areaBy, lineDataAccessor,
+    colorBy, colorScale: setup.colorScale,
+    color, stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+    areaOpacity, showLine, lineWidth, showPoints, pointRadius,
+    xAccessor, yAccessor, xLabel, yLabel, xFormat, yFormat,
+    groupField: areaBy || colorBy,
+  })
 
   // Validate data (after all hooks)
   const validationError = validateArrayData({
@@ -464,20 +372,6 @@ export const AreaChart = forwardRef(function AreaChart<TDatum extends Datum = Da
       yAccessor,
     },
   })
-
-  // Flatten area data into a single array for StreamXYFrame
-  const flattenedData = useMemo(() => {
-    if (isAreaObjectFormat || areaBy) {
-      return areaData.flatMap((area: Datum) => {
-        const coords = area[lineDataAccessor] || []
-        if (areaBy && typeof areaBy === "string") {
-          return coords.map((c: Datum) => ({ ...c, [areaBy]: area[areaBy] }))
-        }
-        return coords
-      })
-    }
-    return safeData
-  }, [areaData, lineDataAccessor, isAreaObjectFormat, areaBy, safeData])
 
   // Build StreamXYFrame props
   const streamProps: StreamXYFrameProps = {

--- a/src/components/charts/xy/BubbleChart.tsx
+++ b/src/components/charts/xy/BubbleChart.tsx
@@ -7,8 +7,8 @@ import { useMemo, useCallback, forwardRef, useRef, useState } from "react"
 import StreamXYFrame from "../../stream/StreamXYFrame"
 import type { StreamXYFrameProps, StreamXYFrameHandle, MarginalGraphicsConfig } from "../../stream/types"
 import type { RealtimeFrameHandle } from "../../realtime/types"
-import { getColor, getSize } from "../shared/colorUtils"
-import { useChartMode, DEFAULT_COLOR } from "../shared/hooks"
+import { getSize } from "../shared/colorUtils"
+import { useChartMode } from "../shared/hooks"
 import type { LegendInteractionMode, LegendPosition } from "../shared/hooks"
 import type { BaseChartProps, AxisConfig, ChartAccessor } from "../shared/types"
 import { type TooltipProp } from "../../Tooltip/Tooltip"
@@ -16,11 +16,12 @@ import { buildDefaultTooltip, accessorName } from "../shared/tooltipUtils"
 import ChartError from "../shared/ChartError"
 import { SafeRender } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { normalizeLinkedBrush, wrapStyleWithSelection } from "../shared/selectionUtils"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
+import { normalizeLinkedBrush } from "../shared/selectionUtils"
 import { useBrushSelection } from "../../store/useSelection"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
+import { useXYPointStyle } from "../shared/useXYPointStyle"
+import { buildRegressionAnnotation, type RegressionProp } from "../shared/regressionUtils"
 
 /**
  * BubbleChart component props
@@ -146,6 +147,15 @@ export interface BubbleChartProps<TDatum extends Datum = Datum> extends BaseChar
    */
   annotations?: Datum[]
 
+  /**
+   * Overlay a regression line on the bubbles. Accepts `true` (linear
+   * with default styling), a method name (`"linear"` | `"polynomial"`
+   * | `"loess"`), or a full `RegressionConfig`. Sugar over the `trend`
+   * annotation — drop into the `annotations` array directly for richer
+   * setups.
+   */
+  regression?: RegressionProp
+
   /** Fixed x domain `[min, max]` (either bound may be undefined to leave that side data-derived). */
   xExtent?: [number | undefined, number | undefined] | [number]
   /** Fixed y domain `[min, max]` (either bound may be undefined to leave that side data-derived). */
@@ -253,6 +263,7 @@ export const BubbleChart = forwardRef(function BubbleChart<TDatum extends Datum 
     marginalGraphics,
     pointIdAccessor,
     annotations,
+    regression,
     xExtent,
     yExtent,
     frameProps = {},
@@ -384,39 +395,18 @@ export const BubbleChart = forwardRef(function BubbleChart<TDatum extends Datum 
     return [Math.min(...sizes), Math.max(...sizes)] as [number, number]
   }, [safeData, sizeBy, isPushMode, sizeDomainVersion])
 
-  // Point style function
-  const basePointStyle = useMemo(() => {
-    return (d: Datum) => {
-      const baseStyle: Record<string, string | number> = {
-        fillOpacity: bubbleOpacity,
-        strokeWidth: bubbleStrokeWidth,
-        stroke: bubbleStrokeColor
-      }
-
-      // Apply color — skip fill when colorScale unavailable (push API)
-      // so the frame's own color map can fill in
-      if (colorBy) {
-        if (setup.colorScale) baseStyle.fill = getColor(d, colorBy, setup.colorScale)
-      } else {
-        baseStyle.fill = color || DEFAULT_COLOR
-      }
-
-      // Apply size
-      baseStyle.r = getSize(d, sizeBy, sizeRange, sizeDomain)
-
-      return baseStyle
-    }
-  }, [colorBy, setup.colorScale, sizeBy, sizeRange, sizeDomain, bubbleOpacity, bubbleStrokeWidth, bubbleStrokeColor, color])
-
-  const basePointStyleWithPrimitives = useMemo(
-    () => mergeShapeStyle(basePointStyle, { stroke, strokeWidth, opacity }),
-    [basePointStyle, stroke, strokeWidth, opacity]
-  )
-
-  const pointStyle = useMemo(
-    () => wrapStyleWithSelection(basePointStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [basePointStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
+  // Bubble's chart-shape defaults (default stroke + width) ride
+  // through `baseStyleExtras`. sizeBy is mandatory on BubbleChart, so
+  // `radiusFn` is always set.
+  const pointStyle = useXYPointStyle({
+    colorBy, colorScale: setup.colorScale, color,
+    fillOpacity: bubbleOpacity,
+    radiusFn: (d) => getSize(d, sizeBy, sizeRange, sizeDomain),
+    baseStyleExtras: { stroke: bubbleStrokeColor, strokeWidth: bubbleStrokeWidth },
+    stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+  })
 
   // Default tooltip showing all configured fields. `xFormat`/`yFormat`
   // cascade from the HOC so the tooltip values read the same way as the axis.
@@ -438,6 +428,14 @@ export const BubbleChart = forwardRef(function BubbleChart<TDatum extends Datum 
     requiredProps: { sizeBy },
   })
   if (error) return <ChartError componentName="BubbleChart" message={error} width={width} height={height} />
+
+  // Splice the `regression` sugar into annotations as a `trend`
+  // annotation. Trend goes first so user-supplied annotations paint
+  // above it.
+  const trendAnn = buildRegressionAnnotation(regression)
+  const resolvedAnnotations = trendAnn
+    ? [trendAnn, ...(annotations || [])]
+    : annotations
 
   // Build StreamXYFrame props
   const streamProps: StreamXYFrameProps = {
@@ -471,7 +469,7 @@ export const BubbleChart = forwardRef(function BubbleChart<TDatum extends Datum 
     }),
     ...(marginalGraphics && { marginalGraphics }),
     ...(pointIdAccessor && { pointIdAccessor }),
-    ...(annotations && annotations.length > 0 && { annotations }),
+    ...(resolvedAnnotations && resolvedAnnotations.length > 0 && { annotations: resolvedAnnotations }),
     ...(xExtent && { xExtent }),
     ...(yExtent && { yExtent }),
     ...setup.crosshairProps,

--- a/src/components/charts/xy/BubbleChart.tsx
+++ b/src/components/charts/xy/BubbleChart.tsx
@@ -398,11 +398,25 @@ export const BubbleChart = forwardRef(function BubbleChart<TDatum extends Datum 
   // Bubble's chart-shape defaults (default stroke + width) ride
   // through `baseStyleExtras`. sizeBy is mandatory on BubbleChart, so
   // `radiusFn` is always set.
+  //
+  // `baseStyleExtras` and `radiusFn` are useMemo-stabilized because
+  // both are deps of `useXYPointStyle`'s internal memo — passing
+  // inline literals would re-allocate the helper's `pointStyle` fn
+  // on every render even when nothing changed.
+  const bubbleBaseExtras = useMemo(
+    () => ({ stroke: bubbleStrokeColor, strokeWidth: bubbleStrokeWidth }),
+    [bubbleStrokeColor, bubbleStrokeWidth],
+  )
+  const bubbleRadiusFn = useCallback(
+    (d: Datum) => getSize(d, sizeBy, sizeRange, sizeDomain),
+    [sizeBy, sizeRange, sizeDomain],
+  )
+
   const pointStyle = useXYPointStyle({
     colorBy, colorScale: setup.colorScale, color,
     fillOpacity: bubbleOpacity,
-    radiusFn: (d) => getSize(d, sizeBy, sizeRange, sizeDomain),
-    baseStyleExtras: { stroke: bubbleStrokeColor, strokeWidth: bubbleStrokeWidth },
+    radiusFn: bubbleRadiusFn,
+    baseStyleExtras: bubbleBaseExtras,
     stroke, strokeWidth, opacity,
     effectiveSelectionHook: setup.effectiveSelectionHook,
     resolvedSelection: setup.resolvedSelection,

--- a/src/components/charts/xy/ConnectedScatterplot.tsx
+++ b/src/components/charts/xy/ConnectedScatterplot.tsx
@@ -13,12 +13,13 @@ import type { LegendInteractionMode } from "../shared/hooks"
 import ChartError from "../shared/ChartError"
 import { SafeRender, warnMissingField } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { DEFAULT_SELECTION_OPACITY, wrapStyleWithSelection } from "../shared/selectionUtils"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
+import { DEFAULT_SELECTION_OPACITY } from "../shared/selectionUtils"
 import { interpolateViridis } from "../shared/colorPalettes"
 import { useChartSetup } from "../shared/useChartSetup"
 import { buildBaseMetadataProps, buildCustomBehaviorProps, buildTooltipProps } from "../shared/streamPropsHelpers"
 import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
+import { useXYPointStyle } from "../shared/useXYPointStyle"
+import { buildRegressionAnnotation, type RegressionProp } from "../shared/regressionUtils"
 
 /**
  * ConnectedScatterplot component props
@@ -52,6 +53,12 @@ export interface ConnectedScatterplotProps<TDatum extends Datum = Datum> extends
   legendInteraction?: LegendInteractionMode
   /** Annotation objects to render on the chart */
   annotations?: Datum[]
+  /**
+   * Overlay a regression line under the connected path. Accepts
+   * `true`, a method name (`"linear"` | `"polynomial"` | `"loess"`),
+   * or a full `RegressionConfig`. Sugar over the `trend` annotation.
+   */
+  regression?: RegressionProp
   /** Fixed x domain `[min, max]` (either bound may be undefined to leave that side data-derived). */
   xExtent?: [number | undefined, number | undefined] | [number]
   /** Fixed y domain `[min, max]` (either bound may be undefined to leave that side data-derived). */
@@ -137,6 +144,7 @@ export const ConnectedScatterplot = forwardRef(function ConnectedScatterplot<TDa
     tooltip,
     pointIdAccessor,
     annotations,
+    regression,
     xExtent,
     yExtent,
     frameProps = {},
@@ -319,32 +327,30 @@ export const ConnectedScatterplot = forwardRef(function ConnectedScatterplot<TDa
 
   // ── Point style — viridis colored, fixed radius ───────────────────────
   //
-  // Reads ordering from the WeakMap (no user data mutation).
-
-  const basePointStyle = useMemo(() => {
-    return (d: Datum) => {
-      const order = orderMap.get(d)
-      const i = order?.idx ?? 0
-      const n = order?.total ?? 1
-      return {
-        fill: n > 0 ? viridisColor(i, n) : "#6366f1",
-        stroke: "white",
-        strokeWidth: 1,
-        r: pointRadius,
-        fillOpacity: 1,
-      }
+  // Reads ordering from the WeakMap (no user data mutation). The
+  // viridis-by-order fill is supplied via `baseStyleExtras`, which
+  // bypasses `useXYPointStyle`'s standard color resolution (same
+  // bypass `useOrdinalPieceStyle` uses for LikertChart).
+  const pointStyleExtras = useMemo(() => (d: Datum) => {
+    const order = orderMap.get(d)
+    const i = order?.idx ?? 0
+    const n = order?.total ?? 1
+    return {
+      fill: n > 0 ? viridisColor(i, n) : "#6366f1",
+      stroke: "white",
+      strokeWidth: 1,
+      r: pointRadius,
+      fillOpacity: 1,
     }
   }, [pointRadius, orderMap])
 
-  const basePointStyleWithPrimitives = useMemo(
-    () => mergeShapeStyle(basePointStyle, { stroke, strokeWidth, opacity }),
-    [basePointStyle, stroke, strokeWidth, opacity]
-  )
-
-  const pointStyle = useMemo(
-    () => wrapStyleWithSelection(basePointStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [basePointStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
+  const pointStyle = useXYPointStyle({
+    colorScale: undefined,
+    baseStyleExtras: pointStyleExtras,
+    stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+  })
 
   // ── Tooltip ───────────────────────────────────────────────────────────
 
@@ -363,6 +369,12 @@ export const ConnectedScatterplot = forwardRef(function ConnectedScatterplot<TDa
     data,
     accessors: { xAccessor, yAccessor },
   })
+
+  // Splice the `regression` sugar into annotations as a `trend` annotation.
+  const trendAnn = buildRegressionAnnotation(regression)
+  const resolvedAnnotations = trendAnn
+    ? [trendAnn, ...(annotations || [])]
+    : annotations
 
   // ── Render ────────────────────────────────────────────────────────────
 
@@ -393,7 +405,7 @@ export const ConnectedScatterplot = forwardRef(function ConnectedScatterplot<TDa
     ...(pointIdAccessor && { pointIdAccessor }),
     canvasPreRenderers,
     svgPreRenderers,
-    ...(annotations && annotations.length > 0 && { annotations }),
+    ...(resolvedAnnotations && resolvedAnnotations.length > 0 && { annotations: resolvedAnnotations }),
     ...(xExtent && { xExtent }),
     ...(yExtent && { yExtent }),
     ...setup.crosshairProps,

--- a/src/components/charts/xy/QuadrantChart.tsx
+++ b/src/components/charts/xy/QuadrantChart.tsx
@@ -311,10 +311,18 @@ export const QuadrantChart = forwardRef(function QuadrantChart<TDatum extends Da
     return quadrants.bottomLeft.color
   }, [getXValue, getYValue, xCenter, yCenter, quadrants, color])
 
+  // useMemo'd because `radiusFn` is a dep of useXYPointStyle's
+  // internal memo — passing an inline literal would re-allocate the
+  // returned `pointStyle` on every render.
+  const sizedRadiusFn = useMemo(
+    () => sizeBy ? (d: Datum) => getSize(d, sizeBy, sizeRange, sizeDomain) : undefined,
+    [sizeBy, sizeRange, sizeDomain],
+  )
+
   const pointStyle = useXYPointStyle({
     colorBy, colorScale: setup.colorScale, color,
     pointRadius, fillOpacity: pointOpacity,
-    radiusFn: sizeBy ? (d) => getSize(d, sizeBy, sizeRange, sizeDomain) : undefined,
+    radiusFn: sizedRadiusFn,
     fallbackFill: quadrantFallbackFill,
     stroke, strokeWidth, opacity,
     effectiveSelectionHook: setup.effectiveSelectionHook,

--- a/src/components/charts/xy/QuadrantChart.tsx
+++ b/src/components/charts/xy/QuadrantChart.tsx
@@ -6,7 +6,7 @@ import { useMemo, forwardRef, useRef } from "react"
 import StreamXYFrame from "../../stream/StreamXYFrame"
 import type { StreamXYFrameProps, StreamXYFrameHandle, CanvasRendererFn, SVGPreRendererFn, StreamScales, StreamLayout, SceneNode } from "../../stream/types"
 import type { RealtimeFrameHandle } from "../../realtime/types"
-import { getColor, getSize } from "../shared/colorUtils"
+import { getSize } from "../shared/colorUtils"
 import type { BaseChartProps, AxisConfig, ChartAccessor } from "../shared/types"
 import { normalizeTooltip, type TooltipProp } from "../../Tooltip/Tooltip"
 import { buildDefaultTooltip, accessorName } from "../shared/tooltipUtils"
@@ -15,10 +15,9 @@ import type { LegendInteractionMode, LegendPosition } from "../shared/hooks"
 import ChartError from "../shared/ChartError"
 import { SafeRender, warnMissingField } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { wrapStyleWithSelection } from "../shared/selectionUtils"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
+import { useXYPointStyle } from "../shared/useXYPointStyle"
 
 /**
  * Quadrant label and color configuration
@@ -296,42 +295,31 @@ export const QuadrantChart = forwardRef(function QuadrantChart<TDatum extends Da
     [yAccessor]
   )
 
-  const basePointStyle = useMemo(() => {
-    return (d: Datum) => {
-      const baseStyle: Record<string, string | number> = { fillOpacity: pointOpacity }
-      if (colorBy) {
-        if (setup.colorScale) baseStyle.fill = getColor(d, colorBy, setup.colorScale)
-        // else: let frame use its own color scheme (push API)
-      } else {
-        // Color by quadrant: determine which quadrant the point falls in
-        // based on xCenter/yCenter thresholds and use the quadrant's color
-        const xVal = getXValue(d)
-        const yVal = getYValue(d)
-        const isRight = xCenter != null ? xVal >= xCenter : undefined
-        const isTop = yCenter != null ? yVal >= yCenter : undefined
-        if (isTop === undefined || isRight === undefined) {
-          baseStyle.fill = color || DEFAULT_COLOR
-        } else if (isTop && isRight) baseStyle.fill = quadrants.topRight.color
-        else if (isTop && !isRight) baseStyle.fill = quadrants.topLeft.color
-        else if (!isTop && isRight) baseStyle.fill = quadrants.bottomRight.color
-        else baseStyle.fill = quadrants.bottomLeft.color
-      }
-      baseStyle.r = sizeBy
-        ? getSize(d, sizeBy, sizeRange, sizeDomain)
-        : pointRadius
-      return baseStyle
-    }
-  }, [colorBy, setup.colorScale, sizeBy, sizeRange, sizeDomain, pointRadius, pointOpacity, getXValue, getYValue, xCenter, yCenter, quadrants, color])
+  // Per-quadrant fill — used as the helper's `fallbackFill` when
+  // `colorBy` is unset. When the centerlines aren't fully specified
+  // (xCenter / yCenter is null), each point falls back to the
+  // standard `color || DEFAULT_COLOR` resolution.
+  const quadrantFallbackFill = useMemo(() => (d: Datum) => {
+    const xVal = getXValue(d)
+    const yVal = getYValue(d)
+    const isRight = xCenter != null ? xVal >= xCenter : undefined
+    const isTop = yCenter != null ? yVal >= yCenter : undefined
+    if (isTop === undefined || isRight === undefined) return color || DEFAULT_COLOR
+    if (isTop && isRight) return quadrants.topRight.color
+    if (isTop && !isRight) return quadrants.topLeft.color
+    if (!isTop && isRight) return quadrants.bottomRight.color
+    return quadrants.bottomLeft.color
+  }, [getXValue, getYValue, xCenter, yCenter, quadrants, color])
 
-  const basePointStyleWithPrimitives = useMemo(
-    () => mergeShapeStyle(basePointStyle, { stroke, strokeWidth, opacity }),
-    [basePointStyle, stroke, strokeWidth, opacity]
-  )
-
-  const pointStyle = useMemo(
-    () => wrapStyleWithSelection(basePointStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [basePointStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
+  const pointStyle = useXYPointStyle({
+    colorBy, colorScale: setup.colorScale, color,
+    pointRadius, fillOpacity: pointOpacity,
+    radiusFn: sizeBy ? (d) => getSize(d, sizeBy, sizeRange, sizeDomain) : undefined,
+    fallbackFill: quadrantFallbackFill,
+    stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+  })
 
   // Default tooltip
   // Auto-detect a title field: first string-valued field not used as an accessor

--- a/src/components/charts/xy/Scatterplot.test.tsx
+++ b/src/components/charts/xy/Scatterplot.test.tsx
@@ -321,4 +321,70 @@ describe("Scatterplot", () => {
       expect(styleB.stroke).toBe("#strokeOverride")
     })
   })
+
+  // ── regression prop ────────────────────────────────────────────────────
+  // Sugar over the `trend` annotation. The HOC prepends a trend-typed
+  // annotation to the user's annotations array; user annotations
+  // remain visible above it.
+  describe("regression prop", () => {
+    it("does not inject a trend annotation when omitted", () => {
+      render(
+        <TooltipProvider>
+          <Scatterplot data={sampleData} />
+        </TooltipProvider>
+      )
+      expect(lastXYFrameProps.annotations).toBeUndefined()
+    })
+
+    it("`regression` injects a default linear trend annotation", () => {
+      render(
+        <TooltipProvider>
+          <Scatterplot data={sampleData} regression />
+        </TooltipProvider>
+      )
+      const ann = lastXYFrameProps.annotations
+      expect(ann).toHaveLength(1)
+      expect(ann[0]).toEqual({ type: "trend", method: "linear" })
+    })
+
+    it("`regression='loess'` picks the LOESS method", () => {
+      render(
+        <TooltipProvider>
+          <Scatterplot data={sampleData} regression="loess" />
+        </TooltipProvider>
+      )
+      expect(lastXYFrameProps.annotations[0]).toEqual({ type: "trend", method: "loess" })
+    })
+
+    it("forwards a full RegressionConfig object", () => {
+      render(
+        <TooltipProvider>
+          <Scatterplot
+            data={sampleData}
+            regression={{ method: "polynomial", order: 3, color: "#ef4444", label: "Cubic" }}
+          />
+        </TooltipProvider>
+      )
+      expect(lastXYFrameProps.annotations[0]).toEqual({
+        type: "trend",
+        method: "polynomial",
+        order: 3,
+        color: "#ef4444",
+        label: "Cubic",
+      })
+    })
+
+    it("prepends the trend annotation in front of user annotations (z-order)", () => {
+      const userAnn = { type: "label", x: 1, y: 10, note: "hi" }
+      render(
+        <TooltipProvider>
+          <Scatterplot data={sampleData} regression annotations={[userAnn]} />
+        </TooltipProvider>
+      )
+      const ann = lastXYFrameProps.annotations
+      expect(ann).toHaveLength(2)
+      expect(ann[0].type).toBe("trend")
+      expect(ann[1]).toBe(userAnn)
+    })
+  })
 })

--- a/src/components/charts/xy/Scatterplot.tsx
+++ b/src/components/charts/xy/Scatterplot.tsx
@@ -273,10 +273,18 @@ export const Scatterplot = forwardRef(function Scatterplot<TDatum extends Datum 
     return [Math.min(...sizes), Math.max(...sizes)] as [number, number]
   }, [safeData, sizeBy])
 
+  // useMemo'd because `radiusFn` is a dep of useXYPointStyle's
+  // internal memo — passing an inline literal would re-allocate the
+  // returned `pointStyle` on every render.
+  const sizedRadiusFn = useMemo(
+    () => sizeBy ? (d: Datum) => getSize(d, sizeBy, sizeRange, sizeDomain) : undefined,
+    [sizeBy, sizeRange, sizeDomain],
+  )
+
   const pointStyle = useXYPointStyle({
     colorBy, colorScale: setup.colorScale, color,
     pointRadius, fillOpacity: pointOpacity,
-    radiusFn: sizeBy ? (d) => getSize(d, sizeBy, sizeRange, sizeDomain) : undefined,
+    radiusFn: sizedRadiusFn,
     stroke, strokeWidth, opacity,
     effectiveSelectionHook: setup.effectiveSelectionHook,
     resolvedSelection: setup.resolvedSelection,

--- a/src/components/charts/xy/Scatterplot.tsx
+++ b/src/components/charts/xy/Scatterplot.tsx
@@ -7,20 +7,21 @@ import { useMemo, useCallback, forwardRef, useRef } from "react"
 import StreamXYFrame from "../../stream/StreamXYFrame"
 import type { StreamXYFrameProps, StreamXYFrameHandle, MarginalGraphicsConfig } from "../../stream/types"
 import type { RealtimeFrameHandle } from "../../realtime/types"
-import { getColor, getSize } from "../shared/colorUtils"
+import { getSize } from "../shared/colorUtils"
 import type { BaseChartProps, AxisConfig, ChartAccessor } from "../shared/types"
 import { type TooltipProp } from "../../Tooltip/Tooltip"
 import { buildDefaultTooltip, accessorName } from "../shared/tooltipUtils"
-import { useChartMode, DEFAULT_COLOR } from "../shared/hooks"
+import { useChartMode } from "../shared/hooks"
 import type { LegendInteractionMode, LegendPosition } from "../shared/hooks"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
 import ChartError from "../shared/ChartError"
 import { SafeRender, warnMissingField } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { normalizeLinkedBrush, wrapStyleWithSelection } from "../shared/selectionUtils"
+import { normalizeLinkedBrush } from "../shared/selectionUtils"
 import { useBrushSelection } from "../../store/useSelection"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
+import { useXYPointStyle } from "../shared/useXYPointStyle"
+import { buildRegressionAnnotation, type RegressionProp } from "../shared/regressionUtils"
 
 /**
  * Scatterplot component props
@@ -62,6 +63,26 @@ export interface ScatterplotProps<TDatum extends Datum = Datum> extends BaseChar
   legendPosition?: LegendPosition
   /** Annotation objects to render on the chart */
   annotations?: Datum[]
+  /**
+   * Overlay a regression line on the scatter. Accepts:
+   * - `true` — linear regression with default styling
+   * - `"linear"` | `"polynomial"` | `"loess"` — pick a method
+   * - `RegressionConfig` — full control (method, bandwidth, order,
+   *   color, strokeWidth, strokeDasharray, label)
+   *
+   * Sugar over `annotations={[{ type: "trend", … }]}` — for richer
+   * setups (multiple regression lines, custom anchoring) drop into
+   * the annotations array directly.
+   *
+   * @example
+   * ```tsx
+   * <Scatterplot data={d} xAccessor="x" yAccessor="y" regression />
+   * <Scatterplot data={d} xAccessor="x" yAccessor="y" regression="loess" />
+   * <Scatterplot data={d} xAccessor="x" yAccessor="y"
+   *   regression={{ method: "polynomial", order: 3, color: "#ef4444", label: "Cubic" }} />
+   * ```
+   */
+  regression?: RegressionProp
   /** Fixed x domain `[min, max]` (either bound may be undefined to leave that side data-derived). */
   xExtent?: [number | undefined, number | undefined] | [number]
   /** Fixed y domain `[min, max]` (either bound may be undefined to leave that side data-derived). */
@@ -148,6 +169,7 @@ export const Scatterplot = forwardRef(function Scatterplot<TDatum extends Datum 
     marginalGraphics,
     pointIdAccessor,
     annotations,
+    regression,
     xExtent,
     yExtent,
     frameProps = {},
@@ -251,33 +273,14 @@ export const Scatterplot = forwardRef(function Scatterplot<TDatum extends Datum 
     return [Math.min(...sizes), Math.max(...sizes)] as [number, number]
   }, [safeData, sizeBy])
 
-  const basePointStyle = useMemo(() => {
-    return (d: Datum) => {
-      const baseStyle: Record<string, string | number> = { fillOpacity: pointOpacity }
-      if (colorBy) {
-        if (setup.colorScale) baseStyle.fill = getColor(d, colorBy, setup.colorScale)
-        // else: let frame use its own color scheme (push API)
-      } else {
-        baseStyle.fill = color || DEFAULT_COLOR
-      }
-      baseStyle.r = sizeBy
-        ? getSize(d, sizeBy, sizeRange, sizeDomain)
-        : pointRadius
-      return baseStyle
-    }
-  }, [colorBy, setup.colorScale, sizeBy, sizeRange, sizeDomain, pointRadius, pointOpacity, color])
-
-  // Overlay top-level primitive style props (stroke/strokeWidth/opacity) last
-  // so they win over the HOC base style and any per-datum color resolution.
-  const pointStyleWithPrimitives = useMemo(
-    () => mergeShapeStyle(basePointStyle, { stroke, strokeWidth, opacity }),
-    [basePointStyle, stroke, strokeWidth, opacity]
-  )
-
-  const pointStyle = useMemo(
-    () => wrapStyleWithSelection(pointStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [pointStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
+  const pointStyle = useXYPointStyle({
+    colorBy, colorScale: setup.colorScale, color,
+    pointRadius, fillOpacity: pointOpacity,
+    radiusFn: sizeBy ? (d) => getSize(d, sizeBy, sizeRange, sizeDomain) : undefined,
+    stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+  })
 
   // Default tooltip showing all configured fields. `xFormat`/`yFormat`
   // cascade from the HOC so the tooltip values read the same way as the axis.
@@ -287,6 +290,16 @@ export const Scatterplot = forwardRef(function Scatterplot<TDatum extends Datum 
     ...(colorBy ? [{ label: accessorName(colorBy), accessor: colorBy, role: "color" as const }] : []),
     ...(sizeBy ? [{ label: accessorName(sizeBy), accessor: sizeBy, role: "size" as const }] : []),
   ]), [xAccessor, yAccessor, xLabel, yLabel, colorBy, sizeBy, xFormat, yFormat])
+
+  // Splice the `regression` sugar into annotations as a `trend`
+  // annotation. User-supplied annotations always win on z-order — the
+  // regression line goes underneath so explicit callouts/markers stay
+  // legible above it.
+  const resolvedAnnotations = useMemo(() => {
+    const trendAnn = buildRegressionAnnotation(regression)
+    if (!trendAnn) return annotations
+    return [trendAnn, ...(annotations || [])]
+  }, [regression, annotations])
 
   // Validate data (after all hooks)
   const error = validateArrayData({
@@ -330,7 +343,7 @@ export const Scatterplot = forwardRef(function Scatterplot<TDatum extends Datum 
     }),
     ...(marginalGraphics && { marginalGraphics }),
     ...(pointIdAccessor && { pointIdAccessor }),
-    ...(annotations && annotations.length > 0 && { annotations }),
+    ...(resolvedAnnotations && resolvedAnnotations.length > 0 && { annotations: resolvedAnnotations }),
     ...(xExtent && { xExtent }),
     ...(yExtent && { yExtent }),
     ...(brushConfig && { brush: { dimension: brushDimension }, onBrush }),

--- a/src/components/charts/xy/StackedAreaChart.tsx
+++ b/src/components/charts/xy/StackedAreaChart.tsx
@@ -7,19 +7,16 @@ import { useMemo, forwardRef, useRef } from "react"
 import StreamXYFrame from "../../stream/StreamXYFrame"
 import type { StreamXYFrameProps, StreamXYFrameHandle } from "../../stream/types"
 import type { RealtimeFrameHandle } from "../../realtime/types"
-import { getColor } from "../shared/colorUtils"
-import { useChartMode, DEFAULT_COLOR } from "../shared/hooks"
+import { useChartMode } from "../shared/hooks"
 import type { LegendInteractionMode, LegendPosition } from "../shared/hooks"
 import type { BaseChartProps, AxisConfig, ChartAccessor } from "../shared/types"
 import { MultiPointTooltip, type TooltipProp } from "../../Tooltip/Tooltip"
-import { buildDefaultTooltip, accessorName } from "../shared/tooltipUtils"
 import ChartError from "../shared/ChartError"
 import { SafeRender } from "../shared/withChartWrapper"
 import { validateArrayData } from "../shared/validateChartData"
-import { wrapStyleWithSelection } from "../shared/selectionUtils"
-import { mergeShapeStyle } from "../shared/mergeShapeStyle"
 import { useChartSetup } from "../shared/useChartSetup"
 import { useFrameImperativeHandle } from "../shared/useFrameImperativeHandle"
+import { useAreaSeriesSetup } from "../shared/useAreaSeriesSetup"
 
 /**
  * StackedAreaChart component props
@@ -322,41 +319,6 @@ export const StackedAreaChart = forwardRef(function StackedAreaChart<TDatum exte
 
   useFrameImperativeHandle(ref, { variant: "xy", frameRef })
 
-  // ── Core chart logic ───────────────────────────────────────────────────
-
-  // Check if data is in area objects format (has lineDataAccessor field)
-  const isAreaObjectFormat = safeData[0]?.[lineDataAccessor] !== undefined
-
-  // Transform data to line/area format if needed
-  const areaData = useMemo(() => {
-    if (isAreaObjectFormat) {
-      // Data is already in area objects format
-      return safeData
-    }
-
-    if (areaBy) {
-      // Group data by areaBy field
-      const grouped = safeData.reduce((acc, d) => {
-        const key = typeof areaBy === "function" ? areaBy(d) : d[areaBy]
-        if (!acc[key]) {
-          const areaObj: Datum = { [lineDataAccessor]: [] }
-          // Add the grouping field
-          if (typeof areaBy === "string") {
-            areaObj[areaBy] = key
-          }
-          acc[key] = areaObj
-        }
-        acc[key][lineDataAccessor].push(d)
-        return acc
-      }, {} as Record<string, Datum>)
-
-      return Object.values(grouped)
-    }
-
-    // Single area - wrap in area object
-    return [{ [lineDataAccessor]: safeData }]
-  }, [safeData, areaBy, lineDataAccessor, isAreaObjectFormat])
-
   // ── Shared setup (color, legend, selection, loading/empty) ────────────
   const setup = useChartSetup({
     data: safeData,
@@ -383,66 +345,22 @@ export const StackedAreaChart = forwardRef(function StackedAreaChart<TDatum exte
     height,
   })
 
-  // Area/line style function
-  const baseLineStyle = useMemo(() => {
-    return (d: Datum) => {
-      const baseStyle: Record<string, string | number> = {}
-
-      // Apply color — skip when colorScale unavailable (push API)
-      // so the frame's own color resolution can fill in
-      if (actualColorBy && setup.colorScale) {
-        const color = getColor(d, actualColorBy, setup.colorScale)
-        baseStyle.fill = color
-        if (showLine) {
-          baseStyle.stroke = color
-          baseStyle.strokeWidth = lineWidth
-        } else {
-          baseStyle.stroke = "none"
-        }
-      } else if (!actualColorBy) {
-        const uniformColor = color || DEFAULT_COLOR
-        baseStyle.fill = uniformColor
-        baseStyle.stroke = showLine ? uniformColor : "none"
-        if (showLine) baseStyle.strokeWidth = lineWidth
-      }
-      baseStyle.fillOpacity = areaOpacity
-
-      return baseStyle
-    }
-  }, [actualColorBy, setup.colorScale, areaOpacity, showLine, lineWidth, color])
-
-  const baseLineStyleWithPrimitives = useMemo(
-    () => mergeShapeStyle(baseLineStyle, { stroke, strokeWidth, opacity }),
-    [baseLineStyle, stroke, strokeWidth, opacity]
-  )
-
-  const lineStyle = useMemo(
-    () => wrapStyleWithSelection(baseLineStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection),
-    [baseLineStyleWithPrimitives, setup.effectiveSelectionHook, setup.resolvedSelection]
-  )
-
-  // Point style function (if showPoints is true)
-  const pointStyle = useMemo(() => {
-    if (!showPoints) return undefined
-    return (d: Datum) => {
-      const baseStyle: Record<string, string | number> = { r: pointRadius, fillOpacity: 1 }
-      if (actualColorBy) {
-        if (setup.colorScale) baseStyle.fill = getColor(d.parentLine || d, actualColorBy, setup.colorScale)
-      } else {
-        baseStyle.fill = color || DEFAULT_COLOR
-      }
-      return baseStyle
-    }
-  }, [showPoints, pointRadius, actualColorBy, setup.colorScale, color])
-
-  // Default tooltip showing all configured fields. `xFormat`/`yFormat`
-  // cascade from the HOC so the tooltip values read the same way as the axis.
-  const groupField = areaBy || colorBy
-  const defaultTooltipContent = useMemo(() => buildDefaultTooltip([
-    { label: xLabel || accessorName(xAccessor), accessor: xAccessor, role: "x", format: xFormat },
-    { label: yLabel || accessorName(yAccessor), accessor: yAccessor, role: "y", format: yFormat },
-    ...(groupField ? [{ label: accessorName(groupField), accessor: groupField, role: "group" as const }] : []),
-  ]), [xAccessor, yAccessor, xLabel, yLabel, groupField, xFormat, yFormat])
+  // ── Area-series construction (data shaping, line/point style, tooltip) ─
+  // `actualColorBy` (= `colorBy ?? areaBy`) feeds the helper's color
+  // resolution since stacked areas without explicit colorBy still want
+  // distinct per-series colors. `groupField` keeps the prior tooltip
+  // label preference (`areaBy ?? colorBy`).
+  const { flattenedData, lineStyle, pointStyle, defaultTooltipContent } = useAreaSeriesSetup({
+    safeData, data,
+    areaBy, lineDataAccessor,
+    colorBy: actualColorBy, colorScale: setup.colorScale,
+    color, stroke, strokeWidth, opacity,
+    effectiveSelectionHook: setup.effectiveSelectionHook,
+    resolvedSelection: setup.resolvedSelection,
+    areaOpacity, showLine, lineWidth, showPoints, pointRadius,
+    xAccessor, yAccessor, xLabel, yLabel, xFormat, yFormat,
+    groupField: areaBy || colorBy,
+  })
 
   // Validate data (after all hooks)
   const validationError = validateArrayData({
@@ -453,20 +371,6 @@ export const StackedAreaChart = forwardRef(function StackedAreaChart<TDatum exte
       yAccessor,
     },
   })
-
-  // Flatten area data into a single array for StreamXYFrame
-  const flattenedData = useMemo(() => {
-    if (isAreaObjectFormat || areaBy) {
-      return areaData.flatMap((area: Datum) => {
-        const coords = area[lineDataAccessor] || []
-        if (areaBy && typeof areaBy === "string") {
-          return coords.map((c: Datum) => ({ ...c, [areaBy]: area[areaBy] }))
-        }
-        return coords
-      })
-    }
-    return safeData
-  }, [areaData, lineDataAccessor, isAreaObjectFormat, areaBy, safeData])
 
   // Build StreamXYFrame props
   const streamProps: StreamXYFrameProps = {

--- a/src/components/stream/GeoPipelineStore.test.ts
+++ b/src/components/stream/GeoPipelineStore.test.ts
@@ -290,4 +290,65 @@ describe("GeoPipelineStore", () => {
       expect(points.length).toBe(3)
     })
   })
+
+  // ── Line ingest snapshot semantics ─────────────────────────────────
+  // pushLine / pushManyLines mutate `lineData` in place for
+  // performance; setLines and getLines must defensive-copy on the
+  // boundary so callers can't observe ingest-side mutation on a
+  // snapshot they thought was stable, and so push can't leak into
+  // a React-owned `lines` prop array.
+  describe("line ingest snapshot semantics", () => {
+    it("setLines defensive-copies the input so push doesn't leak", () => {
+      const store = new GeoPipelineStore(makeConfig({ lineIdAccessor: "id" }))
+      const userArray = [{ id: "a", coordinates: [[0, 0], [1, 1]] }]
+      store.setLines(userArray)
+      store.pushLine({ id: "b", coordinates: [[2, 2], [3, 3]] })
+      // User's original array must remain length-1.
+      expect(userArray).toHaveLength(1)
+      // Store's internal data has both.
+      expect(store.getLines()).toHaveLength(2)
+    })
+
+    it("getLines returns a snapshot — push doesn't mutate prior reads", () => {
+      const store = new GeoPipelineStore(makeConfig({ lineIdAccessor: "id" }))
+      store.pushLine({ id: "a", coordinates: [[0, 0], [1, 1]] })
+      const snapshot = store.getLines()
+      expect(snapshot).toHaveLength(1)
+      store.pushLine({ id: "b", coordinates: [[2, 2], [3, 3]] })
+      // Prior snapshot stays length-1; the new push is visible only
+      // on a fresh getLines() call.
+      expect(snapshot).toHaveLength(1)
+      expect(store.getLines()).toHaveLength(2)
+    })
+
+    it("pushManyLines appends and increments version", () => {
+      const store = new GeoPipelineStore(makeConfig({ lineIdAccessor: "id" }))
+      const v0 = store.version
+      store.pushManyLines([
+        { id: "a", coordinates: [[0, 0], [1, 1]] },
+        { id: "b", coordinates: [[2, 2], [3, 3]] },
+      ])
+      expect(store.getLines()).toHaveLength(2)
+      expect(store.version).toBeGreaterThan(v0)
+    })
+
+    it("removeLine filters by id and bumps version", () => {
+      const store = new GeoPipelineStore(makeConfig({ lineIdAccessor: "id" }))
+      store.pushManyLines([
+        { id: "a", coordinates: [[0, 0], [1, 1]] },
+        { id: "b", coordinates: [[2, 2], [3, 3]] },
+        { id: "c", coordinates: [[4, 4], [5, 5]] },
+      ])
+      const removed = store.removeLine("b")
+      expect(removed).toHaveLength(1)
+      expect(removed[0].id).toBe("b")
+      expect(store.getLines()).toHaveLength(2)
+    })
+
+    it("removeLine throws when lineIdAccessor isn't configured", () => {
+      const store = new GeoPipelineStore(makeConfig())
+      store.pushLine({ id: "a", coordinates: [[0, 0], [1, 1]] })
+      expect(() => store.removeLine("a")).toThrow(/lineIdAccessor/)
+    })
+  })
 })

--- a/src/components/stream/GeoPipelineStore.ts
+++ b/src/components/stream/GeoPipelineStore.ts
@@ -401,9 +401,10 @@ export class GeoPipelineStore {
 
   /** Append a single line/flow record (coordinates pre-resolved). Lines
    *  aren't ring-buffered — the bounded set is the geography.
-   *  Mutates `lineData` in place (the array is internal to the store
-   *  and never returned by reference) so streaming pushes don't pay
-   *  the O(n) GC churn of an array spread per push. */
+   *  Mutates `lineData` in place to avoid the O(n) GC churn of an
+   *  array spread per push. The mutation is invisible to callers
+   *  because `setLines` defensive-copies on entry and `getLines`
+   *  defensive-copies on exit. */
   pushLine(line: Datum): void {
     if (line == null || typeof line !== "object") return
     this.lineData.push(line)
@@ -442,9 +443,13 @@ export class GeoPipelineStore {
     return removed
   }
 
-  /** Read the current line/flow set (post-push, pre-projection). */
+  /** Read the current line/flow set (post-push, pre-projection).
+   *  Defensive copy — `pushLine` / `pushManyLines` mutate
+   *  `lineData` in place, so returning by reference would let
+   *  callers observe ingest-side mutations on a snapshot they
+   *  thought was stable. */
   getLines(): Datum[] {
-    return this.lineData
+    return this.lineData.slice()
   }
 
   /**

--- a/src/components/stream/GeoPipelineStore.ts
+++ b/src/components/stream/GeoPipelineStore.ts
@@ -395,6 +395,50 @@ export class GeoPipelineStore {
     this.lastIngestTime = now
   }
 
+  /** Append a single line/flow record (coordinates pre-resolved). Lines
+   *  aren't ring-buffered — the bounded set is the geography. */
+  pushLine(line: Datum): void {
+    if (line == null || typeof line !== "object") return
+    this.lineData = [...this.lineData, line]
+    this.version++
+  }
+
+  /** Append multiple line/flow records in one pass. */
+  pushManyLines(lines: Datum[]): void {
+    if (!Array.isArray(lines) || lines.length === 0) return
+    const safe = lines.filter((l) => l != null && typeof l === "object")
+    if (safe.length === 0) return
+    this.lineData = [...this.lineData, ...safe]
+    this.version++
+  }
+
+  /** Remove line records by id. Requires `lineIdAccessor`. */
+  removeLine(id: string | string[]): Datum[] {
+    const { lineIdAccessor } = this.config
+    if (!lineIdAccessor) {
+      throw new Error("removeLine() requires lineIdAccessor to be configured")
+    }
+    const getId = typeof lineIdAccessor === "function"
+      ? lineIdAccessor
+      : (d: Datum) => d[lineIdAccessor as string]
+    const ids = new Set(Array.isArray(id) ? id : [id])
+    const removed: Datum[] = []
+    this.lineData = this.lineData.filter((d) => {
+      if (ids.has(String(getId(d)))) {
+        removed.push(d)
+        return false
+      }
+      return true
+    })
+    if (removed.length > 0) this.version++
+    return removed
+  }
+
+  /** Read the current line/flow set (post-push, pre-projection). */
+  getLines(): Datum[] {
+    return this.lineData
+  }
+
   /**
    * Remove points by ID. Requires pointIdAccessor to be configured.
    * Returns the removed items.

--- a/src/components/stream/GeoPipelineStore.ts
+++ b/src/components/stream/GeoPipelineStore.ts
@@ -412,12 +412,15 @@ export class GeoPipelineStore {
   }
 
   /** Append multiple line/flow records in one pass. Same in-place
-   *  mutation rationale as `pushLine`. */
+   *  mutation rationale as `pushLine`. Loops instead of
+   *  `Array.prototype.push(...safe)` so very large batches don't
+   *  blow the engine's argument-count limit (mirrors how `pushMany`
+   *  for points iterates rather than spreads). */
   pushManyLines(lines: Datum[]): void {
     if (!Array.isArray(lines) || lines.length === 0) return
     const safe = lines.filter((l) => l != null && typeof l === "object")
     if (safe.length === 0) return
-    this.lineData.push(...safe)
+    for (const line of safe) this.lineData.push(line)
     this.version++
   }
 

--- a/src/components/stream/GeoPipelineStore.ts
+++ b/src/components/stream/GeoPipelineStore.ts
@@ -366,7 +366,11 @@ export class GeoPipelineStore {
   }
 
   setLines(data: Datum[]): void {
-    this.lineData = data
+    // Defensive copy — `pushLine` / `pushManyLines` mutate
+    // `lineData` in place (no ring buffer for lines), so taking the
+    // user's array reference here would let a subsequent push leak
+    // into the React-owned array passed via the `lines` prop.
+    this.lineData = data.slice()
   }
 
   /** Initialize streaming mode with a ring buffer */
@@ -396,19 +400,23 @@ export class GeoPipelineStore {
   }
 
   /** Append a single line/flow record (coordinates pre-resolved). Lines
-   *  aren't ring-buffered — the bounded set is the geography. */
+   *  aren't ring-buffered — the bounded set is the geography.
+   *  Mutates `lineData` in place (the array is internal to the store
+   *  and never returned by reference) so streaming pushes don't pay
+   *  the O(n) GC churn of an array spread per push. */
   pushLine(line: Datum): void {
     if (line == null || typeof line !== "object") return
-    this.lineData = [...this.lineData, line]
+    this.lineData.push(line)
     this.version++
   }
 
-  /** Append multiple line/flow records in one pass. */
+  /** Append multiple line/flow records in one pass. Same in-place
+   *  mutation rationale as `pushLine`. */
   pushManyLines(lines: Datum[]): void {
     if (!Array.isArray(lines) || lines.length === 0) return
     const safe = lines.filter((l) => l != null && typeof l === "object")
     if (safe.length === 0) return
-    this.lineData = [...this.lineData, ...safe]
+    this.lineData.push(...safe)
     this.version++
   }
 

--- a/src/components/stream/StreamGeoFrame.tsx
+++ b/src/components/stream/StreamGeoFrame.tsx
@@ -168,6 +168,7 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
       yAccessor,
       lineDataAccessor,
       pointIdAccessor,
+      lineIdAccessor,
 
       // Geo-specific
       lineType = "geo",
@@ -323,11 +324,12 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
       transition,
       introAnimation: introEnabled,
       annotations,
-      pointIdAccessor
+      pointIdAccessor,
+      lineIdAccessor
     }), [
       projection, projectionExtent, fitPadding, xAccessor, yAccessor, lineDataAccessor,
       lineType, flowStyle, areaStyle, pointStyle, lineStyle, colorScheme, graticule,
-      projectionTransform, decay, pulse, transition?.duration, transition?.easing, introEnabled, annotations, pointIdAccessor, currentTheme
+      projectionTransform, decay, pulse, transition?.duration, transition?.easing, introEnabled, annotations, pointIdAccessor, lineIdAccessor, currentTheme
     ])
 
     // Stabilize the config reference so inline-object / inline-array
@@ -468,6 +470,21 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
       scheduleRender()
     }, [scheduleRender])
 
+    const pushLine = useCallback((line: Datum) => {
+      if (line == null || typeof line !== "object") return
+      storeRef.current?.pushLine(line)
+      dirtyRef.current = true
+      scheduleRender()
+    }, [scheduleRender])
+
+    const pushManyLines = useCallback((lines: Datum[]) => {
+      const safe = filterSparseArray(lines)
+      if (safe.length === 0) return
+      storeRef.current?.pushManyLines(safe)
+      dirtyRef.current = true
+      scheduleRender()
+    }, [scheduleRender])
+
     const clearAll = useCallback(() => {
       storeRef.current?.clear()
       dirtyRef.current = true
@@ -485,6 +502,17 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
         }
         return removed
       },
+      pushLine,
+      pushManyLines,
+      removeLine: (id: string | string[]) => {
+        const removed = storeRef.current?.removeLine(id) ?? []
+        if (removed.length > 0) {
+          dirtyRef.current = true
+          scheduleRender()
+        }
+        return removed
+      },
+      getLines: () => storeRef.current?.getLines() ?? [],
       clear: clearAll,
       getProjection: () => storeRef.current?.scales?.projection ?? null,
       getGeoPath: () => storeRef.current?.scales?.geoPath ?? null,
@@ -501,7 +529,7 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
         }
       },
       getData: () => storeRef.current?.getPoints() ?? []
-    }), [pushPoint, pushMany, clearAll, scheduleRender])
+    }), [pushPoint, pushMany, pushLine, pushManyLines, clearAll, scheduleRender])
 
     // ── Hover handler ─────────────────────────────────────────────────
     // hoverHandlerRef + hoverLeaveRef + onPointerMove/Leave + cleanup all

--- a/src/components/stream/StreamOrdinalFrame.tsx
+++ b/src/components/stream/StreamOrdinalFrame.tsx
@@ -47,6 +47,7 @@ import { findNearestOrdinalNode } from "./OrdinalCanvasHitTester"
 import { extractOrdinalNavPoints, buildNavGraph, resolvePosition, nextGraphIndex, navPointToHover, type NavGraph } from "./keyboardNav"
 import { useStalenessCheck } from "./useStalenessCheck"
 import { OrdinalSVGOverlay, OrdinalSVGUnderlay } from "./OrdinalSVGOverlay"
+import { resolveAnnotationAccessor, buildEnrichAnnotationData } from "./annotationAccessorResolver"
 import { OrdinalBrushOverlay } from "./OrdinalBrushOverlay"
 import { ordinalSceneNodeToSVG, isServerEnvironment } from "./SceneToSVG"
 import { useHydration, useWasHydratingFromSSR, useHydrationLifecycle } from "./useHydration"
@@ -966,6 +967,22 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
       </FlippingTooltip>
     ) : null
 
+    // ── Annotation accessor resolution ─────────────────────────────────
+    // OrdinalSVGOverlay needs string keys to read coordinates from
+    // annotationData. When `oAccessor` / `rAccessor` are functions
+    // we bake resolved values under synthetic stable keys and
+    // forward those keys as the annotation context's xAccessor /
+    // yAccessor. Without this, annotation rules like `trend` would
+    // see `undefined` accessors and silently fail to read the data.
+    // Mirrors StreamXYFrame's same pattern; helpers shared via
+    // `./annotationAccessorResolver`.
+    const xResolved = resolveAnnotationAccessor(oAccessor, undefined, "__semiotic_resolvedO", "")
+    const yResolved = resolveAnnotationAccessor(rAccessor, undefined, "__semiotic_resolvedR", "")
+    const annXAccessor = xResolved.key
+    const annYAccessor = yResolved.key
+    const hasAnnotations = (annotations && annotations.length > 0) || false
+    const enrichAnnotationData = buildEnrichAnnotationData(xResolved, yResolved, hasAnnotations)
+
     // ── SSR path: render SVG instead of canvas ──────────────────────────
 
     // SSR + actual SSR-hydration only — pure CSR mounts skip the
@@ -1046,9 +1063,9 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
             annotations={annotations}
             svgAnnotationRules={svgAnnotationRules}
             annotationFrame={0}
-            xAccessor={typeof oAccessor === "string" ? oAccessor : undefined}
-            yAccessor={typeof rAccessor === "string" ? rAccessor : undefined}
-            annotationData={store?.getData()}
+            xAccessor={annXAccessor}
+            yAccessor={annYAccessor}
+            annotationData={enrichAnnotationData(store?.getData())}
           />
           {centerContent && projection === "radial" && (
             <div
@@ -1167,9 +1184,9 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
           annotations={annotations}
           svgAnnotationRules={svgAnnotationRules}
           annotationFrame={annotationFrame}
-          xAccessor={typeof oAccessor === "string" ? oAccessor : undefined}
-          yAccessor={typeof rAccessor === "string" ? rAccessor : undefined}
-          annotationData={storeRef.current?.getData()}
+          xAccessor={annXAccessor}
+          yAccessor={annYAccessor}
+          annotationData={enrichAnnotationData(storeRef.current?.getData())}
           underlayRendered
         />
 

--- a/src/components/stream/StreamXYFrame.tsx
+++ b/src/components/stream/StreamXYFrame.tsx
@@ -56,6 +56,7 @@ import type { StreamRendererFn } from "./renderers/types"
 import { resolveNodeColor } from "./sceneUtils"
 import { extractCategoryDomain, sameCategoryDomain } from "./categoryDomain"
 import { filterSparseArray } from "../charts/shared/sparseArray"
+import { resolveAnnotationAccessor, buildEnrichAnnotationData } from "./annotationAccessorResolver"
 
 // ── Auto-date tick formatting ─────────────────────────────────────────
 
@@ -1367,41 +1368,21 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
     )
 
     // ── Annotation accessor resolution ─────────────────────────────────
-    // SVGOverlay needs string keys to look up coordinates in annotationData.
-    // When accessors are functions, we bake resolved values under synthetic keys.
-    // Priority: string accessor → function accessor (resolved) → string fallback
-    // (timeAccessor/valueAccessor) → function fallback (resolved) → undefined.
-    const resolveAnnAccessor = (
-      primary: any, fallback: any, resolvedKey: string, fallbackKey: string
-    ): { key: string | undefined; fn: ((d: Datum) => any) | null } => {
-      if (typeof primary === "string") return { key: primary, fn: null }
-      if (typeof primary === "function") return { key: resolvedKey, fn: primary }
-      if (typeof fallback === "string") return { key: fallback, fn: null }
-      if (typeof fallback === "function") return { key: fallbackKey, fn: fallback }
-      return { key: undefined, fn: null }
-    }
-
-    const xResolved = resolveAnnAccessor(xAccessor, timeAccessor, "__semiotic_resolvedX", "__semiotic_resolvedTime")
-    const yResolved = resolveAnnAccessor(yAccessor, valueAccessor, "__semiotic_resolvedY", "__semiotic_resolvedValue")
+    // SVGOverlay needs string keys to look up coordinates in
+    // annotationData. When accessors are functions, we bake resolved
+    // values under synthetic keys. Priority: string accessor →
+    // function accessor (resolved) → string fallback
+    // (timeAccessor/valueAccessor) → function fallback (resolved) →
+    // undefined.
+    //
+    // Helpers live in `./annotationAccessorResolver` so
+    // StreamOrdinalFrame can share the same plumbing.
+    const xResolved = resolveAnnotationAccessor(xAccessor, timeAccessor, "__semiotic_resolvedX", "__semiotic_resolvedTime")
+    const yResolved = resolveAnnotationAccessor(yAccessor, valueAccessor, "__semiotic_resolvedY", "__semiotic_resolvedValue")
     const annXAccessor = xResolved.key
     const annYAccessor = yResolved.key
-    const hasAnnotations = annotations && annotations.length > 0
-
-    const enrichAnnotationData = (rawData: Datum[] | undefined): Datum[] | undefined => {
-      if (!rawData || !hasAnnotations || (!xResolved.fn && !yResolved.fn)) return rawData
-      let didChange = false
-      const result = rawData.map(d => {
-        const computeX = xResolved.fn && xResolved.key && !(xResolved.key in d)
-        const computeY = yResolved.fn && yResolved.key && !(yResolved.key in d)
-        if (!computeX && !computeY) return d
-        didChange = true
-        const copy = { ...d }
-        if (computeX) copy[xResolved.key!] = xResolved.fn!(d)
-        if (computeY) copy[yResolved.key!] = yResolved.fn!(d)
-        return copy
-      })
-      return didChange ? result : rawData
-    }
+    const hasAnnotations = (annotations && annotations.length > 0) || false
+    const enrichAnnotationData = buildEnrichAnnotationData(xResolved, yResolved, hasAnnotations)
 
     // ── SSR + hydration path: render SVG instead of canvas ─────────────
     //

--- a/src/components/stream/annotationAccessorResolver.ts
+++ b/src/components/stream/annotationAccessorResolver.ts
@@ -1,0 +1,73 @@
+/**
+ * Annotation-context accessors must be string keys — SVG overlay
+ * rules look up coordinates with `data[xAccessor]`. When a chart's
+ * user accessor is a function, we bake the resolved value under a
+ * synthetic stable key on each annotation datum and forward the
+ * synthetic key as the annotation's xAccessor / yAccessor.
+ *
+ * Originally inline in `StreamXYFrame.tsx`; lifted here so
+ * `StreamOrdinalFrame` (and any future frame with the same need)
+ * can share the same plumbing rather than re-implementing it.
+ */
+import type { Datum } from "../charts/shared/datumTypes"
+
+export interface ResolvedAnnotationAccessor {
+  /** String key the annotation context will read on each datum. */
+  key: string | undefined
+  /** Accessor function when the user supplied one (synthetic key
+   *  gets baked from this); `null` when the user supplied a string
+   *  or nothing. */
+  fn: ((d: Datum) => any) | null
+}
+
+/**
+ * Resolve an accessor pair to the (key, fn) shape the annotation
+ * pipeline needs. Probes the primary accessor first, then the
+ * fallback (e.g. `valueAccessor` when no `yAccessor` was supplied).
+ *
+ * - String accessor → use it as the key, no enrichment needed.
+ * - Function accessor → use the synthetic resolved-key, run the fn
+ *   per-datum to bake the value.
+ * - Otherwise undefined.
+ */
+export function resolveAnnotationAccessor(
+  primary: unknown,
+  fallback: unknown,
+  resolvedKey: string,
+  fallbackKey: string,
+): ResolvedAnnotationAccessor {
+  if (typeof primary === "string") return { key: primary, fn: null }
+  if (typeof primary === "function") return { key: resolvedKey, fn: primary as (d: Datum) => any }
+  if (typeof fallback === "string") return { key: fallback, fn: null }
+  if (typeof fallback === "function") return { key: fallbackKey, fn: fallback as (d: Datum) => any }
+  return { key: undefined, fn: null }
+}
+
+/**
+ * Build an `enrichAnnotationData(rawData)` function that walks the
+ * data array and bakes synthetic-key values for any function
+ * accessors. Returns the original array reference unchanged when no
+ * enrichment is needed (no annotations, no function accessors, or
+ * synthetic keys already present).
+ */
+export function buildEnrichAnnotationData(
+  xResolved: ResolvedAnnotationAccessor,
+  yResolved: ResolvedAnnotationAccessor,
+  hasAnnotations: boolean,
+) {
+  return (rawData: Datum[] | undefined): Datum[] | undefined => {
+    if (!rawData || !hasAnnotations || (!xResolved.fn && !yResolved.fn)) return rawData
+    let didChange = false
+    const result = rawData.map((d) => {
+      const computeX = xResolved.fn && xResolved.key && !(xResolved.key in d)
+      const computeY = yResolved.fn && yResolved.key && !(yResolved.key in d)
+      if (!computeX && !computeY) return d
+      didChange = true
+      const copy = { ...d }
+      if (computeX) copy[xResolved.key!] = xResolved.fn!(d)
+      if (computeY) copy[yResolved.key!] = yResolved.fn!(d)
+      return copy
+    })
+    return didChange ? result : rawData
+  }
+}

--- a/src/components/stream/geoTypes.ts
+++ b/src/components/stream/geoTypes.ts
@@ -148,6 +148,8 @@ export interface GeoPipelineConfig {
   // Annotations
   annotations?: Datum[]
   pointIdAccessor?: string | ((d: Datum) => string)
+  /** ID accessor on line data — required for `removeLine` by id. */
+  lineIdAccessor?: string | ((d: Datum) => string)
 }
 
 // ── Frame props ──────────────────────────────────────────────────────
@@ -169,6 +171,8 @@ export interface StreamGeoFrameProps<T = Datum> {
   yAccessor?: string | ((d: T) => number)
   lineDataAccessor?: string | ((d: T) => Datum[])
   pointIdAccessor?: string | ((d: T) => string)
+  /** ID accessor on line data — required for ref `removeLine` by id. */
+  lineIdAccessor?: string | ((d: T) => string)
 
   // ── Geo-specific ──
   lineType?: "geo" | "line"
@@ -276,6 +280,14 @@ export interface StreamGeoFrameHandle {
   pushMany(data: Datum[]): void
   /** Remove points by ID. Requires pointIdAccessor. */
   removePoint(id: string | string[]): Datum[]
+  /** Append a single line/flow record. Coordinates pre-resolved per `lineDataAccessor`. */
+  pushLine(line: Datum): void
+  /** Append multiple line/flow records in one batch. */
+  pushManyLines(lines: Datum[]): void
+  /** Remove lines by ID. Requires `lineIdAccessor`. */
+  removeLine(id: string | string[]): Datum[]
+  /** Read the current line/flow set. */
+  getLines(): Datum[]
   clear(): void
   getProjection(): GeoProjection | null
   getGeoPath(): GeoPath<any, GeoPermissibleObjects> | null


### PR DESCRIPTION


  This PR is the multi-phase output of the HOC/Frame architecture audit (docs/strategy/hoc-frame-architecture-audit.md), the alignment-and-consistency push that followed, and two product-visible features that fall out
  naturally once the matrix exists.

  Net stats
  - 4 new shared hooks consolidate ~480 LOC of duplicated recipe across 27 HOC migrations.
  - 1 new push variant (geo-lines) closes a gap on FlowMap.
  - 1 new annotation behavior (ordinal-frame regression) ships as a chart prop.
  - 1 new AI capability surface (capabilities.json + suggestChart filter + /features/capabilities page) turns the chartSpecs capability matrix from internal bookkeeping into a feature.
  - 4048/4048 tests pass; all 5 alignment checks green (check:capabilities, check:surface, check:ssr, check:chart-specs, check:ai-contracts).

  ---
  Phase 1 — Capability matrix on chartSpecs

  ChartCapabilities interface added to chartSpecs.ts; all 44 chart entries backfilled with renderModes, supportsLegend/Selection/LinkedHover/Push/SSR, colorModel, layoutMode, specialFeatures.

  New script: scripts/check-capabilities.mjs (CI gate). Locks the matrix against runtime behavior:
  - supportsSSR: true ↔ entry in serverChartConfigs.ts
  - supportsPush: true ↔ HOC source imports useFrameImperativeHandle (or has a documented exemption tag in specialFeatures)
  - supportsLinkedHover: true ↔ useChartSelection / setup-hook usage
  - layoutMode: "custom" ↔ customNetworkLayout / customXYLayout / etc. import

  Caught two real drifts during backfill: ScatterplotMatrix and MinimapChart wrongly claimed supportsLinkedHover: true despite being composites that delegate interaction to inner charts — corrected with a
  composite-delegates-interaction specialFeature tag.

  New shared parser: scripts/lib/capabilityMatrix.mjs — one source consumed by check-capabilities, generate-capabilities-md, and the new generate-capabilities-json. Eliminates three drifting copies of the chartSpecs
  regex parser.

  ---
  Phase 2 step 1 — useNetworkChartSetup

  All 8 network HOCs migrated (SankeyDiagram, ForceDirectedGraph, ChordDiagram, Treemap, CirclePack, TreeDiagram, OrbitDiagram, ProcessSankey). Per the alignment-and-consistency principle, ProcessSankey's earlier
  exemption was reversed — it now uses the shared hook for sparse filter, color scale, palette, themeCategorical, customHover/Click, loadingEl, emptyEl. Its custom legend (palette-fallback colorOf for distinct band
  colors) and custom particles overlay stay HOC-side because they're chart-specific.

  Net ~145 LOC saved across the 8 migrations.

  ---
  Phase 2 step 2 — useOrdinalPieceStyle

  All 13 piece-style ordinal HOCs migrated: BarChart, StackedBarChart, GroupedBarChart, PieChart, DonutChart, FunnelChart, DotPlot, SwarmPlot, SwimlaneChart, LikertChart, BoxPlot, ViolinPlot, RidgelinePlot, Histogram.

  Three orthogonal options absorb the full taxonomy:
  - cycleByCategory — pie/donut/funnel slice cycling vs bar uniform fill (default false; locked by bugRepros.test.tsx BR-2 invariant).
  - baseStyleExtras (static or per-datum) — DotPlot's r, SwarmPlot's size-encoded radius, statistical-summary fillOpacity, LikertChart's level-keyed fill.
  - linkStrokeToFill — statistical-summary box outline matches box body.

  The helper detects fill in baseStyleExtras and short-circuits standard color resolution to support LikertChart's bespoke level-keyed palette. Net ~200 LOC saved + dead imports (getColor, resolveDefaultFill,
  wrapStyleWithSelection, mergeShapeStyle) removed across the 13 files.

  GaugeChart still uses bespoke piece-style (it's value-not-data) and is intentionally not migrated.

  ---
  Phase 2 capability re-audit + FlowMap push API

  User feedback flagged that the prior push-capability sweep had pattern-matched some supportsPush: false entries instead of interrogating each chart against its docs streaming behavior. Re-audit findings:

  - FlowMap: was a fixable gap, not particular-realtime. Migrated to push.
  - GaugeChart: single-scalar value — array-append push doesn't fit. Stays false with an explicit blocker in chartSpecs.
  - ChoroplethMap: per-region values live on feature.properties; streaming is property-keyed updates via mergeData. Stays false with an explicit blocker.

  Both false charts now carry controlled-prop-streaming in specialFeatures so capability sweeps see them as deliberate rather than omitted.

  FlowMap implementation (~150 LOC across 4 files):
  - GeoPipelineStore: pushLine / pushManyLines / removeLine / getLines / lineIdAccessor config.
  - StreamGeoFrame imperative handle exposes the new methods.
  - New geo-lines variant in useFrameImperativeHandle (mirrors geo-points).
  - FlowMap HOC forwardRefs and translates pushed flows ({ source, target, value }) → coordinate-resolved lines via nodeLookupRef HOC-side before delegating to the frame's pushLine.
  - Docs streaming demo flipped from setState(flows) to ref.current.push(flow).
  - 6 new push-API tests; chartSpecs flipped to supportsPush: true.

  Net push claim: 36 of 44 charts (was 35).

  ---
  Phase 2 step 3 — useAreaSeriesSetup

  AreaChart and StackedAreaChart shared a verbatim 6-step recipe before this. Hook absorbs:
  1. Area-format detection + grouping (pre-grouped {coordinates} vs flat-with-areaBy).
  2. Re-flatten for <StreamXYFrame>.
  3. Base line/area style with colorBy or uniform-color fallback.
  4. Primitive overlay + selection wrap.
  5. Optional point style with parentLine cascading.
  6. Default tooltip via buildDefaultTooltip.

  StackedAreaChart's actualColorBy = colorBy ?? areaBy cascade stays HOC-side and passes pre-resolved into the helper (same shape as useOrdinalPieceStyle). Net ~200 LOC saved.

  Side-effect alignment fix: AreaChart's point-style fallback now honors the top-level color prop (was hardcoded DEFAULT_COLOR) — matches StackedAreaChart and the broader primitive-color contract.

  14 new unit tests on the hook.

  ---
  Phase 2 step 4 — useXYPointStyle

  The XY-side analogue of useOrdinalPieceStyle. All 4 XY point HOCs migrated: Scatterplot, BubbleChart, QuadrantChart, ConnectedScatterplot.

  Three knobs absorb each chart's variation:
  - radiusFn — sizeBy-derived per-datum radius (Scatterplot, BubbleChart's mandatory getSize).
  - fallbackFill — QuadrantChart's per-quadrant fill resolution when colorBy is unset.
  - baseStyleExtras — BubbleChart's default stroke/width; ConnectedScatterplot's viridis-by-order palette via the extras-supplies-fill bypass.

  Hook signature deliberately mirrors useOrdinalPieceStyle for cross-family consistency. Net ~80 LOC saved. 11 new unit tests.

  ---
  Side quest — regression prop on point HOCs

  Sugar over the existing trend annotation, added to Scatterplot, BubbleChart, ConnectedScatterplot.

  <Scatterplot data={d} regression />                      // linear, default styling
  <Scatterplot data={d} regression="loess" />              // method shorthand
  <Scatterplot data={d} regression={{                      // full config
    method: "polynomial", order: 3,
    color: "#ef4444", strokeWidth: 2.5, label: "Cubic",
  }} />

  Shared helper at src/components/charts/shared/regressionUtils.ts:
  - RegressionProp type (boolean | RegressionMethod | RegressionConfig).
  - buildRegressionAnnotation(prop) returns the annotation object the HOC prepends to its annotations array (so user callouts paint above the regression line).
                                                                                                                                                               
  Discoverability fix: the Scatterplot docs page used to tell users to "graduate to StreamXYFrame for regression lines" — now teaches the prop directly with two LiveExample blocks (linear + loess). CLAUDE.md updated.  
                                                                                                                                                                                                                          
  7 helper tests + 5 integration tests per HOC.                                                                                                                                                                           
                                                                                                                                                                                                                          
  ---                                                                                                                                                                                                                     
  Phase 4 — Capability-driven AI surfaces                
                                         
  The chartSpecs capability matrix was internal bookkeeping. This phase makes it useful externally.
                                                                                                                                                                                                                          
  ai/capabilities.json — generated from chartSpecs by the new generate-capabilities-json.mjs, regenerated alongside the markdown table by npm run docs:capabilities. 44 charts indexed. Locked by check:capabilities so   
  chartSpecs and the JSON cannot drift.                                                                                                                                                                                   
                                                                                                                                                                                                                          
  suggestCharts({ capabilities }) — extends the MCP suggestChart tool. Constraint shape: { push?, linkedHover?, ssr?, selection?, legend? }. Each set to true requires the capability; false forbids it; unset is ignored.
   
  // MCP tool call                                                                                                                                                                                                        
  {                                                      
    "name": "suggestChart",                                                                                                                                                                                               
    "arguments": {                                       
      "data": [{ "category": "A", "value": 10 }, ...],                                                                                                                                                                    
      "intent": "comparison",
      "capabilities": { "push": true, "linkedHover": true }                                                                                                                                                               
    }                                                    
  }                                                                                                                                                                                                                       
                                                         
  Charts that don't satisfy every constraint are dropped from the recommendation set, and the response surfaces a filteredOut list (with chart name + reason) so callers can see what was removed and decide whether to   
  relax constraints. Unknown chart names fail closed.
                                                                                                                                                                                                                          
  /features/capabilities website page — interactive filterable matrix reading the same JSON. Toggle Push / Linked Hover / SSR / Selection / Legend to narrow the table; the page wires identically to what the AI tool    
  consumes. Linked from sidebar nav.
                                                                                                                                                                                                                          
  14 unit tests on the filter + 1 MCP-level integration test.                                                                                                                                                             
   
  ---                                                                                                                                                                                                                     
  Phase B — Ordinal regression overlay                   
                                                                                                                                                                                                                          
  Extends the trend annotation handler to detect frameType === "ordinal":
  - Categorical axis treated as a category-index for regression input (consistent across vertical and horizontal projections).                                                                                            
  - Pixel projection routes regression output through the band scale.                                                                                                                                                     
  - LOESS's fractional indices linearly interpolate between band centers.                                                                                                                                                 
                                                                                                                                                                                                                          
  Then surfaces it as a chart prop: regression on BarChart and DotPlot (same shape as Scatterplot's prop).                                                                                                                
                                                                                                                                                                                                                          
  <BarChart data={quarterlyRevenue} categoryAccessor="quarter" valueAccessor="revenue"                                                                                                                                    
            regression={{ method: "linear", color: "#ef4444", label: "Trend" }} />                                                                                                                                        
                                                                                                                                                                                                                          
  <DotPlot data={surveyResults} categoryAccessor="bucket" valueAccessor="score"                                                                                                                                           
           regression="loess" />                                                                                                                                                                                          
                                                                                                                                                                                                                          
  6 new annotation-handler unit tests (vertical + horizontal projections, LOESS, guards). 9 HOC-level tests.                                                                                                              
   
  ---                                                                                                                                                                                                                     
  Files                                                  
                                                                                                                                                                                                                          
  New (12)
  - src/components/charts/shared/useNetworkChartSetup.{ts,test.tsx}                                                                                                                                                       
  - src/components/charts/shared/useOrdinalPieceStyle.{ts,test.tsx}                                                                                                                                                       
  - src/components/charts/shared/useAreaSeriesSetup.{ts,test.tsx}  
  - src/components/charts/shared/useXYPointStyle.{ts,test.tsx}                                                                                                                                                            
  - src/components/charts/shared/regressionUtils.{ts,test.ts}                                                                                                                                                             
  - src/components/charts/shared/annotationRules.trend.test.tsx                                                                                                                                                           
  - src/__tests__/scenarios/chart-suggestions-capabilities.test.ts                                                                                                                                                        
  - scripts/lib/capabilityMatrix.mjs                                                                                                                                                                                      
  - scripts/check-capabilities.mjs                       
  - scripts/generate-capabilities-md.mjs                                                                                                                                                                                  
  - scripts/generate-capabilities-json.mjs               
  - ai/capabilities.json (generated)                                                                                                                                                                                      
  - docs/capabilities.md (generated)                                                                                                                                                                                      
  - docs/src/pages/features/CapabilitiesPage.js
                                                                                                                                                                                                                          
  Modified — 8 network HOCs + 13 ordinal HOCs + 4 XY point HOCs + AreaChart + StackedAreaChart + FlowMap + 4 stream/store files + chartSpecs.ts + validationMap.ts + annotationRules.tsx + useFrameImperativeHandle.ts +
  MCP server + chartSuggestions.cjs + CLAUDE.md + 3 docs pages + package.json.                                                                                                                                            
                                                         
  Test plan                                                                                                                                                                                                               
                                                         
  - npx vitest run — 4048/4048 pass                                                                                                                                                                                       
  - npm run check:capabilities — green
  - npm run check:surface — green                                                                                                                                                                                         
  - npm run check:ssr — green                            
  - npm run check:chart-specs — green                                                                                                                                                                                     
  - npm run check:ai-contracts — green                                                                                                                                                                                    
  - npx tsc --noEmit — clean
  - npm run typescript:mcp — clean                                                                                                                                                                                        
  - Manually verified regression prop renders on Scatterplot, BarChart, DotPlot in docs                                                                                                                                   
  - Manually verified /features/capabilities page filters work end-to-end                                                                                                                                                 
  - Manually verified MCP suggestChart tool accepts capability constraints                                                                                                                                                
                                                                                                                                                                                                                          
  🤖 Generated with https://claude.com/claude-code                 

Introduce a generated capability matrix and make chart suggestion logic capability-aware. Adds ai/capabilities.json, scripts to generate the matrix and markdown, and a docs page. Enhances chartSuggestions.cjs (and bundled dist/mcp-server) to load the matrix, validate capability constraint args, filter suggestions, and surface what was filtered out; exports helpers and VALID_CAPABILITY_KEYS for tests. Update MCP server types/handlers to accept a capabilities object and update the tool description/schema. Also extend schema.json to add regression props and related small schema tweaks, add tests, and update various docs and component registrations to reflect the new capabilities.
