### PR TITLE
3.5.2 click testing

### DIFF
--- a/src/components/Tooltip/FlippingTooltip.test.tsx
+++ b/src/components/Tooltip/FlippingTooltip.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Regression coverage for the two defensive behaviors `FlippingTooltip`
+ * applies on top of its flip-positioning logic:
+ *
+ *   1. Chrome auto-apply when user `tooltipContent` returns a node
+ *      WITHOUT `.semiotic-tooltip` on its root.
+ *   2. Non-finite position guard (returns null so React doesn't throw
+ *      `'NaN' is an invalid value for the 'top' css style property`).
+ *
+ * Both fixes ship in `FlippingTooltip.tsx`; per-chart `tooltipContent`
+ * implementations stay untouched.
+ */
+import * as React from "react"
+import { render } from "@testing-library/react"
+import { describe, it, expect } from "vitest"
+import { FlippingTooltip } from "./FlippingTooltip"
+
+const baseProps = {
+  x: 100,
+  y: 50,
+  containerWidth: 400,
+  containerHeight: 300,
+  margin: { top: 10, right: 10, bottom: 10, left: 20 },
+}
+
+describe("FlippingTooltip — chrome auto-apply", () => {
+  it("applies default chrome when the user content lacks .semiotic-tooltip", () => {
+    // Mimics the ProcessSankey / earlier-DifferenceChart regression:
+    // a tooltipContent function that returns a bare div with no
+    // chrome class. The wrapper should paint the chrome instead.
+    const { container } = render(
+      <FlippingTooltip {...baseProps}>
+        <div style={{ minWidth: 160 }}>Plain content</div>
+      </FlippingTooltip>
+    )
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper).toBeTruthy()
+    expect(wrapper.className).toContain("semiotic-tooltip")
+    // The chrome style is applied directly on the wrapper.
+    const style = wrapper.style
+    expect(style.background).toBeTruthy()
+    // `padding` is set via the `padding` shorthand in defaultTooltipStyle;
+    // jsdom expands it onto paddingTop. Either form is acceptable evidence.
+    const hasPadding = style.padding !== "" || style.paddingTop !== ""
+    expect(hasPadding).toBe(true)
+  })
+
+  it("does NOT double-apply chrome when the user content already has .semiotic-tooltip", () => {
+    // The shared `Tooltip()` / `MultiLineTooltip()` / `buildDefaultTooltip()`
+    // helpers wrap their output in `<div className="semiotic-tooltip">` —
+    // those should pass through transparent so chrome doesn't pile up.
+    const { container } = render(
+      <FlippingTooltip {...baseProps}>
+        <div className="semiotic-tooltip" style={{ background: "red", padding: 99 }}>
+          Pre-styled
+        </div>
+      </FlippingTooltip>
+    )
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper).toBeTruthy()
+    // Wrapper should NOT have its own background since chrome is owned
+    // by the inner element.
+    expect(wrapper.style.background).toBe("")
+  })
+
+  it("detects .semiotic-tooltip even when other classes are present", () => {
+    const { container } = render(
+      <FlippingTooltip {...baseProps}>
+        <div className="my-custom semiotic-tooltip extra">Pre-styled</div>
+      </FlippingTooltip>
+    )
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.style.background).toBe("")
+  })
+
+  it("auto-applies chrome when content is a plain text node", () => {
+    const { container } = render(
+      <FlippingTooltip {...baseProps}>just a string</FlippingTooltip>
+    )
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.style.background).toBeTruthy()
+  })
+})
+
+describe("FlippingTooltip — non-finite position guard", () => {
+  it("returns null when x is NaN", () => {
+    const { container } = render(
+      <FlippingTooltip {...baseProps} x={NaN}>
+        <div>content</div>
+      </FlippingTooltip>
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("returns null when y is NaN", () => {
+    const { container } = render(
+      <FlippingTooltip {...baseProps} y={NaN}>
+        <div>content</div>
+      </FlippingTooltip>
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("returns null when y is Infinity", () => {
+    const { container } = render(
+      <FlippingTooltip {...baseProps} y={Infinity}>
+        <div>content</div>
+      </FlippingTooltip>
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders normally when both x and y are finite (regression for the guard not over-firing)", () => {
+    const { container } = render(
+      <FlippingTooltip {...baseProps} x={50} y={75}>
+        <div>content</div>
+      </FlippingTooltip>
+    )
+    expect(container.firstChild).not.toBeNull()
+  })
+
+  it("transitioning between finite ↔ NaN positions does not throw the React hook-order error", () => {
+    // Regression: an earlier shape of this guard did `if (!finite)
+    // return null` BEFORE the hooks, so when y oscillated between NaN
+    // and a finite number across re-renders, React's static-hook-flag
+    // check fired ("Expected static flag was missing"). The fix
+    // routes the guard through a render-time decision so all hooks
+    // run in stable order.
+    const errors: unknown[] = []
+    const origError = console.error
+    console.error = (msg: unknown, ...rest: unknown[]) => {
+      errors.push(msg)
+      origError(msg, ...rest)
+    }
+    try {
+      const { rerender, container } = render(
+        <FlippingTooltip {...baseProps} x={50} y={75}>
+          <div>content</div>
+        </FlippingTooltip>
+      )
+      expect(container.firstChild).not.toBeNull()
+      // Transition to NaN — bails out.
+      rerender(
+        <FlippingTooltip {...baseProps} x={50} y={NaN}>
+          <div>content</div>
+        </FlippingTooltip>
+      )
+      expect(container.firstChild).toBeNull()
+      // Back to finite — re-renders.
+      rerender(
+        <FlippingTooltip {...baseProps} x={50} y={75}>
+          <div>content</div>
+        </FlippingTooltip>
+      )
+      expect(container.firstChild).not.toBeNull()
+      // And back to NaN again.
+      rerender(
+        <FlippingTooltip {...baseProps} x={NaN} y={75}>
+          <div>content</div>
+        </FlippingTooltip>
+      )
+      expect(container.firstChild).toBeNull()
+    } finally {
+      console.error = origError
+    }
+    // No React hook-order or "static flag" complaints captured.
+    const reactErrors = errors.filter(e => String(e).includes("static flag") || String(e).includes("hook"))
+    expect(reactErrors).toEqual([])
+  })
+})

--- a/src/components/Tooltip/FlippingTooltip.test.tsx
+++ b/src/components/Tooltip/FlippingTooltip.test.tsx
@@ -73,6 +73,49 @@ describe("FlippingTooltip — chrome auto-apply", () => {
     expect(wrapper.style.background).toBe("")
   })
 
+  it("respects an inline `background` style as chrome ownership (no double-wrap)", () => {
+    // Regression: Landing-page gallery tooltips paint their own chrome
+    // via `style={{ background: "white", padding: ... }}` without
+    // adding the `.semiotic-tooltip` class. The auto-chrome path was
+    // wrapping those in a dark `defaultTooltipStyle` outer box,
+    // visible as a black strip around the user's tooltip.
+    const { container } = render(
+      <FlippingTooltip {...baseProps}>
+        <div style={{ background: "white", padding: "8px 12px", color: "#333" }}>
+          Custom-styled
+        </div>
+      </FlippingTooltip>
+    )
+    const wrapper = container.firstChild as HTMLElement
+    // Wrapper should NOT have its own background — chrome ownership
+    // detected via the inline style.
+    expect(wrapper.style.background).toBe("")
+  })
+
+  it("respects an inline `backgroundColor` style as chrome ownership", () => {
+    const { container } = render(
+      <FlippingTooltip {...baseProps}>
+        <div style={{ backgroundColor: "#222", color: "white", padding: 8 }}>
+          Pre-styled via backgroundColor
+        </div>
+      </FlippingTooltip>
+    )
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.style.background).toBe("")
+  })
+
+  it("still applies chrome when style is set but background is not", () => {
+    // A user style with only padding / fontSize is still chrome-less;
+    // wrap it. Pinning so the detection doesn't over-fire.
+    const { container } = render(
+      <FlippingTooltip {...baseProps}>
+        <div style={{ padding: 8, fontSize: 12 }}>plain</div>
+      </FlippingTooltip>
+    )
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.style.background).toBeTruthy()
+  })
+
   it("auto-applies chrome when content is a plain text node", () => {
     const { container } = render(
       <FlippingTooltip {...baseProps}>just a string</FlippingTooltip>

--- a/src/components/Tooltip/FlippingTooltip.test.tsx
+++ b/src/components/Tooltip/FlippingTooltip.test.tsx
@@ -105,11 +105,40 @@ describe("FlippingTooltip — chrome auto-apply", () => {
   })
 
   it("still applies chrome when style is set but background is not", () => {
-    // A user style with only padding / fontSize is still chrome-less;
-    // wrap it. Pinning so the detection doesn't over-fire.
+    // A user div with only padding / fontSize (no class, no background)
+    // is still chrome-less; wrap it. Pinning so the detection doesn't
+    // over-fire on style-only declarations.
     const { container } = render(
       <FlippingTooltip {...baseProps}>
         <div style={{ padding: 8, fontSize: 12 }}>plain</div>
+      </FlippingTooltip>
+    )
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.style.background).toBeTruthy()
+  })
+
+  it("respects any non-empty className as chrome ownership (CSS-class-styled tooltips)", () => {
+    // Regression: `/cookbook/canvas-interaction` uses
+    // `<div className="tooltip-content">` with chrome in a sibling
+    // CSS file (no inline style, no `.semiotic-tooltip` class). The
+    // narrow detection that only matched the canonical class double-
+    // wrapped these, producing the extra-black-box-offset-to-right
+    // symptom. Any non-empty className is now treated as "consumer is
+    // handling chrome".
+    const { container } = render(
+      <FlippingTooltip {...baseProps}>
+        <div className="tooltip-content">CSS-styled</div>
+      </FlippingTooltip>
+    )
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.style.background).toBe("")
+  })
+
+  it("empty className is not enough to claim chrome", () => {
+    // `className=""` carries no intent — wrap it.
+    const { container } = render(
+      <FlippingTooltip {...baseProps}>
+        <div className="">no real class</div>
       </FlippingTooltip>
     )
     const wrapper = container.firstChild as HTMLElement

--- a/src/components/Tooltip/FlippingTooltip.tsx
+++ b/src/components/Tooltip/FlippingTooltip.tsx
@@ -21,35 +21,45 @@ interface FlippingTooltipProps {
 }
 
 /**
- * True when `node` is a React element whose root already carries
- * tooltip chrome — either via the canonical `.semiotic-tooltip`
- * className (the shared helpers' pattern) OR via an inline
- * `background` / `backgroundColor` style declaration. When neither
- * is present, `FlippingTooltip` paints `defaultTooltipStyle` on its
- * own wrapper so the tooltip can never come out chrome-less.
+ * True when the tooltip content's root element looks like the
+ * consumer is handling chrome themselves. Three signals, any one of
+ * which is enough:
  *
- * Why this exists: chart-specific `tooltipContent` callbacks have
- * recurringly forgotten the `.semiotic-tooltip` class +
- * `defaultTooltipStyle`, producing transparent floating divs (the
- * ProcessSankey and DifferenceChart regressions of 2026-05-12).
- * The shared `Tooltip()` / `MultiLineTooltip()` / `buildDefaultTooltip()`
- * helpers do it right; bespoke per-chart tooltips don't. Auto-applying
- * chrome at the wrapper level converts the "you forgot the wrapper"
- * footgun into a no-op.
+ *   1. A non-empty `className`. Three real cases that all hit this:
+ *      `.semiotic-tooltip` from the shared helpers; bespoke classes
+ *      like `.tooltip-content` whose chrome lives in a CSS file the
+ *      consumer ships alongside the chart; per-chart custom classes
+ *      for theming. We can't inspect computed CSS to know for sure,
+ *      but ANY className is a strong intent signal — the consumer
+ *      reached for the class hook because they're styling it.
+ *   2. An inline `background` declaration on `style`. Catches the
+ *      Landing-page gallery pattern (`style={{ background: "white",
+ *      ... }}` with no className).
+ *   3. An inline `backgroundColor` declaration on `style`. Same
+ *      intent as (2) just spelled differently.
  *
- * The inline-background fallback catches bespoke tooltips that paint
- * their OWN visual chrome via `style={{ background: "white", ... }}`
- * — applying `defaultTooltipStyle` on top of those wraps the user's
- * tooltip in a second, contrasting box (the Landing-page gallery
- * regression). The check is intentionally narrow: presence of either
- * declaration is treated as "chrome handled" — no attempt to parse
- * or validate the values, because partial declarations (just a
- * background with no padding, etc.) are still the consumer's call.
+ * When none of these fire, `FlippingTooltip` paints
+ * `defaultTooltipStyle` on its own wrapper so the tooltip can never
+ * come out chrome-less. The footgun this guards against: chart-
+ * specific `tooltipContent` callbacks have recurringly returned
+ * `<div style={{ minWidth: 160 }}>...</div>` — no class, no
+ * background, just sizing — producing transparent floating boxes
+ * (the ProcessSankey and original-DifferenceChart regressions).
+ *
+ * The "any className" rule was originally narrower ("only the exact
+ * `.semiotic-tooltip` word"), but that mis-fired on consumers using
+ * CSS-class-only chrome — the `/cookbook/canvas-interaction` example
+ * uses `className="tooltip-content"` with the actual chrome in a
+ * sibling CSS file. The narrow rule was double-wrapping that. The
+ * broader rule trusts the consumer's intent when they reached for
+ * the class hook, at the cost of letting through a genuinely chrome-
+ * less classed div — which is an acceptable trade for the recurring
+ * "extra black box around the user's tooltip" regression.
  */
 function hasOwnChrome(node: React.ReactNode): boolean {
   if (!React.isValidElement(node)) return false
   const props = node.props as { className?: unknown; style?: React.CSSProperties }
-  if (typeof props.className === "string" && props.className.split(/\s+/).includes("semiotic-tooltip")) return true
+  if (typeof props.className === "string" && props.className.trim().length > 0) return true
   const style = props.style
   if (style && typeof style === "object") {
     if (style.background != null && style.background !== "") return true

--- a/src/components/Tooltip/FlippingTooltip.tsx
+++ b/src/components/Tooltip/FlippingTooltip.tsx
@@ -21,26 +21,41 @@ interface FlippingTooltipProps {
 }
 
 /**
- * True when `node` is a React element whose root has `semiotic-tooltip`
- * in its className — i.e., the tooltip producer already applied its own
- * chrome (background, padding, shadow, etc. from `defaultTooltipStyle`
- * or an equivalent inline rule). When the producer hasn't, this returns
- * false and `FlippingTooltip` paints the chrome on its own wrapper so
- * the tooltip can never come out transparent.
+ * True when `node` is a React element whose root already carries
+ * tooltip chrome — either via the canonical `.semiotic-tooltip`
+ * className (the shared helpers' pattern) OR via an inline
+ * `background` / `backgroundColor` style declaration. When neither
+ * is present, `FlippingTooltip` paints `defaultTooltipStyle` on its
+ * own wrapper so the tooltip can never come out chrome-less.
  *
  * Why this exists: chart-specific `tooltipContent` callbacks have
- * recurringly forgotten to include the `semiotic-tooltip` class +
- * `defaultTooltipStyle`, producing chrome-less floating divs (the
- * ProcessSankey and DifferenceChart regressions of 2026-05-12). The
- * shared `Tooltip()` / `MultiLineTooltip()` / `buildDefaultTooltip()`
+ * recurringly forgotten the `.semiotic-tooltip` class +
+ * `defaultTooltipStyle`, producing transparent floating divs (the
+ * ProcessSankey and DifferenceChart regressions of 2026-05-12).
+ * The shared `Tooltip()` / `MultiLineTooltip()` / `buildDefaultTooltip()`
  * helpers do it right; bespoke per-chart tooltips don't. Auto-applying
  * chrome at the wrapper level converts the "you forgot the wrapper"
  * footgun into a no-op.
+ *
+ * The inline-background fallback catches bespoke tooltips that paint
+ * their OWN visual chrome via `style={{ background: "white", ... }}`
+ * — applying `defaultTooltipStyle` on top of those wraps the user's
+ * tooltip in a second, contrasting box (the Landing-page gallery
+ * regression). The check is intentionally narrow: presence of either
+ * declaration is treated as "chrome handled" — no attempt to parse
+ * or validate the values, because partial declarations (just a
+ * background with no padding, etc.) are still the consumer's call.
  */
 function hasOwnChrome(node: React.ReactNode): boolean {
   if (!React.isValidElement(node)) return false
-  const cls = (node.props as { className?: unknown })?.className
-  return typeof cls === "string" && cls.split(/\s+/).includes("semiotic-tooltip")
+  const props = node.props as { className?: unknown; style?: React.CSSProperties }
+  if (typeof props.className === "string" && props.className.split(/\s+/).includes("semiotic-tooltip")) return true
+  const style = props.style
+  if (style && typeof style === "object") {
+    if (style.background != null && style.background !== "") return true
+    if (style.backgroundColor != null && style.backgroundColor !== "") return true
+  }
+  return false
 }
 
 /**

--- a/src/components/Tooltip/FlippingTooltip.tsx
+++ b/src/components/Tooltip/FlippingTooltip.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { defaultTooltipStyle } from "./Tooltip"
 
 interface FlippingTooltipProps {
   /** X position within the chart area (relative to margin.left) */
@@ -20,12 +21,50 @@ interface FlippingTooltipProps {
 }
 
 /**
+ * True when `node` is a React element whose root has `semiotic-tooltip`
+ * in its className — i.e., the tooltip producer already applied its own
+ * chrome (background, padding, shadow, etc. from `defaultTooltipStyle`
+ * or an equivalent inline rule). When the producer hasn't, this returns
+ * false and `FlippingTooltip` paints the chrome on its own wrapper so
+ * the tooltip can never come out transparent.
+ *
+ * Why this exists: chart-specific `tooltipContent` callbacks have
+ * recurringly forgotten to include the `semiotic-tooltip` class +
+ * `defaultTooltipStyle`, producing chrome-less floating divs (the
+ * ProcessSankey and DifferenceChart regressions of 2026-05-12). The
+ * shared `Tooltip()` / `MultiLineTooltip()` / `buildDefaultTooltip()`
+ * helpers do it right; bespoke per-chart tooltips don't. Auto-applying
+ * chrome at the wrapper level converts the "you forgot the wrapper"
+ * footgun into a no-op.
+ */
+function hasOwnChrome(node: React.ReactNode): boolean {
+  if (!React.isValidElement(node)) return false
+  const cls = (node.props as { className?: unknown })?.className
+  return typeof cls === "string" && cls.split(/\s+/).includes("semiotic-tooltip")
+}
+
+/**
  * Viewport-aware tooltip wrapper that flips horizontally and vertically
  * when the tooltip would overflow the chart container.
  *
  * On first render, uses a heuristic (similar to the old 70%/30% thresholds).
  * After measuring the actual tooltip size via ref, repositions precisely to
  * prevent clipping against container edges.
+ *
+ * Two defensive behaviors:
+ *
+ *   - **Chrome guarantee.** If the rendered tooltip content lacks the
+ *     `semiotic-tooltip` className on its root, the wrapper applies
+ *     `defaultTooltipStyle` to itself so the tooltip always has a
+ *     visible background, padding, and shadow. Shared tooltip helpers
+ *     keep working unchanged (their `semiotic-tooltip` class causes the
+ *     wrapper to stay transparent).
+ *   - **Non-finite position guard.** Returns `null` when `x` or `y` is
+ *     `NaN` / `Infinity`. The frame's hover plumbing can occasionally
+ *     produce a non-finite hit-test result during a scale rebuild or
+ *     when a custom layout emits a degenerate vertex; without the
+ *     guard, React throws `'NaN' is an invalid value for the 'top' css
+ *     style property` and the entire frame stops rendering.
  */
 export function FlippingTooltip({
   x,
@@ -37,6 +76,14 @@ export function FlippingTooltip({
   className = "stream-frame-tooltip",
   zIndex = 1
 }: FlippingTooltipProps) {
+  // Position guard. The early-return form (before hooks) tripped React's
+  // "static flag" hook-order check when y oscillated between NaN and a
+  // finite number (the hover handler can emit either as a frame transitions
+  // through a degenerate hit-test). Treat the guard as a render-time
+  // decision instead so the hooks always run in the same order, and emit
+  // null at the very end when the position is unusable.
+  const positionFinite = Number.isFinite(x) && Number.isFinite(y)
+
   const ref = React.useRef<HTMLDivElement>(null)
   const [measured, setMeasured] = React.useState<{
     width: number
@@ -79,18 +126,35 @@ export function FlippingTooltip({
     transform = `translate(${tx}, ${ty})`
   }
 
+  // Chrome auto-apply: if the rendered content's root already carries
+  // `.semiotic-tooltip`, the user/helper handled chrome — don't double
+  // up. Otherwise apply `defaultTooltipStyle` to the wrapper itself so
+  // the tooltip is never transparent. `width: max-content` overrides
+  // the chrome's `maxWidth` constraint to keep the existing flip math
+  // working; the chrome's `wordWrap: break-word` still handles long
+  // tokens. `pointerEvents` is set on the wrapper regardless.
+  const ownsChrome = hasOwnChrome(children)
+  const chromeStyle = ownsChrome ? null : defaultTooltipStyle
+  const compositeClassName = ownsChrome ? className : `${className} semiotic-tooltip`.trim()
+  // Late guard return: bail AFTER all hooks have run so the hook call
+  // order stays stable across re-renders. An earlier early-return form
+  // (before useRef / useState / useLayoutEffect) tripped React's
+  // "Expected static flag was missing" check whenever y oscillated
+  // between NaN and a finite number.
+  if (!positionFinite) return null
   return (
     <div
       ref={ref}
-      className={className}
+      className={compositeClassName}
       style={{
+        ...(chromeStyle || {}),
         position: "absolute",
         left: margin.left + x,
         top: margin.top + y,
         transform,
         pointerEvents: "none",
         zIndex,
-        width: "max-content"
+        width: "max-content",
       }}
     >
       {children}

--- a/src/components/recipes/recipes.test.ts
+++ b/src/components/recipes/recipes.test.ts
@@ -77,6 +77,54 @@ describe("waffleLayout", () => {
     )
     expect(result.nodes).toEqual([])
   })
+
+  it("emits tooltip-facing datum fields on each cell (category, value, user-accessor names)", () => {
+    // Regression: the cell datum used to be only `_waffleCategory` /
+    // `_waffleIndex`, both underscore-prefixed and therefore filtered
+    // out as "internal" by the default tooltip's key scanner. Result:
+    // empty tooltips on the docs `features/custom-charts` waffle.
+    // Layout now writes user-friendly keys so default tooltips have
+    // something to surface, plus the user-accessor names (when string-
+    // form) for tooltips that read those.
+    const result = waffleLayout(
+      makeCtx(
+        { rows: 10, columns: 10, categoryAccessor: "region", valueAccessor: "share" },
+        { data: [
+          { region: "AMER", share: 60 },
+          { region: "EMEA", share: 40 },
+        ] }
+      )
+    )
+    expect(result.nodes!.length).toBe(100)
+    const amer = (result.nodes as RectSceneNode[]).find(n => n.group === "AMER")!
+    // Canonical keys for portable tooltips.
+    expect(amer.datum.category).toBe("AMER")
+    expect(amer.datum.value).toBe(60)
+    // User-accessor keys for tooltips that look up by configured field name.
+    expect(amer.datum.region).toBe("AMER")
+    expect(amer.datum.share).toBe(60)
+    // Per-category cell count surfaced as an explicit "cells" field.
+    expect(amer.datum.cells).toBe(60)
+    // The legacy underscore-prefixed fields stay for back-compat.
+    expect(amer.datum._waffleCategory).toBe("AMER")
+    expect(typeof amer.datum._waffleIndex).toBe("number")
+  })
+
+  it("falls back to canonical keys when accessors are functions (no string name to mirror)", () => {
+    const result = waffleLayout(
+      makeCtx(
+        {
+          rows: 10, columns: 10,
+          categoryAccessor: (d: any) => d.cat,
+          valueAccessor: (d: any) => d.v,
+        },
+        { data: [{ cat: "X", v: 100 }] }
+      )
+    )
+    const node = result.nodes![0] as RectSceneNode
+    expect(node.datum.category).toBe("X")
+    expect(node.datum.value).toBe(100)
+  })
 })
 
 describe("calendarLayout", () => {

--- a/src/components/recipes/waffle.ts
+++ b/src/components/recipes/waffle.ts
@@ -1,6 +1,7 @@
 import type { CustomLayout } from "../stream/customLayout"
 import type { Datum } from "../charts/shared/datumTypes"
 import type { RectSceneNode } from "../stream/types"
+import { createSafeDatum } from "./recipeUtils"
 
 export interface WaffleConfig {
   /** Number of rows in the grid. @default 10 */
@@ -113,6 +114,39 @@ export const waffleLayout: CustomLayout<WaffleConfig> = (ctx) => {
     floored[remainders[k % remainders.length].i].count += 1
   }
 
+  // Resolve string accessor names once for the datum-emit loop. Each
+  // cell's datum surfaces the category and the category's TOTAL value
+  // (not the per-cell count) under user-friendly keys so the default
+  // tooltip picks them up — without these, the cell datum only carried
+  // `_waffleCategory` / `_waffleIndex`, both underscore-prefixed and
+  // therefore filtered out as "internal" by the default tooltip's key
+  // scanner, producing empty tooltips. Mirrors the marimekko recipe's
+  // datum-shaping pattern.
+  const categoryKey = typeof cfg.categoryAccessor === "string" ? cfg.categoryAccessor : "category"
+  const valueKey = typeof cfg.valueAccessor === "string" ? cfg.valueAccessor : "value"
+  const buildCellDatum = (cat: string, cellIndex: number, count: number): Datum =>
+    createSafeDatum((set) => {
+      // Canonical keys so consumers writing portable tooltips can rely
+      // on `data.category` / `data.value` regardless of accessor names.
+      set("category", cat)
+      set("value", totals.get(cat) ?? 0)
+      // User-accessor names (when string-form) so a chart configured
+      // with `categoryAccessor: "region"` reads `data.region` in custom
+      // tooltips and tickFormats. Skip when the canonical key already
+      // matches so we don't double-write.
+      if (categoryKey !== "category") set(categoryKey, cat)
+      if (valueKey !== "value") set(valueKey, totals.get(cat) ?? 0)
+      // The per-category cell count (how many grid cells this category
+      // occupies) is occasionally what a custom tooltip wants — pass it
+      // through under an explicit name rather than burying it.
+      set("cells", count)
+      // Internal-by-convention. Preserved for any consumer that was
+      // already pattern-matching on these (the waffle layout has been
+      // shipped with them since v0).
+      set("_waffleCategory", cat)
+      set("_waffleIndex", cellIndex)
+    })
+
   const nodes: RectSceneNode[] = []
   let cellIndex = 0
   for (const slot of floored) {
@@ -129,7 +163,7 @@ export const waffleLayout: CustomLayout<WaffleConfig> = (ctx) => {
         w: cellW,
         h: cellH,
         style: { fill: color, stroke: "none" },
-        datum: { _waffleCategory: slot.cat, _waffleIndex: cellIndex },
+        datum: buildCellDatum(slot.cat, cellIndex, slot.count),
         group: slot.cat,
       })
       cellIndex++


### PR DESCRIPTION
This pull request introduces important improvements to tooltip robustness and user experience, as well as enhanced data shaping for waffle chart tooltips. The main changes include defensive behaviors in the `FlippingTooltip` component to prevent visual and runtime regressions, and the emission of more user-friendly fields for waffle chart tooltips. These updates address recurring regressions and make it easier for consumers to build reliable, informative tooltips.

**Tooltip robustness and defensive behavior:**

- Added a `hasOwnChrome` utility and extended logic in `FlippingTooltip.tsx` to automatically apply default tooltip chrome (background, padding, etc.) when user-provided content does not appear to handle its own styling. This prevents tooltips from rendering as transparent floating boxes and avoids double-applying chrome when the consumer already provides it. [[1]](diffhunk://#diff-e740d1e092a8054d4e4196daa9ad44336c0b18526b22e65fd13af27b30a8a7deR2) [[2]](diffhunk://#diff-e740d1e092a8054d4e4196daa9ad44336c0b18526b22e65fd13af27b30a8a7deR23-R92) [[3]](diffhunk://#diff-e740d1e092a8054d4e4196daa9ad44336c0b18526b22e65fd13af27b30a8a7deR104-R111) [[4]](diffhunk://#diff-e740d1e092a8054d4e4196daa9ad44336c0b18526b22e65fd13af27b30a8a7deR154-R182)
- Implemented a non-finite position guard in `FlippingTooltip` to ensure the tooltip does not render (returns `null`) when its `x` or `y` position is not a finite number, preventing React errors related to invalid CSS values and maintaining hook call order stability. [[1]](diffhunk://#diff-e740d1e092a8054d4e4196daa9ad44336c0b18526b22e65fd13af27b30a8a7deR104-R111) [[2]](diffhunk://#diff-e740d1e092a8054d4e4196daa9ad44336c0b18526b22e65fd13af27b30a8a7deR154-R182)

**Tooltip regression and behavior testing:**

- Added comprehensive regression tests for `FlippingTooltip` covering chrome auto-application, detection of consumer-provided chrome (via className or inline styles), and guarding against non-finite positions, including transitions between valid and invalid positions.

**Waffle chart tooltip data shaping:**

- Updated the `waffleLayout` recipe to emit tooltip-facing fields on each cell's datum, including canonical `category` and `value` keys, user-accessor names (when accessors are strings), cell count, and legacy underscore-prefixed fields for backward compatibility. This ensures default and custom tooltips have access to meaningful data. [[1]](diffhunk://#diff-118312824374b357d61bef7166a33d2787b52ddea7b88346101fa3df6ad656e3R4) [[2]](diffhunk://#diff-118312824374b357d61bef7166a33d2787b52ddea7b88346101fa3df6ad656e3R117-R149) [[3]](diffhunk://#diff-118312824374b357d61bef7166a33d2787b52ddea7b88346101fa3df6ad656e3L132-R166)
- Added tests to verify that waffle chart cells now include these user-friendly fields, and that fallback behavior works correctly when accessors are functions.