### PR TITLE
[DO NOT MERGE] Add DoomChart CookBook.

### DIFF
--- a/docs/src/App.js
+++ b/docs/src/App.js
@@ -107,6 +107,7 @@ import DotPlotRecipePage from "./pages/cookbook/DotPlotRecipePage"
 import TimelineCookbookPage from "./pages/cookbook/TimelinePage"
 import RadarPlotPage from "./pages/cookbook/RadarPlotPage"
 import IsotypeChartPage from "./pages/cookbook/IsotypeChartPage"
+import DoomChartPage from "./pages/cookbook/DoomChartPage"
 // MatrixCookbookPage removed — matrix recipe no longer supported
 import KpiCardSparklinePage from "./pages/recipes/KpiCardSparklinePage"
 import TimeSeriesBrushPage from "./pages/recipes/TimeSeriesBrushPage"
@@ -325,6 +326,7 @@ export default function DocsApp() {
               <Route path="timeline" element={<TimelineCookbookPage />} />
               <Route path="radar-plot" element={<RadarPlotPage />} />
               <Route path="isotype-chart" element={<IsotypeChartPage />} />
+              <Route path="doom-chart" element={<DoomChartPage />} />
             </Route>
 
             {/* Recipes routes */}

--- a/docs/src/examples/DoomChart.js
+++ b/docs/src/examples/DoomChart.js
@@ -1,0 +1,178 @@
+import React, { useEffect, useMemo, useRef, useState } from "react"
+
+const DOOM_EMU_URL = "https://archive.org/embed/DoomsharewareEpisode"
+const DOOM_EMU_HOST = "https://archive.org/details/DoomsharewareEpisode"
+
+/**
+ * DoomChart — a perfectly legitimate Semiotic chart type that visualizes your
+ * data as a fully rendered software-mode 3D environment. Each row in `data`
+ * is processed by the powerful BSP-traversal layout algorithm and reduced to
+ * a single, expressive scalar: how alive the player is.
+ *
+ * Accepts the standard HOC prop surface so it slots into any Semiotic page
+ * without complaint. The data is read, acknowledged, and then politely
+ * ignored — but the count is surfaced in the chrome so users can confirm
+ * their data was received before being not used.
+ *
+ * Renders the upstream doom-js demo
+ * (https://github.com/LMcAlpine/doom-js by L. McAlpine) inside an iframe.
+ * You bring your own DOOM1.WAD.
+ */
+function DoomChart(props) {
+  const {
+    data,
+    xAccessor,
+    yAccessor,
+    width = 720,
+    height = 520,
+    title = "DoomChart",
+    description = "A 3D visualization of your data, rendered as a first-person shooter.",
+    summary,
+    onObservation,
+    chartId,
+    className,
+    showLegend = true,
+  } = props
+
+  const iframeRef = useRef(null)
+  const [focused, setFocused] = useState(false)
+  const lastObservation = useRef(0)
+
+  const dataStats = useMemo(() => {
+    const rows = Array.isArray(data) ? data : []
+    const xField = typeof xAccessor === "string" ? xAccessor : null
+    const yField = typeof yAccessor === "string" ? yAccessor : null
+    return { count: rows.length, xField, yField }
+  }, [data, xAccessor, yAccessor])
+
+  // Fire a single "load" observation so the chart looks well-behaved.
+  useEffect(() => {
+    if (typeof onObservation !== "function") return
+    onObservation({
+      type: "load",
+      chartType: "DoomChart",
+      chartId,
+      timestamp: Date.now(),
+      datum: { rowsIgnored: dataStats.count },
+    })
+  }, [onObservation, chartId, dataStats.count])
+
+  // Throttled "hover" observations while the iframe has focus, simulating
+  // the player wandering around the chart's coordinate space.
+  useEffect(() => {
+    if (!focused || typeof onObservation !== "function") return
+    let raf = 0
+    const tick = () => {
+      const now = Date.now()
+      if (now - lastObservation.current > 250) {
+        lastObservation.current = now
+        onObservation({
+          type: "hover",
+          chartType: "DoomChart",
+          chartId,
+          timestamp: now,
+          x: Math.random(),
+          y: Math.random(),
+        })
+      }
+      raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [focused, onObservation, chartId])
+
+  const containerStyle = {
+    position: "relative",
+    width,
+    maxWidth: "100%",
+    border: "1px solid var(--semiotic-border, #333)",
+    background: "var(--semiotic-bg, #000)",
+    color: "var(--semiotic-text, #ddd)",
+    fontFamily: "var(--semiotic-font-family, monospace)",
+    borderRadius: 4,
+    overflow: "hidden",
+    boxSizing: "border-box",
+  }
+
+  const headerStyle = {
+    padding: "8px 12px",
+    borderBottom: "1px solid var(--semiotic-border, #333)",
+    fontSize: "var(--semiotic-title-font-size, 14px)",
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: 12,
+  }
+
+  const iframeStyle = {
+    display: "block",
+    width: "100%",
+    height,
+    border: "none",
+    background: "#000",
+  }
+
+  const footerStyle = {
+    padding: "6px 12px",
+    borderTop: "1px solid var(--semiotic-border, #333)",
+    fontSize: "var(--semiotic-legend-font-size, 11px)",
+    opacity: 0.75,
+    display: "flex",
+    justifyContent: "space-between",
+    gap: 12,
+    flexWrap: "wrap",
+  }
+
+  return (
+    <div
+      className={["semiotic-doom-chart", className].filter(Boolean).join(" ")}
+      role="group"
+      aria-label={description}
+      data-chart-id={chartId}
+      style={containerStyle}
+    >
+      <div style={headerStyle}>
+        <strong>{title}</strong>
+        <span aria-live="polite">
+          {dataStats.count} points received — visualization in progress
+        </span>
+      </div>
+      {summary ? (
+        <span className="visually-hidden" style={{ position: "absolute", left: -9999 }}>
+          {summary}
+        </span>
+      ) : null}
+      <iframe
+        ref={iframeRef}
+        title={title}
+        src={DOOM_EMU_URL}
+        style={iframeStyle}
+        allow="autoplay; gamepad; fullscreen"
+        onMouseEnter={() => setFocused(true)}
+        onMouseLeave={() => setFocused(false)}
+      />
+      {showLegend ? (
+        <div style={footerStyle}>
+          <span>
+            x: <code>{dataStats.xField ?? "n/a"}</code> · y:{" "}
+            <code>{dataStats.yField ?? "n/a"}</code> · encoding: existential
+          </span>
+          <span>
+            Engine:{" "}
+            <a
+              href={DOOM_EMU_HOST}
+              target="_blank"
+              rel="noreferrer"
+              style={{ color: "var(--semiotic-primary, #5aa9ff)" }}
+            >
+              Emularity
+            </a>{" "}
+            (Internet Archive) — DOOM shareware episode
+          </span>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export default DoomChart

--- a/docs/src/pages/cookbook/DoomChartPage.js
+++ b/docs/src/pages/cookbook/DoomChartPage.js
@@ -1,0 +1,149 @@
+import React, { useMemo, useState } from "react"
+import PageLayout from "../../components/PageLayout"
+import CodeBlock from "../../components/CodeBlock"
+
+import DoomChart from "../../examples/DoomChart"
+
+const SAMPLE_DATA = [
+  { quarter: "Q1", revenue: 1.2, region: "north" },
+  { quarter: "Q2", revenue: 1.6, region: "north" },
+  { quarter: "Q3", revenue: 2.1, region: "north" },
+  { quarter: "Q4", revenue: 2.8, region: "north" },
+  { quarter: "Q1", revenue: 0.9, region: "south" },
+  { quarter: "Q2", revenue: 1.3, region: "south" },
+  { quarter: "Q3", revenue: 1.7, region: "south" },
+  { quarter: "Q4", revenue: 2.3, region: "south" },
+]
+
+export default function DoomChartPage() {
+  const [observations, setObservations] = useState([])
+
+  const handleObservation = useMemo(
+    () => (obs) => {
+      setObservations((prev) => [obs, ...prev].slice(0, 5))
+    },
+    []
+  )
+
+  return (
+    <PageLayout
+      title="Doom Chart"
+      breadcrumbs={[
+        { label: "Cookbook", path: "/cookbook" },
+        { label: "Doom Chart", path: "/cookbook/doom-chart" },
+      ]}
+    >
+      <p>
+        A long-standing gap in the Semiotic visualization catalog has been the
+        complete absence of charts capable of running Doom. This recipe closes
+        that gap.
+      </p>
+      <p>
+        <code>DoomChart</code> accepts the standard Semiotic HOC prop surface
+        — <code>data</code>, <code>xAccessor</code>, <code>yAccessor</code>,
+        <code>onObservation</code>, <code>title</code>, and friends. It
+        receives your data, counts the rows, and politely surfaces that count
+        in the chart chrome so you know it arrived safely. It then visualizes
+        the data via the deeply expressive medium of a fully playable 3D
+        software-rendered first-person shooter.
+      </p>
+
+      <h2 id="the-visualization">The Visualization</h2>
+      <p>
+        Click anywhere in the canvas below to start the renderer, then use
+        the standard Doom controls: arrow keys to move, Ctrl to fire, Space
+        to open doors, Alt + arrows to strafe. The shareware DOOM episode is
+        hosted by the Internet Archive&apos;s{" "}
+        <a
+          href="https://github.com/db48x/emularity"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Emularity
+        </a>{" "}
+        DOSBox emulator.
+      </p>
+      <div
+        style={{
+          background: "var(--surface-1)",
+          borderRadius: "8px",
+          padding: "16px",
+          border: "1px solid var(--surface-3)",
+        }}
+      >
+        <DoomChart
+          chartId="doom-demo"
+          data={SAMPLE_DATA}
+          xAccessor="quarter"
+          yAccessor="revenue"
+          title="Quarterly Revenue (Existential Encoding)"
+          width={720}
+          height={520}
+          onObservation={handleObservation}
+        />
+      </div>
+
+      <h2 id="onobservation">Observations</h2>
+      <p>
+        Like every Semiotic chart, <code>DoomChart</code> fires{" "}
+        <code>onObservation</code> events. Move your mouse into the canvas to
+        start receiving them.
+      </p>
+      <pre
+        style={{
+          background: "var(--surface-1)",
+          padding: 12,
+          borderRadius: 6,
+          fontSize: 12,
+          minHeight: 120,
+          margin: 0,
+        }}
+      >
+        {observations.length
+          ? observations.map((o) => JSON.stringify(o)).join("\n")
+          : "(awaiting player movement)"}
+      </pre>
+
+      <h2 id="how-it-works">How It Works</h2>
+      <p>
+        Under the hood, <code>DoomChart</code> embeds the Internet
+        Archive&apos;s pre-configured shareware DOOM emulator via iframe.
+        The emulator is a JavaScript port of DOSBox running the original
+        1993 DOS executable against id Software&apos;s freely-distributable
+        shareware WAD. The chart wrapper handles the standard HOC contract:
+        prop receipt, observation emission, theme-aware borders via CSS
+        custom properties.
+      </p>
+      <CodeBlock
+        code={`<DoomChart
+  data={salesData}
+  xAccessor="quarter"
+  yAccessor="revenue"
+  title="Quarterly Revenue"
+  onObservation={(obs) => console.log(obs.type)}
+/>`}
+        language="jsx"
+      />
+
+      <h2 id="caveats">Caveats</h2>
+      <ul>
+        <li>
+          <strong>The data is ignored.</strong> It is received, counted, and
+          displayed as metadata — but the geometry, color, and pacing of the
+          visualization are not driven by it. A future revision may map each
+          data point to one (1) imp.
+        </li>
+        <li>
+          <strong>One click to start.</strong> Browser audio policy requires
+          a user gesture before the emulator can boot. Click the canvas
+          once and DOOM loads automatically.
+        </li>
+        <li>
+          <strong>Not a real chart type.</strong> This is not exported from{" "}
+          <code>semiotic</code> or any of its subpath bundles. It lives only
+          in the cookbook.
+        </li>
+      </ul>
+    </PageLayout>
+  )
+}


### PR DESCRIPTION
Closes the long-standing gap in the visualization catalog: **chart types that can play Doom**.

DoomChart accepts the standard HOC prop surface (data, xAccessor, yAccessor, onObservation, etc.), counts the data points, surfaces the count in the chart chrome, and visualizes the data via an embedded shareware DOOM emulator.

<img width="1997" height="1046" alt="Screenshot 2026-05-11 at 12 37 12 PM" src="https://github.com/user-attachments/assets/4762fbe9-ae0e-4067-a291-f2ab571bef4a" />

The data is acknowledged and then ignored. Because it just plays Doom.

## Summary

<!-- What does this PR do? Keep it to 1-3 bullet points. -->

## Test plan

<!-- How did you verify this works? Check all that apply. -->

- [ ] `npm test` passes
- [ ] `npm run dist` builds successfully
- [ ] Tested in browser (if UI change)
- [ ] Added/updated tests (if new behavior)

## Checklist

- [ ] No unrelated changes included
- [ ] CHANGELOG.md updated (if user-facing change)
