### PR TITLE
Release 3.5.4: changelog, docs, version bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.4] - 2026-05-21
+
 ### Added
 
 - **`band` prop on `LineChart` and `AreaChart` (and `StreamXYFrame`)** — asymmetric min/max envelope drawn under the lines/areas, driven by independent `y0Accessor` / `y1Accessor`. Distinct from the existing `boundsAccessor` (symmetric ±offset) and from `AreaChart.y0Accessor` (which replaces the area baseline). Pass a single `BandConfig` or an array of them for percentile fans (e.g. p25/p75 stacked on top of p10/p90). Per-series by default — one ribbon per `lineBy` / `colorBy` group, colored from the parent line at 0.2 fillOpacity. Pass `perSeries: false` for an aggregate min/max envelope across all series. Non-interactive by default (hovers pass through to the line on top); set `interactive: true` if the band should participate in hit testing. Band y0/y1 values feed `yExtent` auto-derivation so a tall envelope can never clip, with explicit `yExtent` still winning.

--- a/ai/dist/mcp-server.js
+++ b/ai/dist/mcp-server.js
@@ -3106,6 +3106,9 @@ var require_utils = __commonJS({
     "use strict";
     var isUUID = RegExp.prototype.test.bind(/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iu);
     var isIPv4 = RegExp.prototype.test.bind(/^(?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)$/u);
+    var isHexPair = RegExp.prototype.test.bind(/^[\da-f]{2}$/iu);
+    var isUnreserved = RegExp.prototype.test.bind(/^[\da-z\-._~]$/iu);
+    var isPathCharacter = RegExp.prototype.test.bind(/^[\da-z\-._~!$&'()*+,;=:@/]$/iu);
     function stringArrayToHexStripped(input) {
       let acc = "";
       let code = 0;
@@ -3298,27 +3301,77 @@ var require_utils = __commonJS({
       }
       return output.join("");
     }
-    function normalizeComponentEncoding(component, esc2) {
-      const func = esc2 !== true ? escape : unescape;
-      if (component.scheme !== void 0) {
-        component.scheme = func(component.scheme);
+    var HOST_DELIMS = { "@": "%40", "/": "%2F", "?": "%3F", "#": "%23", ":": "%3A" };
+    var HOST_DELIM_RE = /[@/?#:]/g;
+    var HOST_DELIM_NO_COLON_RE = /[@/?#]/g;
+    function reescapeHostDelimiters(host, isIP) {
+      const re = isIP ? HOST_DELIM_NO_COLON_RE : HOST_DELIM_RE;
+      re.lastIndex = 0;
+      return host.replace(re, (ch) => HOST_DELIMS[ch]);
+    }
+    function normalizePercentEncoding(input, decodeUnreserved = false) {
+      if (input.indexOf("%") === -1) {
+        return input;
       }
-      if (component.userinfo !== void 0) {
-        component.userinfo = func(component.userinfo);
+      let output = "";
+      for (let i = 0; i < input.length; i++) {
+        if (input[i] === "%" && i + 2 < input.length) {
+          const hex3 = input.slice(i + 1, i + 3);
+          if (isHexPair(hex3)) {
+            const normalizedHex = hex3.toUpperCase();
+            const decoded = String.fromCharCode(parseInt(normalizedHex, 16));
+            if (decodeUnreserved && isUnreserved(decoded)) {
+              output += decoded;
+            } else {
+              output += "%" + normalizedHex;
+            }
+            i += 2;
+            continue;
+          }
+        }
+        output += input[i];
       }
-      if (component.host !== void 0) {
-        component.host = func(component.host);
+      return output;
+    }
+    function normalizePathEncoding(input) {
+      let output = "";
+      for (let i = 0; i < input.length; i++) {
+        if (input[i] === "%" && i + 2 < input.length) {
+          const hex3 = input.slice(i + 1, i + 3);
+          if (isHexPair(hex3)) {
+            const normalizedHex = hex3.toUpperCase();
+            const decoded = String.fromCharCode(parseInt(normalizedHex, 16));
+            if (decoded !== "." && isUnreserved(decoded)) {
+              output += decoded;
+            } else {
+              output += "%" + normalizedHex;
+            }
+            i += 2;
+            continue;
+          }
+        }
+        if (isPathCharacter(input[i])) {
+          output += input[i];
+        } else {
+          output += escape(input[i]);
+        }
       }
-      if (component.path !== void 0) {
-        component.path = func(component.path);
+      return output;
+    }
+    function escapePreservingEscapes(input) {
+      let output = "";
+      for (let i = 0; i < input.length; i++) {
+        if (input[i] === "%" && i + 2 < input.length) {
+          const hex3 = input.slice(i + 1, i + 3);
+          if (isHexPair(hex3)) {
+            output += "%" + hex3.toUpperCase();
+            i += 2;
+            continue;
+          }
+        }
+        output += escape(input[i]);
       }
-      if (component.query !== void 0) {
-        component.query = func(component.query);
-      }
-      if (component.fragment !== void 0) {
-        component.fragment = func(component.fragment);
-      }
-      return component;
+      return output;
     }
     function recomposeAuthority(component) {
       const uriTokens = [];
@@ -3333,7 +3386,7 @@ var require_utils = __commonJS({
           if (ipV6res.isIPV6 === true) {
             host = `[${ipV6res.escapedHost}]`;
           } else {
-            host = component.host;
+            host = reescapeHostDelimiters(host, false);
           }
         }
         uriTokens.push(host);
@@ -3347,7 +3400,10 @@ var require_utils = __commonJS({
     module2.exports = {
       nonSimpleDomain,
       recomposeAuthority,
-      normalizeComponentEncoding,
+      reescapeHostDelimiters,
+      normalizePercentEncoding,
+      normalizePathEncoding,
+      escapePreservingEscapes,
       removeDotSegments,
       isIPv4,
       isUUID,
@@ -3571,12 +3627,12 @@ var require_schemes = __commonJS({
 var require_fast_uri = __commonJS({
   "node_modules/fast-uri/index.js"(exports2, module2) {
     "use strict";
-    var { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizeComponentEncoding, isIPv4, nonSimpleDomain } = require_utils();
+    var { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizePercentEncoding, normalizePathEncoding, escapePreservingEscapes, reescapeHostDelimiters, isIPv4, nonSimpleDomain } = require_utils();
     var { SCHEMES, getSchemeHandler } = require_schemes();
     function normalize(uri, options) {
       if (typeof uri === "string") {
         uri = /** @type {T} */
-        serialize(parse3(uri, options), options);
+        normalizeString(uri, options);
       } else if (typeof uri === "object") {
         uri = /** @type {T} */
         parse3(serialize(uri, options), options);
@@ -3643,19 +3699,9 @@ var require_fast_uri = __commonJS({
       return target;
     }
     function equal(uriA, uriB, options) {
-      if (typeof uriA === "string") {
-        uriA = unescape(uriA);
-        uriA = serialize(normalizeComponentEncoding(parse3(uriA, options), true), { ...options, skipEscape: true });
-      } else if (typeof uriA === "object") {
-        uriA = serialize(normalizeComponentEncoding(uriA, true), { ...options, skipEscape: true });
-      }
-      if (typeof uriB === "string") {
-        uriB = unescape(uriB);
-        uriB = serialize(normalizeComponentEncoding(parse3(uriB, options), true), { ...options, skipEscape: true });
-      } else if (typeof uriB === "object") {
-        uriB = serialize(normalizeComponentEncoding(uriB, true), { ...options, skipEscape: true });
-      }
-      return uriA.toLowerCase() === uriB.toLowerCase();
+      const normalizedA = normalizeComparableURI(uriA, options);
+      const normalizedB = normalizeComparableURI(uriB, options);
+      return normalizedA !== void 0 && normalizedB !== void 0 && normalizedA.toLowerCase() === normalizedB.toLowerCase();
     }
     function serialize(cmpts, opts) {
       const component = {
@@ -3680,12 +3726,12 @@ var require_fast_uri = __commonJS({
       if (schemeHandler && schemeHandler.serialize) schemeHandler.serialize(component, options);
       if (component.path !== void 0) {
         if (!options.skipEscape) {
-          component.path = escape(component.path);
+          component.path = escapePreservingEscapes(component.path);
           if (component.scheme !== void 0) {
             component.path = component.path.split("%3A").join(":");
           }
         } else {
-          component.path = unescape(component.path);
+          component.path = normalizePercentEncoding(component.path);
         }
       }
       if (options.reference !== "suffix" && component.scheme) {
@@ -3720,7 +3766,16 @@ var require_fast_uri = __commonJS({
       return uriTokens.join("");
     }
     var URI_PARSE = /^(?:([^#/:?]+):)?(?:\/\/((?:([^#/?@]*)@)?(\[[^#/?\]]+\]|[^#/:?]*)(?::(\d*))?))?([^#?]*)(?:\?([^#]*))?(?:#((?:.|[\n\r])*))?/u;
-    function parse3(uri, opts) {
+    function getParseError(parsed, matches) {
+      if (matches[2] !== void 0 && parsed.path && parsed.path[0] !== "/") {
+        return 'URI path must start with "/" when authority is present.';
+      }
+      if (typeof parsed.port === "number" && (parsed.port < 0 || parsed.port > 65535)) {
+        return "URI port is malformed.";
+      }
+      return void 0;
+    }
+    function parseWithStatus(uri, opts) {
       const options = Object.assign({}, opts);
       const parsed = {
         scheme: void 0,
@@ -3731,6 +3786,7 @@ var require_fast_uri = __commonJS({
         query: void 0,
         fragment: void 0
       };
+      let malformedAuthorityOrPort = false;
       let isIP = false;
       if (options.reference === "suffix") {
         if (options.scheme) {
@@ -3750,6 +3806,11 @@ var require_fast_uri = __commonJS({
         parsed.fragment = matches[8];
         if (isNaN(parsed.port)) {
           parsed.port = matches[5];
+        }
+        const parseError = getParseError(parsed, matches);
+        if (parseError !== void 0) {
+          parsed.error = parsed.error || parseError;
+          malformedAuthorityOrPort = true;
         }
         if (parsed.host) {
           const ipv4result = isIPv4(parsed.host);
@@ -3789,14 +3850,18 @@ var require_fast_uri = __commonJS({
               parsed.scheme = unescape(parsed.scheme);
             }
             if (parsed.host !== void 0) {
-              parsed.host = unescape(parsed.host);
+              parsed.host = reescapeHostDelimiters(unescape(parsed.host), isIP);
             }
           }
           if (parsed.path) {
-            parsed.path = escape(unescape(parsed.path));
+            parsed.path = normalizePathEncoding(parsed.path);
           }
           if (parsed.fragment) {
-            parsed.fragment = encodeURI(decodeURIComponent(parsed.fragment));
+            try {
+              parsed.fragment = encodeURI(decodeURIComponent(parsed.fragment));
+            } catch {
+              parsed.error = parsed.error || "URI malformed";
+            }
           }
         }
         if (schemeHandler && schemeHandler.parse) {
@@ -3805,7 +3870,29 @@ var require_fast_uri = __commonJS({
       } else {
         parsed.error = parsed.error || "URI can not be parsed.";
       }
-      return parsed;
+      return { parsed, malformedAuthorityOrPort };
+    }
+    function parse3(uri, opts) {
+      return parseWithStatus(uri, opts).parsed;
+    }
+    function normalizeString(uri, opts) {
+      return normalizeStringWithStatus(uri, opts).normalized;
+    }
+    function normalizeStringWithStatus(uri, opts) {
+      const { parsed, malformedAuthorityOrPort } = parseWithStatus(uri, opts);
+      return {
+        normalized: malformedAuthorityOrPort ? uri : serialize(parsed, opts),
+        malformedAuthorityOrPort
+      };
+    }
+    function normalizeComparableURI(uri, opts) {
+      if (typeof uri === "string") {
+        const { normalized, malformedAuthorityOrPort } = normalizeStringWithStatus(uri, opts);
+        return malformedAuthorityOrPort ? void 0 : normalized;
+      }
+      if (typeof uri === "object") {
+        return serialize(uri, opts);
+      }
     }
     var fastUri = {
       SCHEMES,
@@ -6856,6 +6943,7 @@ var require_componentMetadata = __commonJS({
       realtime: [
         "RealtimeLineChart",
         "RealtimeHistogram",
+        "TemporalHistogram",
         "RealtimeSwarmChart",
         "RealtimeWaterfallChart",
         "RealtimeHeatmap"
@@ -6883,11 +6971,12 @@ var require_componentMetadata = __commonJS({
     function metadataForComponent2(entryOrName) {
       const name = typeof entryOrName === "string" ? entryOrName : entryOrName.name;
       const category = categoryForComponent(name);
+      const isPushOnly = category === "realtime" && name.startsWith("Realtime");
       return {
         name,
         category,
         importPath: importPathForCategory(category),
-        renderable: category !== "realtime",
+        renderable: !isPushOnly,
         description: typeof entryOrName === "string" ? void 0 : entryOrName.description
       };
     }
@@ -10006,7 +10095,7 @@ var ZodObject = class _ZodObject extends ZodType {
   //         ...def.shape(),
   //         ...augmentation,
   //       }),
-  //     });
+  //     }) as any;
   //   };
   extend(augmentation) {
     return new _ZodObject({
@@ -10066,7 +10155,7 @@ var ZodObject = class _ZodObject extends ZodType {
   //     shape: () =>
   //       objectUtil.mergeShapes(this._def.shape(), merging._def.shape()),
   //     typeName: ZodFirstPartyTypeKind.ZodObject,
-  //   });
+  //   }) as any;
   //   return merged;
   // }
   setKey(key, schema2) {
@@ -10090,7 +10179,7 @@ var ZodObject = class _ZodObject extends ZodType {
   //     shape: () =>
   //       objectUtil.mergeShapes(this._def.shape(), merging._def.shape()),
   //     typeName: ZodFirstPartyTypeKind.ZodObject,
-  //   });
+  //   }) as any;
   //   return merged;
   // }
   catchall(index) {
@@ -32276,6 +32365,7 @@ var COMPONENT_REGISTRY = {
   QuadrantChart: { component: import_ai.QuadrantChart, category: "xy" },
   MultiAxisLineChart: { component: import_ai.MultiAxisLineChart, category: "xy" },
   CandlestickChart: { component: import_ai.CandlestickChart, category: "xy" },
+  TemporalHistogram: { component: import_ai.TemporalHistogram, category: "xy" },
   BarChart: { component: import_ai.BarChart, category: "ordinal" },
   StackedBarChart: { component: import_ai.StackedBarChart, category: "ordinal" },
   GroupedBarChart: { component: import_ai.GroupedBarChart, category: "ordinal" },

--- a/ai/schema.json
+++ b/ai/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "semiotic",
-  "version": "",
+  "version": "3.5.4",
   "description": "React data visualization library for charts, networks, and beyond",
   "tools": [
     {

--- a/ai/schema.json
+++ b/ai/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "semiotic",
-  "version": "3.5.3",
+  "version": "",
   "description": "React data visualization library for charts, networks, and beyond",
   "tools": [
     {

--- a/docs/src/blog/entries-meta.js
+++ b/docs/src/blog/entries-meta.js
@@ -17,6 +17,17 @@
 
 export const blogEntriesMeta = [
   {
+    slug: "release-3-5-4",
+    title: "Semiotic 3.5.4",
+    subtitle:
+      "Asymmetric bands and percentile fans on LineChart/AreaChart, edge-anchored ticks, theme-driven CSS font-size variables, per-axis class names, loadingContent on every HOC, and one unified ribbon primitive for bounds and band.",
+    author: "AI-Generated",
+    date: "2026-05-21",
+    tags: ["release"],
+    excerpt:
+      "3.5.4 adds a first-class asymmetric band encoding (with percentile fans) to LineChart and AreaChart, sharpens the axis surface with edge-anchored ticks, CSS-variable font sizes, and per-axis class names, ships loadingContent across every HOC, and collapses bounds + band into a single shared ribbon primitive.",
+  },
+  {
     slug: "release-3-5-3",
     title: "Semiotic 3.5.3",
     subtitle:

--- a/docs/src/blog/entries.js
+++ b/docs/src/blog/entries.js
@@ -34,6 +34,7 @@
  */
 
 import ProcessSankeyVsClassicSankey from "./entries/process-sankey-vs-classic-sankey.js"
+import Release354 from "./entries/release-3-5-4.js"
 import Release353 from "./entries/release-3-5-3.js"
 import MinardsMarch from "./entries/minards-march.js"
 import Release352 from "./entries/release-3-5-2.js"
@@ -43,6 +44,7 @@ import FunnelChartExplainer from "./entries/funnel-chart.js"
 import OrbitDiagramExplainer from "./entries/orbit-diagram.js"
 
 export const blogEntries = [
+  Release354,
   Release353,
   ProcessSankeyVsClassicSankey,
   MinardsMarch,

--- a/docs/src/blog/entries/release-3-5-4.js
+++ b/docs/src/blog/entries/release-3-5-4.js
@@ -1,0 +1,152 @@
+import React from "react"
+import { Link } from "react-router-dom"
+
+function Body() {
+  return (
+    <>
+      <p>
+        3.5.4 lands a real envelope encoding on{" "}
+        <Link to="/charts/line-chart">LineChart</Link> and{" "}
+        <Link to="/charts/area-chart">AreaChart</Link>, sharpens the axis surface
+        (edge-anchored ticks, CSS-variable font sizes, per-axis class names), and gives every
+        HOC a sibling to <code>emptyContent</code> with the new <code>loadingContent</code>{" "}
+        slot. Under the hood, <code>boundsAccessor</code> and <code>band</code> now share a
+        single ribbon primitive — one scene builder, one y-extent pass, one style cascade.
+        Full release notes are on{" "}
+        <a
+          href="https://github.com/nteract/semiotic/blob/main/CHANGELOG.md#354---2026-05-21"
+          target="_blank"
+          rel="noreferrer"
+        >
+          GitHub
+        </a>
+        .
+      </p>
+
+      <h2 id="band">Asymmetric bands and percentile fans</h2>
+      <p>
+        The new <code>band</code> prop on LineChart and AreaChart draws an asymmetric min/max
+        envelope under the line/area, driven by independent <code>y0Accessor</code> and{" "}
+        <code>y1Accessor</code>. That's distinct from the existing{" "}
+        <code>boundsAccessor</code> (which is symmetric ±offset) and from{" "}
+        <code>AreaChart.y0Accessor</code> (which replaces the area baseline). Pass a single{" "}
+        <code>BandConfig</code> for one envelope or an array for percentile fans — p25/p75
+        stacked on top of p10/p90 is the canonical shape.
+      </p>
+      <p>
+        Per-series by default: one ribbon per <code>lineBy</code> / <code>colorBy</code>{" "}
+        group, colored from the parent line at <code>0.2</code> fillOpacity. Pass{" "}
+        <code>perSeries: false</code> for an aggregate min/max envelope across all series.
+        Bands are non-interactive by default (hovers pass through to the line on top); set{" "}
+        <code>interactive: true</code> if the band should participate in hit testing. Band
+        y0/y1 values feed <code>yExtent</code> auto-derivation so a tall envelope can never
+        clip; explicit <code>yExtent</code> still wins. Live demo at{" "}
+        <Link to="/charts/line-chart#band">/charts/line-chart#band</Link>.
+      </p>
+      <p>
+        Tooltip enrichment covers every interaction surface: the hovered datum carries{" "}
+        <code>band: {`{ y0, y1 }`}</code> (first band) and <code>bands: [...]</code> (all
+        bands) on the pointer hover path, each <code>allSeries[i].datum</code> in multi-mode,
+        and the keyboard-navigation datum. The default tooltip auto-surfaces band rows when{" "}
+        <code>band</code> is configured without a custom tooltip — string accessors become
+        labels; function accessors fall back to <code>low</code> / <code>high</code>.
+      </p>
+
+      <h2 id="axes">Axis surface: edge anchors, CSS vars, per-axis targeting</h2>
+      <ul>
+        <li>
+          <strong>
+            <code>tickAnchor: "edges"</code> on <code>frameProps.axes[i]</code>
+          </strong>{" "}
+          — flips the leftmost tick&apos;s <code>text-anchor</code> to <code>start</code> and
+          the rightmost to <code>end</code> on horizontal axes (and{" "}
+          <code>dominant-baseline</code> to <code>hanging</code> / <code>auto</code> on
+          vertical axes) so edge labels can&apos;t overflow the plot. Pairs naturally with{" "}
+          <code>axisExtent: "exact"</code>: exact pins the domain to the literal data
+          min/max; edges keeps the labels readable at those bounds. Edge detection is
+          pixel-based, so inverted y scales and reversed-x streaming charts anchor
+          correctly.
+        </li>
+        <li>
+          <strong>
+            <code>--semiotic-tick-font-size</code> and{" "}
+            <code>--semiotic-axis-label-font-size</code> CSS variables
+          </strong>{" "}
+          — emitted from the canonical theme typography fields (<code>tickSize</code>,{" "}
+          <code>labelSize</code>) alongside the existing tick/title font-family/size
+          variables. Both <code>themeToCSS</code> and <code>ThemeProvider</code> write them;{" "}
+          <code>themeToTokens</code> exports them as DTCG <code>dimension</code> tokens. SVG
+          axes consume the vars via inline <code>style</code>, so an override on any
+          ancestor (<code>{`<div style={{ "--semiotic-tick-font-size": "14px" }}>`}</code>)
+          flows down without consumers needing <code>!important</code>.
+        </li>
+        <li>
+          <strong>
+            <code>data-orient</code> and per-axis class names
+          </strong>{" "}
+          — each axis now renders as its own{" "}
+          <code>{`<g class="semiotic-axis semiotic-axis-{bottom|left|right|top}" data-orient="…">`}</code>{" "}
+          inside <code>.stream-axes</code>. Style one axis at a time from external CSS:{" "}
+          <code>{`[data-orient='left'] text { font-size: 14px }`}</code>. Tick text carries{" "}
+          <code>semiotic-axis-tick</code>, axis labels{" "}
+          <code>semiotic-axis-label</code>, and chart titles <code>semiotic-chart-title</code>{" "}
+          for class-based targeting.
+        </li>
+      </ul>
+
+      <h2 id="loading">loadingContent on every HOC</h2>
+      <p>
+        Sibling to <code>emptyContent</code>. When <code>loading</code> is true and{" "}
+        <code>loadingContent</code> is set, it renders in place of the default shimmer-bar
+        skeleton (wrapped in the same sized container so the chart slot stays reserved).
+        Pass <code>loadingContent={`{false}`}</code> to suppress the loading UI entirely —
+        the early-return becomes <code>null</code> and a consumer&apos;s outer loading state
+        takes over. Threaded through <code>useChartSetup</code>,{" "}
+        <code>useNetworkChartSetup</code>, and <code>useCustomChartSetup</code>; all 47 HOCs
+        accept it via <code>BaseChartProps</code>.
+      </p>
+
+      <h2 id="ribbon-primitive">One ribbon primitive for bounds and band</h2>
+      <p>
+        Both public envelope APIs (<code>boundsAccessor</code> and <code>band</code>) now
+        normalize to a single <code>resolvedRibbons: ResolvedRibbon[]</code> array at the
+        PipelineStore layer, then flow through <code>xySceneBuilders/ribbonScene.ts</code> —
+        one scene builder, one y-extent expansion pass, one style cascade. The dedicated{" "}
+        <code>boundsScene.ts</code> and <code>bandScene.ts</code> modules are gone. Public
+        prop surfaces stay distinct (asymmetric pairs read better as <code>band</code> than
+        as a <code>boundsAccessor</code> union return type), but the implementation is no
+        longer duplicated.
+      </p>
+      <p>
+        Two correctness wins fell out of the unification: bounds ribbons now skip datums
+        with null/NaN <code>y</code> (the coerced <code>+null === 0</code> previously
+        rendered a ribbon around the implicit-zero "value" of a missing row), and a{" "}
+        <code>kind: "bounds" | "band"</code> discriminator on each ribbon restricts{" "}
+        <code>datum.band</code> / <code>datum.bands</code> tooltip enrichment to band-sourced
+        envelopes — bounds stays decorative-only, matching its prior contract.
+      </p>
+
+      <h2 id="upgrade-notes">Upgrade notes</h2>
+      <p>
+        This release is additive. Consumers already using <code>boundsAccessor</code> get the
+        null/NaN-row fix for free; anything that relied on the implicit-zero ribbon behavior
+        should switch to filtering at the data layer. The website build now injects the Atom
+        feed <code>{`<link rel="alternate">`}</code> via the prerender step instead of source
+        HTML, which closes a parcel resolution failure on nested prerendered routes.
+      </p>
+    </>
+  )
+}
+
+export default {
+  slug: "release-3-5-4",
+  title: "Semiotic 3.5.4",
+  subtitle:
+    "Asymmetric bands and percentile fans on LineChart/AreaChart, edge-anchored ticks, theme-driven CSS font-size variables, per-axis class names, loadingContent on every HOC, and one unified ribbon primitive for bounds and band.",
+  author: "AI-Generated",
+  date: "2026-05-21",
+  tags: ["release"],
+  excerpt:
+    "3.5.4 adds a first-class asymmetric band encoding (with percentile fans) to LineChart and AreaChart, sharpens the axis surface with edge-anchored ticks, CSS-variable font sizes, and per-axis class names, ships loadingContent across every HOC, and collapses bounds + band into a single shared ribbon primitive.",
+  component: Body,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "semiotic",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "semiotic",
-      "version": "3.5.3",
+      "version": "3.5.4",
       "license": "Apache-2.0",
       "dependencies": {
         "d3-array": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semiotic",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "mcpName": "io.github.nteract/semiotic",
   "description": "React data visualization library with built-in MCP server for AI-assisted chart generation",
   "main": "dist/semiotic.min.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/nteract/semiotic",
     "source": "github"
   },
-  "version": "3.5.3",
+  "version": "3.5.4",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "semiotic",
-      "version": "3.5.3",
+      "version": "3.5.4",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Prepare and publish Semiotic 3.5.4: update CHANGELOG and add a new release blog entry (docs/src/blog/entries/release-3-5-4.js) and metadata/imports so it appears in the site. Bump version to 3.5.4 across package.json, package-lock.json and server.json. Update ai/dist generated code with URI/encoding normalization, path/host escaping helpers, parsing/normalization status handling, a few component metadata tweaks (TemporalHistogram registration and renderable flag fix), and assorted zod/ts-fix comments. Clear the ai/schema.json version field. These changes prepare the release notes, site content, and runtime bits for 3.5.4.
