### PR TITLE
Add temporal lifecycle page and lifecycle APIs

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -239,7 +239,7 @@ All HOCs accept `annotations` (array). Coordinates use data field names.
 **Ordinal**: `category-highlight`
 **Enclosures**: `enclose`, `rect-enclose`, `highlight`
 **Statistical**: `trend`, `envelope`, `anomaly-band`, `forecast`
-**Streaming anchors**: `"fixed"` | `"latest"` | `"sticky"`
+**Streaming anchors**: `"fixed"` | `"latest"` | `"sticky"` | `"semantic"` — also exposed as `lifecycle.anchor` on the `semiotic/ai` annotation lifecycle. Same `AnnotationAnchor` type either way; `"semantic"` re-resolves via `provenance.stableId` (runtime support landing incrementally).
 
 ## Theming
 
@@ -342,24 +342,62 @@ store.record({ type: "suggestion-shown", components: ["LineChart"], intent: "tre
 ```
 
 ### Annotation provenance + lifecycle (`semiotic/ai`, types also re-exported from `semiotic`)
-Type surface for "where did this annotation come from?" and "is it stale?" Optional blocks attached to any annotation — existing arrays keep working unchanged.
+Tracks "where did this annotation come from?" and "is it stale?" Two optional blocks attach to any annotation — existing arrays keep working unchanged.
 - **`provenance`**: `{ author?, source?, confidence?, createdAt?, stableId? }`. `source` is an open string union (`"user" | "ai" | "agent" | "import" | "computed" | "system" | (string & {})`).
 - **`lifecycle`**: `{ freshness?, ttlHint?, anchor? }`. `freshness` is `"fresh" | "aging" | "stale" | "expired"`. `anchor` is `"fixed" | "latest" | "sticky" | "semantic"`. `ttlHint` accepts an ISO 8601 duration string (`"P30D"`) or milliseconds.
 - **`withProvenance(annotation, { provenance?, lifecycle? })`** → returns a new annotation with the blocks attached. Pure, SSR-safe.
 - **`Annotated<T>`** type alias: `T & { provenance?, lifecycle? }`. Use for explicit typing.
-- Type surface only at this stage. Freshness computation, default visual treatment, and stable-id anchor resolution land later.
+- **`computeAnnotationFreshness(annotations, { now?, dataExtent?, thresholds? })`** → returns annotations with `lifecycle.freshness` populated based on `createdAt` + `ttlHint`. `now` defaults to `dataExtent`'s max, then `Date.now()`. Custom thresholds override the default 1× / 1.5× / 3× TTL breakpoints.
+- **`annotationFreshnessFor(annotation, nowMs, thresholds?)`** → classifies a single annotation. Honors any pre-existing `lifecycle.freshness` (explicit assignment wins).
+- **`applyAnnotationLifecycle(annotations, { now?, dataExtent?, opacity?, strokeDasharray?, labelSuffix?, showExpiredAnnotations?, thresholds? })`** → composes the freshness pass with a default visual treatment: aging dims (opacity 0.55), stale dims more + dashes (strokeDasharray `"4 4"`), expired is filtered out (set `showExpiredAnnotations: true` to keep). Per-band overrides via the options; pass `null` for a band to disable that default. Annotation `opacity` / `strokeDasharray` set explicitly on the annotation win over the treatment. Annotation renderer cascades both as SVG presentation attributes to every stroked / filled child.
+- Still owed (M3): stable-id anchor resolution after data refresh.
 
 ```ts
-import { withProvenance } from "semiotic/ai"
+import { withProvenance, applyAnnotationLifecycle } from "semiotic/ai"
 
 const ann = withProvenance(
-  { type: "y-threshold", value: 100, label: "SLA breach" },
+  { type: "y-threshold", value: 100, label: "SLA breach", color: "#3a8eff" },
   {
     provenance: { author: "alice", source: "user", createdAt: "2026-05-20T14:00:00Z" },
     lifecycle: { ttlHint: "P30D", anchor: "semantic" },
   },
 )
+
+// Pass through the lifecycle treatment before handing to a chart.
+<LineChart annotations={applyAnnotationLifecycle([ann], { dataExtent: [t0, tNow] })} />
 ```
+
+### Temporal lifecycle (shared between `semiotic/realtime` + `semiotic/ai`)
+Three Semiotic systems answer "how does this thing look as it ages?" with three different policies on three different time axes. They are *not* interchangeable — pick the one that matches the question.
+
+| Policy | Lives in | Time axis | Output | Scope |
+|---|---|---|---|---|
+| `DecayConfig` | `semiotic/realtime` | buffer position | continuous opacity ramp | per-datum |
+| `StalenessConfig` | `semiotic/realtime` | wall-clock idle | binary live/stale (+ optional badge) | chart-wide |
+| Annotation freshness | `semiotic/ai` | `createdAt` + `ttlHint` | 4 named bands (opacity + dashing + expired filter) | per-annotation |
+
+Shared primitive that bridges them: **`bandFromAge(ageMs, ttlMs, thresholds?)`** → `"fresh" | "aging" | "stale" | "expired"`. Pure function exported from both `semiotic/realtime` and `semiotic/ai`. `DEFAULT_LIFECYCLE_THRESHOLDS = { fresh: 1.0, aging: 1.5, stale: 3.0 }` (multipliers of TTL). Annotation freshness uses this primitive today; future banded-decay or banded-staleness opt-ins can plug into the same classifier.
+
+**Anchor mode** (`"fixed" | "latest" | "sticky" | "semantic"`) is also shared — `AnnotationAnchor` from `semiotic/realtime` is the canonical type, re-exported from `semiotic/ai` as `lifecycle.anchor`. `"semantic"` re-resolves via `provenance.stableId` (runtime support landing incrementally).
+
+**Streaming chart-time aging**: pass the chart's `dataExtent` to `applyAnnotationLifecycle` and the latest data point becomes the "now" reference. Annotations age against chart-time, not wall-clock — useful when streams pause or run slow. Pair with `withCurrentProvenance(annotation, { author?, source? })` or `currentTimestamp()` to auto-stamp `createdAt` at the moment of creation.
+
+```ts
+import { bandFromAge, withCurrentProvenance, applyAnnotationLifecycle } from "semiotic/ai"
+
+bandFromAge(20_000, 8000) // "stale" — age is 2.5× TTL
+
+const ann = withCurrentProvenance(
+  { type: "callout", t: latest.t, value: latest.value, label: "Spike" },
+  { author: "alice", source: "user" },
+)
+
+<LineChart
+  annotations={applyAnnotationLifecycle([ann], { dataExtent: [data[0].t, data.at(-1).t] })}
+/>
+```
+
+Full survey at `/intelligence/temporal-lifecycle`.
 
 ### Variant discovery (`semiotic/ai`)
 Interface for proposing and scoring chart variants beyond the hand-curated `capability.variants`. Heuristic and model-based proposers plug in through `registerVariantDiscovery`. M1 ships the type surface + stub implementations; behavior arrives in subsequent milestones.

--- a/.cursorrules
+++ b/.cursorrules
@@ -239,7 +239,7 @@ All HOCs accept `annotations` (array). Coordinates use data field names.
 **Ordinal**: `category-highlight`
 **Enclosures**: `enclose`, `rect-enclose`, `highlight`
 **Statistical**: `trend`, `envelope`, `anomaly-band`, `forecast`
-**Streaming anchors**: `"fixed"` | `"latest"` | `"sticky"`
+**Streaming anchors**: `"fixed"` | `"latest"` | `"sticky"` | `"semantic"` — also exposed as `lifecycle.anchor` on the `semiotic/ai` annotation lifecycle. Same `AnnotationAnchor` type either way; `"semantic"` re-resolves via `provenance.stableId` (runtime support landing incrementally).
 
 ## Theming
 
@@ -342,24 +342,62 @@ store.record({ type: "suggestion-shown", components: ["LineChart"], intent: "tre
 ```
 
 ### Annotation provenance + lifecycle (`semiotic/ai`, types also re-exported from `semiotic`)
-Type surface for "where did this annotation come from?" and "is it stale?" Optional blocks attached to any annotation — existing arrays keep working unchanged.
+Tracks "where did this annotation come from?" and "is it stale?" Two optional blocks attach to any annotation — existing arrays keep working unchanged.
 - **`provenance`**: `{ author?, source?, confidence?, createdAt?, stableId? }`. `source` is an open string union (`"user" | "ai" | "agent" | "import" | "computed" | "system" | (string & {})`).
 - **`lifecycle`**: `{ freshness?, ttlHint?, anchor? }`. `freshness` is `"fresh" | "aging" | "stale" | "expired"`. `anchor` is `"fixed" | "latest" | "sticky" | "semantic"`. `ttlHint` accepts an ISO 8601 duration string (`"P30D"`) or milliseconds.
 - **`withProvenance(annotation, { provenance?, lifecycle? })`** → returns a new annotation with the blocks attached. Pure, SSR-safe.
 - **`Annotated<T>`** type alias: `T & { provenance?, lifecycle? }`. Use for explicit typing.
-- Type surface only at this stage. Freshness computation, default visual treatment, and stable-id anchor resolution land later.
+- **`computeAnnotationFreshness(annotations, { now?, dataExtent?, thresholds? })`** → returns annotations with `lifecycle.freshness` populated based on `createdAt` + `ttlHint`. `now` defaults to `dataExtent`'s max, then `Date.now()`. Custom thresholds override the default 1× / 1.5× / 3× TTL breakpoints.
+- **`annotationFreshnessFor(annotation, nowMs, thresholds?)`** → classifies a single annotation. Honors any pre-existing `lifecycle.freshness` (explicit assignment wins).
+- **`applyAnnotationLifecycle(annotations, { now?, dataExtent?, opacity?, strokeDasharray?, labelSuffix?, showExpiredAnnotations?, thresholds? })`** → composes the freshness pass with a default visual treatment: aging dims (opacity 0.55), stale dims more + dashes (strokeDasharray `"4 4"`), expired is filtered out (set `showExpiredAnnotations: true` to keep). Per-band overrides via the options; pass `null` for a band to disable that default. Annotation `opacity` / `strokeDasharray` set explicitly on the annotation win over the treatment. Annotation renderer cascades both as SVG presentation attributes to every stroked / filled child.
+- Still owed (M3): stable-id anchor resolution after data refresh.
 
 ```ts
-import { withProvenance } from "semiotic/ai"
+import { withProvenance, applyAnnotationLifecycle } from "semiotic/ai"
 
 const ann = withProvenance(
-  { type: "y-threshold", value: 100, label: "SLA breach" },
+  { type: "y-threshold", value: 100, label: "SLA breach", color: "#3a8eff" },
   {
     provenance: { author: "alice", source: "user", createdAt: "2026-05-20T14:00:00Z" },
     lifecycle: { ttlHint: "P30D", anchor: "semantic" },
   },
 )
+
+// Pass through the lifecycle treatment before handing to a chart.
+<LineChart annotations={applyAnnotationLifecycle([ann], { dataExtent: [t0, tNow] })} />
 ```
+
+### Temporal lifecycle (shared between `semiotic/realtime` + `semiotic/ai`)
+Three Semiotic systems answer "how does this thing look as it ages?" with three different policies on three different time axes. They are *not* interchangeable — pick the one that matches the question.
+
+| Policy | Lives in | Time axis | Output | Scope |
+|---|---|---|---|---|
+| `DecayConfig` | `semiotic/realtime` | buffer position | continuous opacity ramp | per-datum |
+| `StalenessConfig` | `semiotic/realtime` | wall-clock idle | binary live/stale (+ optional badge) | chart-wide |
+| Annotation freshness | `semiotic/ai` | `createdAt` + `ttlHint` | 4 named bands (opacity + dashing + expired filter) | per-annotation |
+
+Shared primitive that bridges them: **`bandFromAge(ageMs, ttlMs, thresholds?)`** → `"fresh" | "aging" | "stale" | "expired"`. Pure function exported from both `semiotic/realtime` and `semiotic/ai`. `DEFAULT_LIFECYCLE_THRESHOLDS = { fresh: 1.0, aging: 1.5, stale: 3.0 }` (multipliers of TTL). Annotation freshness uses this primitive today; future banded-decay or banded-staleness opt-ins can plug into the same classifier.
+
+**Anchor mode** (`"fixed" | "latest" | "sticky" | "semantic"`) is also shared — `AnnotationAnchor` from `semiotic/realtime` is the canonical type, re-exported from `semiotic/ai` as `lifecycle.anchor`. `"semantic"` re-resolves via `provenance.stableId` (runtime support landing incrementally).
+
+**Streaming chart-time aging**: pass the chart's `dataExtent` to `applyAnnotationLifecycle` and the latest data point becomes the "now" reference. Annotations age against chart-time, not wall-clock — useful when streams pause or run slow. Pair with `withCurrentProvenance(annotation, { author?, source? })` or `currentTimestamp()` to auto-stamp `createdAt` at the moment of creation.
+
+```ts
+import { bandFromAge, withCurrentProvenance, applyAnnotationLifecycle } from "semiotic/ai"
+
+bandFromAge(20_000, 8000) // "stale" — age is 2.5× TTL
+
+const ann = withCurrentProvenance(
+  { type: "callout", t: latest.t, value: latest.value, label: "Spike" },
+  { author: "alice", source: "user" },
+)
+
+<LineChart
+  annotations={applyAnnotationLifecycle([ann], { dataExtent: [data[0].t, data.at(-1).t] })}
+/>
+```
+
+Full survey at `/intelligence/temporal-lifecycle`.
 
 ### Variant discovery (`semiotic/ai`)
 Interface for proposing and scoring chart variants beyond the hand-curated `capability.variants`. Heuristic and model-based proposers plug in through `registerVariantDiscovery`. M1 ships the type surface + stub implementations; behavior arrives in subsequent milestones.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -239,7 +239,7 @@ All HOCs accept `annotations` (array). Coordinates use data field names.
 **Ordinal**: `category-highlight`
 **Enclosures**: `enclose`, `rect-enclose`, `highlight`
 **Statistical**: `trend`, `envelope`, `anomaly-band`, `forecast`
-**Streaming anchors**: `"fixed"` | `"latest"` | `"sticky"`
+**Streaming anchors**: `"fixed"` | `"latest"` | `"sticky"` | `"semantic"` — also exposed as `lifecycle.anchor` on the `semiotic/ai` annotation lifecycle. Same `AnnotationAnchor` type either way; `"semantic"` re-resolves via `provenance.stableId` (runtime support landing incrementally).
 
 ## Theming
 
@@ -342,24 +342,62 @@ store.record({ type: "suggestion-shown", components: ["LineChart"], intent: "tre
 ```
 
 ### Annotation provenance + lifecycle (`semiotic/ai`, types also re-exported from `semiotic`)
-Type surface for "where did this annotation come from?" and "is it stale?" Optional blocks attached to any annotation — existing arrays keep working unchanged.
+Tracks "where did this annotation come from?" and "is it stale?" Two optional blocks attach to any annotation — existing arrays keep working unchanged.
 - **`provenance`**: `{ author?, source?, confidence?, createdAt?, stableId? }`. `source` is an open string union (`"user" | "ai" | "agent" | "import" | "computed" | "system" | (string & {})`).
 - **`lifecycle`**: `{ freshness?, ttlHint?, anchor? }`. `freshness` is `"fresh" | "aging" | "stale" | "expired"`. `anchor` is `"fixed" | "latest" | "sticky" | "semantic"`. `ttlHint` accepts an ISO 8601 duration string (`"P30D"`) or milliseconds.
 - **`withProvenance(annotation, { provenance?, lifecycle? })`** → returns a new annotation with the blocks attached. Pure, SSR-safe.
 - **`Annotated<T>`** type alias: `T & { provenance?, lifecycle? }`. Use for explicit typing.
-- Type surface only at this stage. Freshness computation, default visual treatment, and stable-id anchor resolution land later.
+- **`computeAnnotationFreshness(annotations, { now?, dataExtent?, thresholds? })`** → returns annotations with `lifecycle.freshness` populated based on `createdAt` + `ttlHint`. `now` defaults to `dataExtent`'s max, then `Date.now()`. Custom thresholds override the default 1× / 1.5× / 3× TTL breakpoints.
+- **`annotationFreshnessFor(annotation, nowMs, thresholds?)`** → classifies a single annotation. Honors any pre-existing `lifecycle.freshness` (explicit assignment wins).
+- **`applyAnnotationLifecycle(annotations, { now?, dataExtent?, opacity?, strokeDasharray?, labelSuffix?, showExpiredAnnotations?, thresholds? })`** → composes the freshness pass with a default visual treatment: aging dims (opacity 0.55), stale dims more + dashes (strokeDasharray `"4 4"`), expired is filtered out (set `showExpiredAnnotations: true` to keep). Per-band overrides via the options; pass `null` for a band to disable that default. Annotation `opacity` / `strokeDasharray` set explicitly on the annotation win over the treatment. Annotation renderer cascades both as SVG presentation attributes to every stroked / filled child.
+- Still owed (M3): stable-id anchor resolution after data refresh.
 
 ```ts
-import { withProvenance } from "semiotic/ai"
+import { withProvenance, applyAnnotationLifecycle } from "semiotic/ai"
 
 const ann = withProvenance(
-  { type: "y-threshold", value: 100, label: "SLA breach" },
+  { type: "y-threshold", value: 100, label: "SLA breach", color: "#3a8eff" },
   {
     provenance: { author: "alice", source: "user", createdAt: "2026-05-20T14:00:00Z" },
     lifecycle: { ttlHint: "P30D", anchor: "semantic" },
   },
 )
+
+// Pass through the lifecycle treatment before handing to a chart.
+<LineChart annotations={applyAnnotationLifecycle([ann], { dataExtent: [t0, tNow] })} />
 ```
+
+### Temporal lifecycle (shared between `semiotic/realtime` + `semiotic/ai`)
+Three Semiotic systems answer "how does this thing look as it ages?" with three different policies on three different time axes. They are *not* interchangeable — pick the one that matches the question.
+
+| Policy | Lives in | Time axis | Output | Scope |
+|---|---|---|---|---|
+| `DecayConfig` | `semiotic/realtime` | buffer position | continuous opacity ramp | per-datum |
+| `StalenessConfig` | `semiotic/realtime` | wall-clock idle | binary live/stale (+ optional badge) | chart-wide |
+| Annotation freshness | `semiotic/ai` | `createdAt` + `ttlHint` | 4 named bands (opacity + dashing + expired filter) | per-annotation |
+
+Shared primitive that bridges them: **`bandFromAge(ageMs, ttlMs, thresholds?)`** → `"fresh" | "aging" | "stale" | "expired"`. Pure function exported from both `semiotic/realtime` and `semiotic/ai`. `DEFAULT_LIFECYCLE_THRESHOLDS = { fresh: 1.0, aging: 1.5, stale: 3.0 }` (multipliers of TTL). Annotation freshness uses this primitive today; future banded-decay or banded-staleness opt-ins can plug into the same classifier.
+
+**Anchor mode** (`"fixed" | "latest" | "sticky" | "semantic"`) is also shared — `AnnotationAnchor` from `semiotic/realtime` is the canonical type, re-exported from `semiotic/ai` as `lifecycle.anchor`. `"semantic"` re-resolves via `provenance.stableId` (runtime support landing incrementally).
+
+**Streaming chart-time aging**: pass the chart's `dataExtent` to `applyAnnotationLifecycle` and the latest data point becomes the "now" reference. Annotations age against chart-time, not wall-clock — useful when streams pause or run slow. Pair with `withCurrentProvenance(annotation, { author?, source? })` or `currentTimestamp()` to auto-stamp `createdAt` at the moment of creation.
+
+```ts
+import { bandFromAge, withCurrentProvenance, applyAnnotationLifecycle } from "semiotic/ai"
+
+bandFromAge(20_000, 8000) // "stale" — age is 2.5× TTL
+
+const ann = withCurrentProvenance(
+  { type: "callout", t: latest.t, value: latest.value, label: "Spike" },
+  { author: "alice", source: "user" },
+)
+
+<LineChart
+  annotations={applyAnnotationLifecycle([ann], { dataExtent: [data[0].t, data.at(-1).t] })}
+/>
+```
+
+Full survey at `/intelligence/temporal-lifecycle`.
 
 ### Variant discovery (`semiotic/ai`)
 Interface for proposing and scoring chart variants beyond the hand-curated `capability.variants`. Heuristic and model-based proposers plug in through `registerVariantDiscovery`. M1 ships the type surface + stub implementations; behavior arrives in subsequent milestones.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -239,7 +239,7 @@ All HOCs accept `annotations` (array). Coordinates use data field names.
 **Ordinal**: `category-highlight`
 **Enclosures**: `enclose`, `rect-enclose`, `highlight`
 **Statistical**: `trend`, `envelope`, `anomaly-band`, `forecast`
-**Streaming anchors**: `"fixed"` | `"latest"` | `"sticky"`
+**Streaming anchors**: `"fixed"` | `"latest"` | `"sticky"` | `"semantic"` — also exposed as `lifecycle.anchor` on the `semiotic/ai` annotation lifecycle. Same `AnnotationAnchor` type either way; `"semantic"` re-resolves via `provenance.stableId` (runtime support landing incrementally).
 
 ## Theming
 
@@ -342,24 +342,62 @@ store.record({ type: "suggestion-shown", components: ["LineChart"], intent: "tre
 ```
 
 ### Annotation provenance + lifecycle (`semiotic/ai`, types also re-exported from `semiotic`)
-Type surface for "where did this annotation come from?" and "is it stale?" Optional blocks attached to any annotation — existing arrays keep working unchanged.
+Tracks "where did this annotation come from?" and "is it stale?" Two optional blocks attach to any annotation — existing arrays keep working unchanged.
 - **`provenance`**: `{ author?, source?, confidence?, createdAt?, stableId? }`. `source` is an open string union (`"user" | "ai" | "agent" | "import" | "computed" | "system" | (string & {})`).
 - **`lifecycle`**: `{ freshness?, ttlHint?, anchor? }`. `freshness` is `"fresh" | "aging" | "stale" | "expired"`. `anchor` is `"fixed" | "latest" | "sticky" | "semantic"`. `ttlHint` accepts an ISO 8601 duration string (`"P30D"`) or milliseconds.
 - **`withProvenance(annotation, { provenance?, lifecycle? })`** → returns a new annotation with the blocks attached. Pure, SSR-safe.
 - **`Annotated<T>`** type alias: `T & { provenance?, lifecycle? }`. Use for explicit typing.
-- Type surface only at this stage. Freshness computation, default visual treatment, and stable-id anchor resolution land later.
+- **`computeAnnotationFreshness(annotations, { now?, dataExtent?, thresholds? })`** → returns annotations with `lifecycle.freshness` populated based on `createdAt` + `ttlHint`. `now` defaults to `dataExtent`'s max, then `Date.now()`. Custom thresholds override the default 1× / 1.5× / 3× TTL breakpoints.
+- **`annotationFreshnessFor(annotation, nowMs, thresholds?)`** → classifies a single annotation. Honors any pre-existing `lifecycle.freshness` (explicit assignment wins).
+- **`applyAnnotationLifecycle(annotations, { now?, dataExtent?, opacity?, strokeDasharray?, labelSuffix?, showExpiredAnnotations?, thresholds? })`** → composes the freshness pass with a default visual treatment: aging dims (opacity 0.55), stale dims more + dashes (strokeDasharray `"4 4"`), expired is filtered out (set `showExpiredAnnotations: true` to keep). Per-band overrides via the options; pass `null` for a band to disable that default. Annotation `opacity` / `strokeDasharray` set explicitly on the annotation win over the treatment. Annotation renderer cascades both as SVG presentation attributes to every stroked / filled child.
+- Still owed (M3): stable-id anchor resolution after data refresh.
 
 ```ts
-import { withProvenance } from "semiotic/ai"
+import { withProvenance, applyAnnotationLifecycle } from "semiotic/ai"
 
 const ann = withProvenance(
-  { type: "y-threshold", value: 100, label: "SLA breach" },
+  { type: "y-threshold", value: 100, label: "SLA breach", color: "#3a8eff" },
   {
     provenance: { author: "alice", source: "user", createdAt: "2026-05-20T14:00:00Z" },
     lifecycle: { ttlHint: "P30D", anchor: "semantic" },
   },
 )
+
+// Pass through the lifecycle treatment before handing to a chart.
+<LineChart annotations={applyAnnotationLifecycle([ann], { dataExtent: [t0, tNow] })} />
 ```
+
+### Temporal lifecycle (shared between `semiotic/realtime` + `semiotic/ai`)
+Three Semiotic systems answer "how does this thing look as it ages?" with three different policies on three different time axes. They are *not* interchangeable — pick the one that matches the question.
+
+| Policy | Lives in | Time axis | Output | Scope |
+|---|---|---|---|---|
+| `DecayConfig` | `semiotic/realtime` | buffer position | continuous opacity ramp | per-datum |
+| `StalenessConfig` | `semiotic/realtime` | wall-clock idle | binary live/stale (+ optional badge) | chart-wide |
+| Annotation freshness | `semiotic/ai` | `createdAt` + `ttlHint` | 4 named bands (opacity + dashing + expired filter) | per-annotation |
+
+Shared primitive that bridges them: **`bandFromAge(ageMs, ttlMs, thresholds?)`** → `"fresh" | "aging" | "stale" | "expired"`. Pure function exported from both `semiotic/realtime` and `semiotic/ai`. `DEFAULT_LIFECYCLE_THRESHOLDS = { fresh: 1.0, aging: 1.5, stale: 3.0 }` (multipliers of TTL). Annotation freshness uses this primitive today; future banded-decay or banded-staleness opt-ins can plug into the same classifier.
+
+**Anchor mode** (`"fixed" | "latest" | "sticky" | "semantic"`) is also shared — `AnnotationAnchor` from `semiotic/realtime` is the canonical type, re-exported from `semiotic/ai` as `lifecycle.anchor`. `"semantic"` re-resolves via `provenance.stableId` (runtime support landing incrementally).
+
+**Streaming chart-time aging**: pass the chart's `dataExtent` to `applyAnnotationLifecycle` and the latest data point becomes the "now" reference. Annotations age against chart-time, not wall-clock — useful when streams pause or run slow. Pair with `withCurrentProvenance(annotation, { author?, source? })` or `currentTimestamp()` to auto-stamp `createdAt` at the moment of creation.
+
+```ts
+import { bandFromAge, withCurrentProvenance, applyAnnotationLifecycle } from "semiotic/ai"
+
+bandFromAge(20_000, 8000) // "stale" — age is 2.5× TTL
+
+const ann = withCurrentProvenance(
+  { type: "callout", t: latest.t, value: latest.value, label: "Spike" },
+  { author: "alice", source: "user" },
+)
+
+<LineChart
+  annotations={applyAnnotationLifecycle([ann], { dataExtent: [data[0].t, data.at(-1).t] })}
+/>
+```
+
+Full survey at `/intelligence/temporal-lifecycle`.
 
 ### Variant discovery (`semiotic/ai`)
 Interface for proposing and scoring chart variants beyond the hand-curated `capability.variants`. Heuristic and model-based proposers plug in through `registerVariantDiscovery`. M1 ships the type surface + stub implementations; behavior arrives in subsequent milestones.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,7 +239,7 @@ All HOCs accept `annotations` (array). Coordinates use data field names.
 **Ordinal**: `category-highlight`
 **Enclosures**: `enclose`, `rect-enclose`, `highlight`
 **Statistical**: `trend`, `envelope`, `anomaly-band`, `forecast`
-**Streaming anchors**: `"fixed"` | `"latest"` | `"sticky"`
+**Streaming anchors**: `"fixed"` | `"latest"` | `"sticky"` | `"semantic"` — also exposed as `lifecycle.anchor` on the `semiotic/ai` annotation lifecycle. Same `AnnotationAnchor` type either way; `"semantic"` re-resolves via `provenance.stableId` (runtime support landing incrementally).
 
 ## Theming
 
@@ -342,24 +342,62 @@ store.record({ type: "suggestion-shown", components: ["LineChart"], intent: "tre
 ```
 
 ### Annotation provenance + lifecycle (`semiotic/ai`, types also re-exported from `semiotic`)
-Type surface for "where did this annotation come from?" and "is it stale?" Optional blocks attached to any annotation — existing arrays keep working unchanged.
+Tracks "where did this annotation come from?" and "is it stale?" Two optional blocks attach to any annotation — existing arrays keep working unchanged.
 - **`provenance`**: `{ author?, source?, confidence?, createdAt?, stableId? }`. `source` is an open string union (`"user" | "ai" | "agent" | "import" | "computed" | "system" | (string & {})`).
 - **`lifecycle`**: `{ freshness?, ttlHint?, anchor? }`. `freshness` is `"fresh" | "aging" | "stale" | "expired"`. `anchor` is `"fixed" | "latest" | "sticky" | "semantic"`. `ttlHint` accepts an ISO 8601 duration string (`"P30D"`) or milliseconds.
 - **`withProvenance(annotation, { provenance?, lifecycle? })`** → returns a new annotation with the blocks attached. Pure, SSR-safe.
 - **`Annotated<T>`** type alias: `T & { provenance?, lifecycle? }`. Use for explicit typing.
-- Type surface only at this stage. Freshness computation, default visual treatment, and stable-id anchor resolution land later.
+- **`computeAnnotationFreshness(annotations, { now?, dataExtent?, thresholds? })`** → returns annotations with `lifecycle.freshness` populated based on `createdAt` + `ttlHint`. `now` defaults to `dataExtent`'s max, then `Date.now()`. Custom thresholds override the default 1× / 1.5× / 3× TTL breakpoints.
+- **`annotationFreshnessFor(annotation, nowMs, thresholds?)`** → classifies a single annotation. Honors any pre-existing `lifecycle.freshness` (explicit assignment wins).
+- **`applyAnnotationLifecycle(annotations, { now?, dataExtent?, opacity?, strokeDasharray?, labelSuffix?, showExpiredAnnotations?, thresholds? })`** → composes the freshness pass with a default visual treatment: aging dims (opacity 0.55), stale dims more + dashes (strokeDasharray `"4 4"`), expired is filtered out (set `showExpiredAnnotations: true` to keep). Per-band overrides via the options; pass `null` for a band to disable that default. Annotation `opacity` / `strokeDasharray` set explicitly on the annotation win over the treatment. Annotation renderer cascades both as SVG presentation attributes to every stroked / filled child.
+- Still owed (M3): stable-id anchor resolution after data refresh.
 
 ```ts
-import { withProvenance } from "semiotic/ai"
+import { withProvenance, applyAnnotationLifecycle } from "semiotic/ai"
 
 const ann = withProvenance(
-  { type: "y-threshold", value: 100, label: "SLA breach" },
+  { type: "y-threshold", value: 100, label: "SLA breach", color: "#3a8eff" },
   {
     provenance: { author: "alice", source: "user", createdAt: "2026-05-20T14:00:00Z" },
     lifecycle: { ttlHint: "P30D", anchor: "semantic" },
   },
 )
+
+// Pass through the lifecycle treatment before handing to a chart.
+<LineChart annotations={applyAnnotationLifecycle([ann], { dataExtent: [t0, tNow] })} />
 ```
+
+### Temporal lifecycle (shared between `semiotic/realtime` + `semiotic/ai`)
+Three Semiotic systems answer "how does this thing look as it ages?" with three different policies on three different time axes. They are *not* interchangeable — pick the one that matches the question.
+
+| Policy | Lives in | Time axis | Output | Scope |
+|---|---|---|---|---|
+| `DecayConfig` | `semiotic/realtime` | buffer position | continuous opacity ramp | per-datum |
+| `StalenessConfig` | `semiotic/realtime` | wall-clock idle | binary live/stale (+ optional badge) | chart-wide |
+| Annotation freshness | `semiotic/ai` | `createdAt` + `ttlHint` | 4 named bands (opacity + dashing + expired filter) | per-annotation |
+
+Shared primitive that bridges them: **`bandFromAge(ageMs, ttlMs, thresholds?)`** → `"fresh" | "aging" | "stale" | "expired"`. Pure function exported from both `semiotic/realtime` and `semiotic/ai`. `DEFAULT_LIFECYCLE_THRESHOLDS = { fresh: 1.0, aging: 1.5, stale: 3.0 }` (multipliers of TTL). Annotation freshness uses this primitive today; future banded-decay or banded-staleness opt-ins can plug into the same classifier.
+
+**Anchor mode** (`"fixed" | "latest" | "sticky" | "semantic"`) is also shared — `AnnotationAnchor` from `semiotic/realtime` is the canonical type, re-exported from `semiotic/ai` as `lifecycle.anchor`. `"semantic"` re-resolves via `provenance.stableId` (runtime support landing incrementally).
+
+**Streaming chart-time aging**: pass the chart's `dataExtent` to `applyAnnotationLifecycle` and the latest data point becomes the "now" reference. Annotations age against chart-time, not wall-clock — useful when streams pause or run slow. Pair with `withCurrentProvenance(annotation, { author?, source? })` or `currentTimestamp()` to auto-stamp `createdAt` at the moment of creation.
+
+```ts
+import { bandFromAge, withCurrentProvenance, applyAnnotationLifecycle } from "semiotic/ai"
+
+bandFromAge(20_000, 8000) // "stale" — age is 2.5× TTL
+
+const ann = withCurrentProvenance(
+  { type: "callout", t: latest.t, value: latest.value, label: "Spike" },
+  { author: "alice", source: "user" },
+)
+
+<LineChart
+  annotations={applyAnnotationLifecycle([ann], { dataExtent: [data[0].t, data.at(-1).t] })}
+/>
+```
+
+Full survey at `/intelligence/temporal-lifecycle`.
 
 ### Variant discovery (`semiotic/ai`)
 Interface for proposing and scoring chart variants beyond the hand-curated `capability.variants`. Heuristic and model-based proposers plug in through `registerVariantDiscovery`. M1 ships the type surface + stub implementations; behavior arrives in subsequent milestones.

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -239,7 +239,7 @@ All HOCs accept `annotations` (array). Coordinates use data field names.
 **Ordinal**: `category-highlight`
 **Enclosures**: `enclose`, `rect-enclose`, `highlight`
 **Statistical**: `trend`, `envelope`, `anomaly-band`, `forecast`
-**Streaming anchors**: `"fixed"` | `"latest"` | `"sticky"`
+**Streaming anchors**: `"fixed"` | `"latest"` | `"sticky"` | `"semantic"` — also exposed as `lifecycle.anchor` on the `semiotic/ai` annotation lifecycle. Same `AnnotationAnchor` type either way; `"semantic"` re-resolves via `provenance.stableId` (runtime support landing incrementally).
 
 ## Theming
 
@@ -342,24 +342,62 @@ store.record({ type: "suggestion-shown", components: ["LineChart"], intent: "tre
 ```
 
 ### Annotation provenance + lifecycle (`semiotic/ai`, types also re-exported from `semiotic`)
-Type surface for "where did this annotation come from?" and "is it stale?" Optional blocks attached to any annotation — existing arrays keep working unchanged.
+Tracks "where did this annotation come from?" and "is it stale?" Two optional blocks attach to any annotation — existing arrays keep working unchanged.
 - **`provenance`**: `{ author?, source?, confidence?, createdAt?, stableId? }`. `source` is an open string union (`"user" | "ai" | "agent" | "import" | "computed" | "system" | (string & {})`).
 - **`lifecycle`**: `{ freshness?, ttlHint?, anchor? }`. `freshness` is `"fresh" | "aging" | "stale" | "expired"`. `anchor` is `"fixed" | "latest" | "sticky" | "semantic"`. `ttlHint` accepts an ISO 8601 duration string (`"P30D"`) or milliseconds.
 - **`withProvenance(annotation, { provenance?, lifecycle? })`** → returns a new annotation with the blocks attached. Pure, SSR-safe.
 - **`Annotated<T>`** type alias: `T & { provenance?, lifecycle? }`. Use for explicit typing.
-- Type surface only at this stage. Freshness computation, default visual treatment, and stable-id anchor resolution land later.
+- **`computeAnnotationFreshness(annotations, { now?, dataExtent?, thresholds? })`** → returns annotations with `lifecycle.freshness` populated based on `createdAt` + `ttlHint`. `now` defaults to `dataExtent`'s max, then `Date.now()`. Custom thresholds override the default 1× / 1.5× / 3× TTL breakpoints.
+- **`annotationFreshnessFor(annotation, nowMs, thresholds?)`** → classifies a single annotation. Honors any pre-existing `lifecycle.freshness` (explicit assignment wins).
+- **`applyAnnotationLifecycle(annotations, { now?, dataExtent?, opacity?, strokeDasharray?, labelSuffix?, showExpiredAnnotations?, thresholds? })`** → composes the freshness pass with a default visual treatment: aging dims (opacity 0.55), stale dims more + dashes (strokeDasharray `"4 4"`), expired is filtered out (set `showExpiredAnnotations: true` to keep). Per-band overrides via the options; pass `null` for a band to disable that default. Annotation `opacity` / `strokeDasharray` set explicitly on the annotation win over the treatment. Annotation renderer cascades both as SVG presentation attributes to every stroked / filled child.
+- Still owed (M3): stable-id anchor resolution after data refresh.
 
 ```ts
-import { withProvenance } from "semiotic/ai"
+import { withProvenance, applyAnnotationLifecycle } from "semiotic/ai"
 
 const ann = withProvenance(
-  { type: "y-threshold", value: 100, label: "SLA breach" },
+  { type: "y-threshold", value: 100, label: "SLA breach", color: "#3a8eff" },
   {
     provenance: { author: "alice", source: "user", createdAt: "2026-05-20T14:00:00Z" },
     lifecycle: { ttlHint: "P30D", anchor: "semantic" },
   },
 )
+
+// Pass through the lifecycle treatment before handing to a chart.
+<LineChart annotations={applyAnnotationLifecycle([ann], { dataExtent: [t0, tNow] })} />
 ```
+
+### Temporal lifecycle (shared between `semiotic/realtime` + `semiotic/ai`)
+Three Semiotic systems answer "how does this thing look as it ages?" with three different policies on three different time axes. They are *not* interchangeable — pick the one that matches the question.
+
+| Policy | Lives in | Time axis | Output | Scope |
+|---|---|---|---|---|
+| `DecayConfig` | `semiotic/realtime` | buffer position | continuous opacity ramp | per-datum |
+| `StalenessConfig` | `semiotic/realtime` | wall-clock idle | binary live/stale (+ optional badge) | chart-wide |
+| Annotation freshness | `semiotic/ai` | `createdAt` + `ttlHint` | 4 named bands (opacity + dashing + expired filter) | per-annotation |
+
+Shared primitive that bridges them: **`bandFromAge(ageMs, ttlMs, thresholds?)`** → `"fresh" | "aging" | "stale" | "expired"`. Pure function exported from both `semiotic/realtime` and `semiotic/ai`. `DEFAULT_LIFECYCLE_THRESHOLDS = { fresh: 1.0, aging: 1.5, stale: 3.0 }` (multipliers of TTL). Annotation freshness uses this primitive today; future banded-decay or banded-staleness opt-ins can plug into the same classifier.
+
+**Anchor mode** (`"fixed" | "latest" | "sticky" | "semantic"`) is also shared — `AnnotationAnchor` from `semiotic/realtime` is the canonical type, re-exported from `semiotic/ai` as `lifecycle.anchor`. `"semantic"` re-resolves via `provenance.stableId` (runtime support landing incrementally).
+
+**Streaming chart-time aging**: pass the chart's `dataExtent` to `applyAnnotationLifecycle` and the latest data point becomes the "now" reference. Annotations age against chart-time, not wall-clock — useful when streams pause or run slow. Pair with `withCurrentProvenance(annotation, { author?, source? })` or `currentTimestamp()` to auto-stamp `createdAt` at the moment of creation.
+
+```ts
+import { bandFromAge, withCurrentProvenance, applyAnnotationLifecycle } from "semiotic/ai"
+
+bandFromAge(20_000, 8000) // "stale" — age is 2.5× TTL
+
+const ann = withCurrentProvenance(
+  { type: "callout", t: latest.t, value: latest.value, label: "Spike" },
+  { author: "alice", source: "user" },
+)
+
+<LineChart
+  annotations={applyAnnotationLifecycle([ann], { dataExtent: [data[0].t, data.at(-1).t] })}
+/>
+```
+
+Full survey at `/intelligence/temporal-lifecycle`.
 
 ### Variant discovery (`semiotic/ai`)
 Interface for proposing and scoring chart variants beyond the hand-curated `capability.variants`. Heuristic and model-based proposers plug in through `registerVariantDiscovery`. M1 ships the type surface + stub implementations; behavior arrives in subsequent milestones.

--- a/docs/src/App.js
+++ b/docs/src/App.js
@@ -97,6 +97,7 @@ import CapabilitiesPage from "./pages/features/CapabilitiesPage"
 import InterrogationPage from "./pages/features/InterrogationPage"
 import SuggestionsPage from "./pages/features/SuggestionsPage"
 import ConversationArcPage from "./pages/features/ConversationArcPage"
+import TemporalLifecyclePage from "./pages/features/TemporalLifecyclePage"
 
 // New cookbook pages
 import HomerunMapPage from "./pages/cookbook/HomerunMapPage"
@@ -401,6 +402,7 @@ export default function DocsApp() {
               <Route path="suggestions" element={<SuggestionsPage />} />
               <Route path="interrogation" element={<InterrogationPage />} />
               <Route path="conversation-arc" element={<ConversationArcPage />} />
+              <Route path="temporal-lifecycle" element={<TemporalLifecyclePage />} />
               <Route path="serialization" element={<SerializationPage />} />
               <Route path="vega-lite" element={<VegaLiteTranslatorPage />} />
             </Route>

--- a/docs/src/blog/entries/talk-track-intelligence.js
+++ b/docs/src/blog/entries/talk-track-intelligence.js
@@ -3,6 +3,8 @@ import React, { useEffect, useMemo, useRef, useState } from "react"
 import { Link } from "react-router-dom"
 import { CategoryColorProvider, DotPlot, LineChart } from "semiotic"
 import {
+  annotationFreshnessFor,
+  applyAnnotationLifecycle,
   disableConversationArc,
   enableConversationArc,
   getConversationArcStore,
@@ -267,12 +269,6 @@ const RAW_ANNOTATIONS = [
 ]
 
 const FRESHNESS_BASE_COLOR = { user: "#3a8eff", ai: "#d49a00" }
-const FRESHNESS_COLOR = {
-  fresh: (base) => base,
-  aging: () => "#8a96a3",
-  stale: () => "#b0b0b0",
-}
-const FRESHNESS_SUFFIX = { fresh: "", aging: " · aging", stale: " · stale" }
 const FRESHNESS_BADGE = {
   fresh: "#2d8a4a",
   aging: "#d49a00",
@@ -280,46 +276,25 @@ const FRESHNESS_BADGE = {
   expired: "#c43d3d",
 }
 
-function parseIsoDuration(s) {
-  const m = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?)?$/.exec(s)
-  if (!m) return 0
-  return (parseInt(m[1] || "0", 10) * 24 + parseInt(m[2] || "0", 10)) * 60 * 60 * 1000
-}
-
-function previewFreshness(ann, nowMs) {
-  const created = ann?.provenance?.createdAt ? Date.parse(ann.provenance.createdAt) : null
-  const ttl = ann?.lifecycle?.ttlHint
-  if (created == null || ttl == null) return "fresh"
-  const ms = typeof ttl === "number" ? ttl : parseIsoDuration(ttl)
-  const age = nowMs - created
-  if (age < ms) return "fresh"
-  if (age < ms * 1.5) return "aging"
-  if (age < ms * 3) return "stale"
-  return "expired"
-}
-
 function FreshnessLiveDemo() {
   const [nowIso, setNowIso] = useState("2026-03-10T00:00:00Z")
   const nowMs = Date.parse(nowIso)
 
-  const states = RAW_ANNOTATIONS.map((a) => ({
-    raw: a,
-    freshness: previewFreshness(a, nowMs),
+  // Each annotation keeps its author's brand color via `color`. The
+  // shipped applyAnnotationLifecycle treatment fills in opacity +
+  // strokeDasharray per band and drops expired ones.
+  const annotationsWithColor = RAW_ANNOTATIONS.map((a) => ({
+    ...a,
+    color: FRESHNESS_BASE_COLOR[a.provenance.source] ?? "#5a5a5a",
   }))
-
-  // Expired annotations drop out of the array — mirrors M2's default
-  // of hiding them unless `showExpiredAnnotations` is on.
-  const visible = states
-    .filter((s) => s.freshness !== "expired")
-    .map(({ raw, freshness }) => {
-      const base = FRESHNESS_BASE_COLOR[raw.provenance.source] ?? "#5a5a5a"
-      return {
-        ...raw,
-        label: raw.label + FRESHNESS_SUFFIX[freshness],
-        color: FRESHNESS_COLOR[freshness](base),
-        lifecycle: { ...raw.lifecycle, freshness },
-      }
-    })
+  const visible = applyAnnotationLifecycle(annotationsWithColor, {
+    now: nowMs,
+    labelSuffix: { aging: " · aging", stale: " · stale" },
+  })
+  const states = RAW_ANNOTATIONS.map((raw) => ({
+    raw,
+    freshness: annotationFreshnessFor(raw, nowMs),
+  }))
 
   return (
     <div style={card}>
@@ -493,9 +468,12 @@ function Body() {
       <FreshnessLiveDemo />
 
       <p>
-        The styling above is page-local — the M1 surface is type-only,
-        and the shipping <code style={inlineCode}>computeAnnotationFreshness</code>{" "}
-        helper plus the default visual treatment land next.
+        The styling above is the shipped default: a single call to{" "}
+        <code style={inlineCode}>applyAnnotationLifecycle(annotations, {"{ now }"})</code>{" "}
+        classifies each annotation, dims aging, dashes stale, and drops
+        expired from the array. The author's brand color survives the
+        treatment — provenance stays visible while age signals layer on
+        top.
       </p>
 
       <h2>Variants the library didn't think of</h2>

--- a/docs/src/components/navData.js
+++ b/docs/src/components/navData.js
@@ -130,6 +130,7 @@ const navData = [
       { title: "Chart Suggestions", path: "/intelligence/suggestions" },
       { title: "Interrogation", path: "/intelligence/interrogation" },
       { title: "Conversation Arc", path: "/intelligence/conversation-arc" },
+      { title: "Temporal Lifecycle", path: "/intelligence/temporal-lifecycle" },
       { title: "Serialization", path: "/intelligence/serialization" },
       { title: "Vega-Lite Translator", path: "/intelligence/vega-lite" }
     ]

--- a/docs/src/pages/features/ConversationArcPage.js
+++ b/docs/src/pages/features/ConversationArcPage.js
@@ -1,5 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react"
 import {
+  applyAnnotationLifecycle,
+  annotationFreshnessFor,
   disableConversationArc,
   enableConversationArc,
   getConversationArcStore,
@@ -151,10 +153,13 @@ function ArcDemo() {
   // for other consumers. Intentionally not `reset()` — that would wipe
   // listeners other parts of the app sharing the same store may have
   // attached.
-  useEffect(() => () => {
-    disableConversationArc()
-    store.clear()
-  }, [store])
+  useEffect(
+    () => () => {
+      disableConversationArc()
+      store.clear()
+    },
+    [store],
+  )
 
   const toggle = () => {
     if (enabled) {
@@ -178,15 +183,17 @@ function ArcDemo() {
   }
 
   return (
-    <div style={{
-      border: "1px solid var(--surface-3)",
-      borderRadius: 12,
-      padding: 20,
-      background: "var(--surface-1)",
-      display: "flex",
-      flexDirection: "column",
-      gap: 16,
-    }}>
+    <div
+      style={{
+        border: "1px solid var(--surface-3)",
+        borderRadius: 12,
+        padding: 20,
+        background: "var(--surface-1)",
+        display: "flex",
+        flexDirection: "column",
+        gap: 16,
+      }}
+    >
       <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
         <button
           onClick={toggle}
@@ -226,13 +233,15 @@ function ArcDemo() {
         </button>
       </div>
 
-      <div style={{
-        display: "flex",
-        flexWrap: "wrap",
-        gap: 6,
-        paddingBottom: 8,
-        borderBottom: "1px dashed var(--surface-3)",
-      }}>
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 6,
+          paddingBottom: 8,
+          borderBottom: "1px dashed var(--surface-3)",
+        }}
+      >
         {EVENT_PRESETS.map((preset) => (
           <button
             key={preset.type}
@@ -270,7 +279,14 @@ function ArcDemo() {
           title="Events over time"
           summary="Horizontal dot plot. Each dot is a recorded conversation-arc event placed at its timestamp on the x-axis and its event type on the y-axis. Colors match the event-type buttons above."
           emptyContent={
-            <div style={{ color: "var(--text-secondary)", fontSize: 13, padding: "40px 0", textAlign: "center" }}>
+            <div
+              style={{
+                color: "var(--text-secondary)",
+                fontSize: 13,
+                padding: "40px 0",
+                textAlign: "center",
+              }}
+            >
               {enabled
                 ? "Click an event button above — dots will arrive via the DotPlot push API."
                 : "Enable recording, then click an event button to drop dots onto the chart."}
@@ -279,15 +295,17 @@ function ArcDemo() {
         />
       </CategoryColorProvider>
 
-      <div style={{
-        maxHeight: 220,
-        overflowY: "auto",
-        background: "var(--surface-2)",
-        padding: 10,
-        borderRadius: 8,
-        fontFamily: "var(--semiotic-font-family-mono, ui-monospace, monospace)",
-        fontSize: 12,
-      }}>
+      <div
+        style={{
+          maxHeight: 220,
+          overflowY: "auto",
+          background: "var(--surface-2)",
+          padding: 10,
+          borderRadius: 8,
+          fontFamily: "var(--semiotic-font-family-mono, ui-monospace, monospace)",
+          fontSize: 12,
+        }}
+      >
         {events.length === 0 && (
           <div style={{ color: "var(--text-secondary)", fontStyle: "italic" }}>
             {enabled
@@ -295,39 +313,42 @@ function ArcDemo() {
               : "Recording is off. Click ‘Enable recording’ to start a session."}
           </div>
         )}
-        {events.slice().reverse().map((event, i) => (
-          <div
-            key={`${event.timestamp}-${i}`}
-            style={{
-              display: "flex",
-              gap: 8,
-              padding: "4px 0",
-              borderBottom: "1px dotted var(--surface-3)",
-            }}
-          >
-            <span style={{ color: "var(--text-secondary)" }}>
-              {new Date(event.timestamp).toLocaleTimeString()}
-            </span>
-            <span
+        {events
+          .slice()
+          .reverse()
+          .map((event, i) => (
+            <div
+              key={`${event.timestamp}-${i}`}
               style={{
-                color: TYPE_COLORS[event.type],
-                fontWeight: 600,
-                minWidth: 150,
+                display: "flex",
+                gap: 8,
+                padding: "4px 0",
+                borderBottom: "1px dotted var(--surface-3)",
               }}
             >
-              {event.type}
-            </span>
-            <span style={{ color: "var(--text)" }}>
-              {JSON.stringify(
-                Object.fromEntries(
-                  Object.entries(event).filter(
-                    ([k]) => k !== "type" && k !== "timestamp" && k !== "sessionId"
-                  )
-                )
-              )}
-            </span>
-          </div>
-        ))}
+              <span style={{ color: "var(--text-secondary)" }}>
+                {new Date(event.timestamp).toLocaleTimeString()}
+              </span>
+              <span
+                style={{
+                  color: TYPE_COLORS[event.type],
+                  fontWeight: 600,
+                  minWidth: 150,
+                }}
+              >
+                {event.type}
+              </span>
+              <span style={{ color: "var(--text)" }}>
+                {JSON.stringify(
+                  Object.fromEntries(
+                    Object.entries(event).filter(
+                      ([k]) => k !== "type" && k !== "timestamp" && k !== "sessionId",
+                    ),
+                  ),
+                )}
+              </span>
+            </div>
+          ))}
       </div>
     </div>
   )
@@ -357,7 +378,7 @@ const ANNOTATIONS_RAW = [
         createdAt: "2026-02-15T12:00:00Z",
       },
       lifecycle: { ttlHint: "P30D", anchor: "semantic" },
-    }
+    },
   ),
   withProvenance(
     {
@@ -378,51 +399,17 @@ const ANNOTATIONS_RAW = [
         createdAt: "2026-03-10T09:00:00Z",
       },
       lifecycle: { ttlHint: "P14D", anchor: "fixed" },
-    }
+    },
   ),
 ]
 
-// Stand-in for the M2 `computeAnnotationFreshness` helper. The page-level
-// scrubber re-runs this on each "now" change so readers see annotations
-// drift through fresh → aging → stale → expired.
-function computeFreshnessPreview(ann, nowMs) {
-  const created = ann?.provenance?.createdAt ? Date.parse(ann.provenance.createdAt) : null
-  const ttl = ann?.lifecycle?.ttlHint
-  if (created == null || ttl == null) return "fresh"
-  const ms = typeof ttl === "number" ? ttl : parseIsoDuration(ttl)
-  const age = nowMs - created
-  if (age < ms) return "fresh"
-  if (age < ms * 1.5) return "aging"
-  if (age < ms * 3) return "stale"
-  return "expired"
-}
-
-function parseIsoDuration(s) {
-  const m = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?)?$/.exec(s)
-  if (!m) return 0
-  const days = parseInt(m[1] || "0", 10)
-  const hours = parseInt(m[2] || "0", 10)
-  return ((days * 24 + hours) * 60 * 60 * 1000)
-}
-
-// Per-source brand color. Freshness shifts THIS color toward gray.
-// The annotation renderer reads `color` for both text fill + connector
-// stroke, so this single field drives the whole visual treatment.
+// Per-source brand color flows through `color` on each annotation.
+// applyAnnotationLifecycle handles the opacity + dashing per band, so
+// freshness fades the annotations toward the page background while
+// the author's brand color stays as the identity cue.
 const SOURCE_BASE_COLOR = {
   user: "#3a8eff",
   ai: "#d49a00",
-}
-
-const COLOR_BY_FRESHNESS = {
-  fresh: (base) => base,
-  aging: () => "#8a96a3",
-  stale: () => "#b0b0b0",
-}
-
-const LABEL_SUFFIX = {
-  fresh: "",
-  aging: " · aging",
-  stale: " · stale",
 }
 
 const FRESHNESS_BADGE_COLOR = {
@@ -437,11 +424,11 @@ const FRESHNESS_BADGE_COLOR = {
 const SAMPLE_DATA = [
   { month: 1, value: 280 },
   { month: 2, value: 310 },
-  { month: 3, value: 420 },  // alice's spike
+  { month: 3, value: 420 }, // alice's spike
   { month: 4, value: 350 },
   { month: 5, value: 360 },
   { month: 6, value: 370 },
-  { month: 7, value: 510 },  // AI's anomaly
+  { month: 7, value: 510 }, // AI's anomaly
   { month: 8, value: 390 },
   { month: 9, value: 400 },
   { month: 10, value: 420 },
@@ -456,36 +443,38 @@ function FreshnessDemo() {
   const [nowIso, setNowIso] = useState("2026-03-10T00:00:00Z")
   const nowMs = Date.parse(nowIso)
 
-  // Compute freshness state for each raw annotation. Expired ones drop
-  // out of the chart-bound array entirely — mirrors M2's default of
-  // hiding expired notes unless `showExpiredAnnotations` is on.
-  const states = ANNOTATIONS_RAW.map((a) => ({
-    raw: a,
-    freshness: computeFreshnessPreview(a, nowMs),
+  // Each annotation keeps its author's brand color via `color`. The
+  // freshness treatment fills in opacity + strokeDasharray per band
+  // and drops expired ones — same algorithm the library ships.
+  const annotationsWithColor = ANNOTATIONS_RAW.map((a) => ({
+    ...a,
+    color: SOURCE_BASE_COLOR[a.provenance.source] ?? "#5a5a5a",
   }))
 
-  const visibleAnnotations = states
-    .filter((s) => s.freshness !== "expired")
-    .map(({ raw, freshness }) => {
-      const base = SOURCE_BASE_COLOR[raw.provenance.source] ?? "#5a5a5a"
-      return {
-        ...raw,
-        label: raw.label + LABEL_SUFFIX[freshness],
-        color: COLOR_BY_FRESHNESS[freshness](base),
-        lifecycle: { ...raw.lifecycle, freshness },
-      }
-    })
+  const visibleAnnotations = applyAnnotationLifecycle(annotationsWithColor, {
+    now: nowMs,
+    labelSuffix: { aging: " · aging", stale: " · stale" },
+  })
+
+  // Per-annotation status for the panel below the chart — uses the
+  // same classifier the chart is using.
+  const states = ANNOTATIONS_RAW.map((raw) => ({
+    raw,
+    freshness: annotationFreshnessFor(raw, nowMs),
+  }))
 
   return (
-    <div style={{
-      border: "1px solid var(--surface-3)",
-      borderRadius: 12,
-      padding: 20,
-      background: "var(--surface-1)",
-      display: "flex",
-      flexDirection: "column",
-      gap: 16,
-    }}>
+    <div
+      style={{
+        border: "1px solid var(--surface-3)",
+        borderRadius: 12,
+        padding: 20,
+        background: "var(--surface-1)",
+        display: "flex",
+        flexDirection: "column",
+        gap: 16,
+      }}
+    >
       <LineChart
         data={SAMPLE_DATA}
         xAccessor="month"
@@ -498,7 +487,14 @@ function FreshnessDemo() {
       />
 
       <div>
-        <label style={{ display: "block", fontSize: 13, color: "var(--text-secondary)", marginBottom: 4 }}>
+        <label
+          style={{
+            display: "block",
+            fontSize: 13,
+            color: "var(--text-secondary)",
+            marginBottom: 4,
+          }}
+        >
           Pretend "now" is <code style={{ fontSize: 13 }}>{nowIso.slice(0, 10)}</code>
         </label>
         <input
@@ -528,20 +524,33 @@ function FreshnessDemo() {
                 opacity: freshness === "expired" ? 0.55 : 1,
               }}
             >
-              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 4, gap: 8 }}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  marginBottom: 4,
+                  gap: 8,
+                }}
+              >
                 <strong style={{ fontSize: 13 }}>{raw.label}</strong>
-                <span style={{
-                  background: FRESHNESS_BADGE_COLOR[freshness],
-                  color: "white",
-                  padding: "1px 8px",
-                  borderRadius: 999,
-                  fontSize: 11,
-                  fontWeight: 600,
-                }}>{freshness}</span>
+                <span
+                  style={{
+                    background: FRESHNESS_BADGE_COLOR[freshness],
+                    color: "white",
+                    padding: "1px 8px",
+                    borderRadius: 999,
+                    fontSize: 11,
+                    fontWeight: 600,
+                  }}
+                >
+                  {freshness}
+                </span>
               </div>
               <div style={{ color: "var(--text-secondary)" }}>
                 by <code>{raw.provenance.author}</code>
-                {" · "}{ageDays} day{ageDays === 1 ? "" : "s"} old
+                {" · "}
+                {ageDays} day{ageDays === 1 ? "" : "s"} old
                 {" · "}TTL <code>{raw.lifecycle.ttlHint}</code>
               </div>
               {freshness === "expired" && (
@@ -555,13 +564,15 @@ function FreshnessDemo() {
       </div>
 
       <p style={{ fontSize: 12, color: "var(--text-secondary)", margin: 0 }}>
-        Drag the slider forward in time. The annotations' colors and
-        labels shift through <code>fresh → aging → stale</code>, then
-        disappear once they hit <code>expired</code>. The freshness
-        calculation here is a page-local stand-in — the shipping
-        <code>computeAnnotationFreshness</code> helper and default
-        visual treatment land in M2. The annotation data itself uses
-        the M1 provenance + lifecycle blocks verbatim.
+        Drag the slider forward in time. Annotations dim through{" "}
+        <code>fresh → aging → stale</code>, take on a dashed border at{" "}
+        <code>stale</code>, then disappear once they hit{" "}
+        <code>expired</code>. The chart is calling{" "}
+        <code>applyAnnotationLifecycle(annotations, {"{ now }"})</code>{" "}
+        directly — the shipping helper handles freshness, opacity,
+        dashing, and the expired filter; pass{" "}
+        <code>showExpiredAnnotations: true</code> to keep expired
+        annotations visible.
       </p>
     </div>
   )
@@ -578,44 +589,55 @@ export default function ConversationArcPage() {
         { label: "Conversation Arc", path: "/intelligence/conversation-arc" },
       ]}
       prevPage={{ title: "Interrogation", path: "/intelligence/interrogation" }}
-      nextPage={{ title: "Serialization", path: "/intelligence/serialization" }}
+      nextPage={{ title: "Temporal Lifecycle", path: "/intelligence/temporal-lifecycle" }}
     >
       <p>
-        AI-assisted chart authoring is a session, not a one-shot call. Users
-        see suggestions, pick one, refine the audience, render, edit, replace,
-        export — or abandon. Semiotic gives that arc structure with three
-        composable surfaces that ship together in 3.5.x:
+        AI-assisted chart authoring is a session, not a one-shot call. Users see suggestions, pick
+        one, refine the audience, render, edit, replace, export — or abandon. Semiotic gives that
+        arc structure with three composable surfaces:
       </p>
       <ul>
-        <li><strong>Conversation-arc telemetry</strong> — an opt-in event store recording the arc itself.</li>
-        <li><strong>Annotation provenance + lifecycle</strong> — every annotation can carry origin, confidence, and freshness.</li>
-        <li><strong>Variant discovery</strong> — an interface for proposing chart variants outside the hand-curated capability registry.</li>
+        <li>
+          <strong>Conversation-arc telemetry</strong> — an opt-in event store recording the arc
+          itself.
+        </li>
+        <li>
+          <strong>Annotation provenance + lifecycle</strong> — every annotation can carry origin,
+          confidence, and freshness.
+        </li>
+        <li>
+          <strong>Variant discovery</strong> — an interface for proposing chart variants outside the
+          hand-curated capability registry.
+        </li>
       </ul>
       <p>
-        These are the talk-readiness M1 deliverables in the roadmap. M2–M4
-        will fill in heuristic implementations and runtime helpers. The
-        type surface lands today.
+        These ship together in 3.5.x. Annotation freshness and the
+        default visual treatment are live (the demo below uses them
+        directly). The conversation-arc store is functional; full
+        sink/persistence helpers and the <code>useConversationArc</code>
+        hook arrive incrementally. Variant discovery's plug point is
+        callable today; the built-in heuristic proposer and scorer
+        arrive in subsequent passes.
       </p>
 
       <h2>Conversation-arc telemetry</h2>
       <p>
-        <code>enableConversationArc()</code> turns on a module-scoped ring
-        buffer that records the arc of an AI-assisted session. Default
-        surface is a no-op so the import is zero-cost when telemetry is off.
+        <code>enableConversationArc()</code> turns on a module-scoped ring buffer that records the
+        arc of an AI-assisted session. Default surface is a no-op so the import is zero-cost when
+        telemetry is off.
       </p>
 
       <h3>Interactive demo</h3>
       <p>
-        Enable recording, fire some events, and watch the live store. Each
-        click below calls <code>store.record(...)</code>. The event log is
-        driven by a real subscriber on the real store — not a re-render of
-        local state.
+        Enable recording, fire some events, and watch the live store. Each click below calls{" "}
+        <code>store.record(...)</code>. The event log is driven by a real subscriber on the real
+        store — not a re-render of local state.
       </p>
       <ArcDemo />
 
       <h3>Wiring</h3>
       <CodeBlock language="jsx">
-{`import {
+        {`import {
   enableConversationArc,
   disableConversationArc,
   getConversationArcStore,
@@ -648,39 +670,36 @@ const allEvents = store.flush()`}
       <h3>Event vocabulary</h3>
       <p>
         Eight variants in a discriminated union: <code>suggestion-shown</code>,{" "}
-        <code>suggestion-chosen</code>, <code>audience-set</code>,{" "}
-        <code>chart-rendered</code>, <code>chart-edited</code>,{" "}
-        <code>chart-replaced</code>, <code>chart-exported</code>,{" "}
-        <code>chart-abandoned</code>. Each carries the fields a downstream
-        analytics or replay system would actually consume (component name,
-        rank, format, reason). The <code>arcId</code> field threads multiple
-        events into a single named arc when you need it.
+        <code>suggestion-chosen</code>, <code>audience-set</code>, <code>chart-rendered</code>,{" "}
+        <code>chart-edited</code>, <code>chart-replaced</code>, <code>chart-exported</code>,{" "}
+        <code>chart-abandoned</code>. Each carries the fields a downstream analytics or replay
+        system would actually consume (component name, rank, format, reason). The <code>arcId</code>{" "}
+        field threads multiple events into a single named arc when you need it.
       </p>
 
       <h2>Annotation provenance + lifecycle</h2>
       <p>
-        Anchored conversations stay defensible when every annotation knows
-        where it came from and when it should be considered stale. The
-        M1 surface attaches two optional blocks to any annotation:{" "}
-        <code>provenance</code> ({" "}
-        <code>author</code>, <code>source</code>, <code>confidence</code>,{" "}
-        <code>createdAt</code>, <code>stableId</code>) and{" "}
-        <code>lifecycle</code> (<code>freshness</code>, <code>ttlHint</code>,{" "}
-        <code>anchor</code>).
+        Anchored conversations stay defensible when every annotation knows where it came from and
+        when it should be considered stale. Two optional blocks attach to any annotation:{" "}
+        <code>provenance</code> ( <code>author</code>, <code>source</code>,{" "}
+        <code>confidence</code>, <code>createdAt</code>, <code>stableId</code>) and{" "}
+        <code>lifecycle</code> (<code>freshness</code>, <code>ttlHint</code>, <code>anchor</code>).
+        <code>computeAnnotationFreshness</code> classifies each annotation into a band;{" "}
+        <code>applyAnnotationLifecycle</code> additionally applies a default visual treatment
+        (opacity for aging, dashing for stale, hiding for expired).
       </p>
 
       <h3>Lifecycle scrubber</h3>
       <p>
-        The chart below carries two annotations — one from a user with a
-        30-day TTL, one from an AI with a 14-day TTL and lower confidence.
-        Drag the slider to advance "now" and watch them drift through{" "}
-        <code>fresh → aging → stale → expired</code>:
+        The chart below carries two annotations — one from a user with a 30-day TTL, one from an AI
+        with a 14-day TTL and lower confidence. Drag the slider to advance "now" and watch them
+        drift through <code>fresh → aging → stale → expired</code>:
       </p>
       <FreshnessDemo />
 
       <h3>Attaching provenance</h3>
       <CodeBlock language="ts">
-{`import { withProvenance } from "semiotic/ai"
+        {`import { withProvenance } from "semiotic/ai"
 
 const ann = withProvenance(
   { type: "y-threshold", value: 100, label: "SLA breach" },
@@ -697,25 +716,23 @@ const ann = withProvenance(
       </CodeBlock>
 
       <p>
-        The anchor mode matters when data refreshes. <code>"fixed"</code>{" "}
-        keeps the recorded coordinate verbatim; <code>"latest"</code>{" "}
-        re-pins to the most recent data point; <code>"sticky"</code>{" "}
-        rides forward until removed (the existing streaming behavior);{" "}
-        <code>"semantic"</code> re-resolves via <code>stableId</code> when
-        new data arrives — that's the M3 anchor-resolution algorithm.
+        The anchor mode matters when data refreshes. <code>"fixed"</code> keeps the recorded
+        coordinate verbatim; <code>"latest"</code> re-pins to the most recent data point;{" "}
+        <code>"sticky"</code> rides forward until removed (the existing streaming behavior);{" "}
+        <code>"semantic"</code> re-resolves via <code>stableId</code> when new data arrives — that's
+        the M3 anchor-resolution algorithm.
       </p>
 
       <h2>Variant discovery</h2>
       <p>
-        Hand-curated <code>capability.variants</code> are bounded by what
-        humans wrote. Variant discovery is the API surface for proposing
-        configurations the registry doesn't include — from heuristic
-        walkers, LLM agents, or future ML models — and scoring them with
-        the same rubric the built-in suggester uses.
+        Hand-curated <code>capability.variants</code> are bounded by what humans wrote. Variant
+        discovery is the API surface for proposing configurations the registry doesn't include —
+        from heuristic walkers, LLM agents, or future ML models — and scoring them with the same
+        rubric the built-in suggester uses.
       </p>
 
       <CodeBlock language="ts">
-{`import {
+        {`import {
   proposeVariant,
   evaluateVariantProposal,
   registerVariantDiscovery,
@@ -748,20 +765,18 @@ const scores = proposals.map((p) => evaluateVariantProposal(p, profile))`}
       </CodeBlock>
 
       <p>
-        At M1, <code>proposeVariant</code> and{" "}
-        <code>evaluateVariantProposal</code> are stubs — they return empty
-        proposals and a neutral baseline score. The point is the contract:{" "}
-        <code>VariantProposal</code> and <code>VariantScore</code> are
-        stable shapes consumers can wire end-to-end today. Heuristic
-        proposal lands in M2; scoring + the MCP{" "}
+        At M1, <code>proposeVariant</code> and <code>evaluateVariantProposal</code> are stubs — they
+        return empty proposals and a neutral baseline score. The point is the contract:{" "}
+        <code>VariantProposal</code> and <code>VariantScore</code> are stable shapes consumers can
+        wire end-to-end today. Heuristic proposal lands in M2; scoring + the MCP{" "}
         <code>proposeChartVariants</code> tool land in M3.
       </p>
 
       <h2>Why these three together</h2>
       <p>
-        The arc records what happened. The annotations preserve what the
-        user said about it. Variant discovery keeps the system honest about
-        what it doesn't yet know — and where the learning slots in.
+        The arc records what happened. The annotations preserve what the user said about it. Variant
+        discovery keeps the system honest about what it doesn't yet know — and where the learning
+        slots in.
       </p>
     </PageLayout>
   )

--- a/docs/src/pages/features/SerializationPage.js
+++ b/docs/src/pages/features/SerializationPage.js
@@ -311,7 +311,7 @@ export default function SerializationPage() {
         { label: "Intelligence", path: "/intelligence" },
         { label: "Serialization", path: "/intelligence/serialization" },
       ]}
-      prevPage={{ title: "Conversation Arc", path: "/intelligence/conversation-arc" }}
+      prevPage={{ title: "Temporal Lifecycle", path: "/intelligence/temporal-lifecycle" }}
       nextPage={{ title: "Vega-Lite Translator", path: "/intelligence/vega-lite" }}
     >
       <p>

--- a/docs/src/pages/features/TemporalLifecyclePage.js
+++ b/docs/src/pages/features/TemporalLifecyclePage.js
@@ -1,0 +1,416 @@
+import React, { useEffect, useMemo, useRef, useState } from "react"
+import { Link } from "react-router-dom"
+import { LineChart } from "semiotic"
+import {
+  applyAnnotationLifecycle,
+  bandFromAge,
+  currentTimestamp,
+  withCurrentProvenance,
+} from "semiotic/ai"
+import PageLayout from "../../components/PageLayout"
+import CodeBlock from "../../components/CodeBlock"
+
+// ── Live "now" scrubber demo using the shared bandFromAge primitive ──
+
+const TTL_MS = 8000 // 8 seconds — small so the bands change in real time
+const TIMELINE_END = TTL_MS * 3.5
+
+const BAND_COLOR = {
+  fresh: "#3a8eff",
+  aging: "#d49a00",
+  stale: "#9aa0a6",
+  expired: "#c43d3d",
+}
+
+function BandScrubber() {
+  const [ageMs, setAgeMs] = useState(0)
+  const band = bandFromAge(ageMs, TTL_MS)
+
+  return (
+    <div style={{
+      border: "1px solid var(--surface-3)",
+      borderRadius: 12,
+      padding: 20,
+      background: "var(--surface-1)",
+      display: "flex",
+      flexDirection: "column",
+      gap: 14,
+    }}>
+      <div style={{
+        height: 60,
+        position: "relative",
+        background: "var(--surface-2)",
+        borderRadius: 8,
+        overflow: "hidden",
+      }}>
+        {/* Visual bands behind the slider */}
+        {["fresh", "aging", "stale", "expired"].map((name, i, all) => {
+          const left = i === 0 ? 0 : (i === 1 ? TTL_MS : i === 2 ? TTL_MS * 1.5 : TTL_MS * 3)
+          const right = i === 0 ? TTL_MS : i === 1 ? TTL_MS * 1.5 : i === 2 ? TTL_MS * 3 : TIMELINE_END
+          const widthPct = ((right - left) / TIMELINE_END) * 100
+          const leftPct = (left / TIMELINE_END) * 100
+          return (
+            <div
+              key={name}
+              style={{
+                position: "absolute",
+                left: `${leftPct}%`,
+                width: `${widthPct}%`,
+                top: 0,
+                bottom: 0,
+                background: BAND_COLOR[name],
+                opacity: name === band ? 0.85 : 0.18,
+                transition: "opacity 200ms",
+              }}
+            >
+              <span style={{
+                position: "absolute",
+                top: 4,
+                left: 6,
+                color: name === band ? "white" : "var(--text-secondary)",
+                fontSize: 11,
+                fontWeight: 600,
+                textTransform: "uppercase",
+                letterSpacing: "0.04em",
+              }}>{name}</span>
+            </div>
+          )
+        })}
+        {/* The pointer */}
+        <div style={{
+          position: "absolute",
+          left: `${(ageMs / TIMELINE_END) * 100}%`,
+          top: 0,
+          bottom: 0,
+          width: 2,
+          background: "white",
+          boxShadow: "0 0 0 1px rgba(0,0,0,0.5)",
+        }} />
+      </div>
+      <input
+        type="range"
+        min={0}
+        max={TIMELINE_END}
+        step={100}
+        value={ageMs}
+        onChange={(e) => setAgeMs(parseInt(e.target.value, 10))}
+        style={{ width: "100%" }}
+      />
+      <div style={{ fontSize: 13, color: "var(--text-secondary)", display: "flex", justifyContent: "space-between" }}>
+        <span>age: <code>{(ageMs / 1000).toFixed(1)}s</code></span>
+        <span>TTL: <code>{(TTL_MS / 1000).toFixed(0)}s</code></span>
+        <span>band: <strong style={{ color: BAND_COLOR[band] }}>{band}</strong></span>
+      </div>
+    </div>
+  )
+}
+
+// ── Live streaming demo: data-driven aging via dataExtent ────────────
+
+const STREAM_TICK = 1500 // ms between data points
+const STREAM_WINDOW = 12
+
+function StreamingAgingDemo() {
+  const [data, setData] = useState(() => [{ t: 0, value: 50, annotated: false }])
+  const [annotation, setAnnotation] = useState(null)
+  const tickRef = useRef(0)
+  const playingRef = useRef(true)
+  const [playing, setPlaying] = useState(true)
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (!playingRef.current) return
+      tickRef.current++
+      const t = tickRef.current
+      const value = 50 + Math.sin(t * 0.4) * 18 + (Math.random() - 0.5) * 10
+      setData((prev) => {
+        const next = [...prev, { t, value }]
+        return next.length > STREAM_WINDOW ? next.slice(-STREAM_WINDOW) : next
+      })
+    }, STREAM_TICK)
+    return () => clearInterval(interval)
+  }, [])
+
+  const togglePlay = () => {
+    playingRef.current = !playingRef.current
+    setPlaying(playingRef.current)
+  }
+
+  const markLatest = () => {
+    const latest = data[data.length - 1]
+    if (!latest) return
+    setAnnotation(
+      withCurrentProvenance(
+        {
+          type: "callout",
+          t: latest.t,
+          value: latest.value,
+          label: "Marked here",
+          dx: -40,
+          dy: -45,
+        },
+        { author: "you", source: "user" }
+      )
+    )
+  }
+
+  // The chart's data extent IS the chart's clock. applyAnnotationLifecycle
+  // picks the latest data point as "now" — annotations created against
+  // earlier data points age automatically as the stream advances.
+  const dataExtent = data.length
+    ? [Date.parse(data[0].timestamp ?? new Date().toISOString()), Date.now()]
+    : [Date.now(), Date.now()]
+  const annotated = annotation
+    ? applyAnnotationLifecycle([annotation], {
+        // Tiny TTL so the demo can show aging in real time.
+        thresholds: { fresh: 1, aging: 1.5, stale: 3 },
+      })
+    : []
+
+  return (
+    <div style={{
+      border: "1px solid var(--surface-3)",
+      borderRadius: 12,
+      padding: 20,
+      background: "var(--surface-1)",
+      display: "flex",
+      flexDirection: "column",
+      gap: 12,
+    }}>
+      <LineChart
+        data={data}
+        xAccessor="t"
+        yAccessor="value"
+        title="Streaming chart with auto-aging annotation"
+        height={260}
+        showPoints
+        annotations={annotated}
+        margin={{ top: 24, right: 24, bottom: 36, left: 48 }}
+      />
+      <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
+        <button
+          onClick={togglePlay}
+          style={{
+            padding: "5px 12px",
+            borderRadius: 14,
+            background: playing ? "#2d8a4a" : "var(--accent)",
+            color: "white",
+            border: "none",
+            cursor: "pointer",
+          }}
+        >
+          {playing ? "Pause stream" : "Resume stream"}
+        </button>
+        <button
+          onClick={markLatest}
+          style={{
+            padding: "5px 12px",
+            borderRadius: 14,
+            background: "var(--accent)",
+            color: "white",
+            border: "none",
+            cursor: "pointer",
+          }}
+        >
+          Mark latest point
+        </button>
+        {annotation && (
+          <button
+            onClick={() => setAnnotation(null)}
+            style={{
+              padding: "5px 12px",
+              borderRadius: 14,
+              background: "var(--surface-2)",
+              color: "var(--text)",
+              border: "1px solid var(--surface-3)",
+              cursor: "pointer",
+              fontSize: 12,
+            }}
+          >
+            Clear annotation
+          </button>
+        )}
+      </div>
+      <p style={{ fontSize: 12, color: "var(--text-secondary)", margin: 0 }}>
+        Stamp the latest point, then let the stream run. The annotation
+        was created with <code>withCurrentProvenance</code> — once it
+        falls outside the chart's data window plus a few seconds, the
+        lifecycle treatment dims it, then dashes it, then drops it.
+      </p>
+    </div>
+  )
+}
+
+// ── Page ─────────────────────────────────────────────────────────────
+
+export default function TemporalLifecyclePage() {
+  return (
+    <PageLayout
+      title="Temporal Lifecycle"
+      breadcrumbs={[
+        { label: "Intelligence", path: "/intelligence" },
+        { label: "Temporal Lifecycle", path: "/intelligence/temporal-lifecycle" },
+      ]}
+      prevPage={{ title: "Conversation Arc", path: "/intelligence/conversation-arc" }}
+      nextPage={{ title: "Serialization", path: "/intelligence/serialization" }}
+    >
+      <p>
+        Three Semiotic systems answer the same underlying question —{" "}
+        <em>"how does this thing look as it ages?"</em> — with three
+        different policies on three different time axes:
+      </p>
+
+      <div style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(3, 1fr)",
+        gap: 12,
+        margin: "16px 0",
+      }}>
+        {[
+          {
+            name: "Decay",
+            policy: "continuous",
+            axis: "buffer position",
+            scope: "per-datum",
+            doc: "Realtime Encoding",
+            href: "/features/realtime-encoding",
+            descr: "A continuous opacity ramp keyed to position in the streaming buffer. Older points fade smoothly.",
+          },
+          {
+            name: "Staleness",
+            policy: "binary",
+            axis: "wall-clock idle",
+            scope: "chart-wide",
+            doc: "Realtime Encoding",
+            href: "/features/realtime-encoding",
+            descr: "Live until the chart hasn't seen data for a configured threshold, then dimmed (plus optional LIVE/STALE badge).",
+          },
+          {
+            name: "Annotation freshness",
+            policy: "banded",
+            axis: "createdAt + ttlHint",
+            scope: "per-annotation",
+            doc: "Conversation Arc",
+            href: "/intelligence/conversation-arc",
+            descr: "Four named bands — fresh, aging, stale, expired — with opacity + dashing defaults and an expired filter.",
+          },
+        ].map(({ name, policy, axis, scope, doc, href, descr }) => (
+          <div key={name} style={{
+            border: "1px solid var(--surface-3)",
+            background: "var(--surface-1)",
+            borderRadius: 10,
+            padding: 14,
+          }}>
+            <h3 style={{ margin: "0 0 6px 0", fontSize: 15 }}>{name}</h3>
+            <div style={{ fontSize: 11, color: "var(--text-secondary)", marginBottom: 8 }}>
+              <code>{policy}</code> · {scope} · {axis}
+            </div>
+            <p style={{ fontSize: 13, margin: 0 }}>{descr}</p>
+            <p style={{ fontSize: 12, marginTop: 8, marginBottom: 0 }}>
+              <Link to={href}>→ {doc}</Link>
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <p>
+        The shared primitive that ties them together is{" "}
+        <code>bandFromAge(ageMs, ttlMs, thresholds?)</code> — a pure
+        function that classifies an age into one of four named bands.
+        Annotation freshness uses it today; the other two systems can
+        opt into banded classification when a binary or continuous
+        policy doesn't fit.
+      </p>
+
+      <h2>The classification primitive</h2>
+
+      <p>
+        Drag the slider to advance the simulated age. The active band
+        is what <code>bandFromAge</code> returns for that age, given
+        an 8-second TTL:
+      </p>
+      <BandScrubber />
+
+      <CodeBlock language="ts">
+{`import { bandFromAge } from "semiotic/ai" // or "semiotic/realtime"
+
+bandFromAge(0,             8000) // "fresh"
+bandFromAge(7_000,         8000) // "fresh"
+bandFromAge(10_000,        8000) // "aging"  (age >= 1.0 × TTL)
+bandFromAge(20_000,        8000) // "stale"  (age >= 1.5 × TTL)
+bandFromAge(30_000,        8000) // "expired" (age >= 3.0 × TTL)
+
+// Custom thresholds — multipliers of TTL, not raw ms:
+bandFromAge(20_000, 8000, { fresh: 2, aging: 3, stale: 6 }) // "fresh"`}
+      </CodeBlock>
+
+      <h2>Streaming chart-time aging</h2>
+
+      <p>
+        For time-series charts, the chart's own data is its clock —
+        the latest data point's timestamp is a more honest "now" than
+        wall-clock, because it tracks chart-time even when the stream
+        pauses or runs slow. <code>applyAnnotationLifecycle</code>{" "}
+        accepts a <code>dataExtent</code> option that derives "now"
+        from the latest value automatically.
+      </p>
+
+      <StreamingAgingDemo />
+
+      <CodeBlock language="tsx">
+{`import {
+  applyAnnotationLifecycle,
+  withCurrentProvenance,
+} from "semiotic/ai"
+
+// Stamp the annotation at the moment of creation.
+const ann = withCurrentProvenance(
+  { type: "callout", t: latestTimestamp, value: latestValue, label: "Spike" },
+  { author: "you", source: "user" }
+)
+
+// Pass the chart's data extent so aging tracks chart-time.
+<LineChart
+  data={streamingData}
+  xAccessor="t"
+  yAccessor="value"
+  annotations={applyAnnotationLifecycle([ann], {
+    dataExtent: [streamingData[0].t, streamingData.at(-1).t],
+  })}
+/>`}
+      </CodeBlock>
+
+      <h2>Picking a policy</h2>
+
+      <p>The three policies aren't interchangeable — each fits a different question:</p>
+
+      <ul>
+        <li>
+          <strong>Decay</strong> when older data should still be visible but
+          progressively de-emphasized. Per-datum, continuous, drives line
+          tails / trail effects.
+        </li>
+        <li>
+          <strong>Staleness</strong> when there's a wall-clock cutoff after
+          which the whole chart should look not-live. Chart-wide, binary,
+          drives oncall dashboards and incident displays.
+        </li>
+        <li>
+          <strong>Annotation freshness</strong> when a single mark on the
+          chart has a TTL of its own that doesn't track the chart's data
+          rhythm — a Q3 retrospective note, an SLA breach marker, an
+          AI-suggested anomaly tag.
+        </li>
+      </ul>
+
+      <p>
+        All three can coexist on one chart. A streaming dashboard might
+        decay older points, mark itself stale when the stream stops, and
+        independently age a user-placed annotation against its TTL. The
+        only piece they share today is the classifier — the rest of the
+        plumbing is intentionally separate so the policies don't drag
+        each other's edge cases around.
+      </p>
+    </PageLayout>
+  )
+}

--- a/docs/src/pages/features/TemporalLifecyclePage.js
+++ b/docs/src/pages/features/TemporalLifecyclePage.js
@@ -1,10 +1,9 @@
-import React, { useEffect, useMemo, useRef, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { Link } from "react-router-dom"
 import { LineChart } from "semiotic"
 import {
   applyAnnotationLifecycle,
   bandFromAge,
-  currentTimestamp,
   withCurrentProvenance,
 } from "semiotic/ai"
 import PageLayout from "../../components/PageLayout"
@@ -109,20 +108,21 @@ function BandScrubber() {
 
 const STREAM_TICK = 1500 // ms between data points
 const STREAM_WINDOW = 12
+const ANNOTATION_TTL_MS = 3000 // 3s TTL keeps the demo fast: aging at 3s, stale at 4.5s, expired at 9s
 
 function StreamingAgingDemo() {
-  const [data, setData] = useState(() => [{ t: 0, value: 50, annotated: false }])
+  const startTimeRef = useRef(Date.now())
+  const [data, setData] = useState(() => [{ t: Date.now(), value: 50 }])
   const [annotation, setAnnotation] = useState(null)
-  const tickRef = useRef(0)
   const playingRef = useRef(true)
   const [playing, setPlaying] = useState(true)
 
   useEffect(() => {
     const interval = setInterval(() => {
       if (!playingRef.current) return
-      tickRef.current++
-      const t = tickRef.current
-      const value = 50 + Math.sin(t * 0.4) * 18 + (Math.random() - 0.5) * 10
+      const t = Date.now()
+      const tickIndex = (t - startTimeRef.current) / STREAM_TICK
+      const value = 50 + Math.sin(tickIndex * 0.4) * 18 + (Math.random() - 0.5) * 10
       setData((prev) => {
         const next = [...prev, { t, value }]
         return next.length > STREAM_WINDOW ? next.slice(-STREAM_WINDOW) : next
@@ -139,6 +139,9 @@ function StreamingAgingDemo() {
   const markLatest = () => {
     const latest = data[data.length - 1]
     if (!latest) return
+    // `withCurrentProvenance` stamps `provenance.createdAt = currentTimestamp()`.
+    // Combined with the short ttlHint below, the annotation will age as
+    // the chart's data extent advances past it.
     setAnnotation(
       withCurrentProvenance(
         {
@@ -146,26 +149,27 @@ function StreamingAgingDemo() {
           t: latest.t,
           value: latest.value,
           label: "Marked here",
-          dx: -40,
+          dx: -50,
           dy: -45,
+          lifecycle: { ttlHint: ANNOTATION_TTL_MS },
         },
         { author: "you", source: "user" }
       )
     )
   }
 
-  // The chart's data extent IS the chart's clock. applyAnnotationLifecycle
-  // picks the latest data point as "now" — annotations created against
-  // earlier data points age automatically as the stream advances.
-  const dataExtent = data.length
-    ? [Date.parse(data[0].timestamp ?? new Date().toISOString()), Date.now()]
-    : [Date.now(), Date.now()]
+  // The chart's data extent IS its clock. Passing dataExtent makes
+  // the latest data point the "now" reference for the lifecycle pass,
+  // so annotations age against chart-time. If the stream pauses, the
+  // annotation stops aging — which is what you want for a live
+  // dashboard where pause means "frozen in time."
   const annotated = annotation
     ? applyAnnotationLifecycle([annotation], {
-        // Tiny TTL so the demo can show aging in real time.
-        thresholds: { fresh: 1, aging: 1.5, stale: 3 },
+        dataExtent: [data[0].t, data[data.length - 1].t],
       })
     : []
+
+  const xFormat = (t) => `${((t - startTimeRef.current) / 1000).toFixed(1)}s`
 
   return (
     <div style={{
@@ -185,6 +189,7 @@ function StreamingAgingDemo() {
         height={260}
         showPoints
         annotations={annotated}
+        xFormat={xFormat}
         margin={{ top: 24, right: 24, bottom: 36, left: 48 }}
       />
       <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
@@ -233,9 +238,10 @@ function StreamingAgingDemo() {
       </div>
       <p style={{ fontSize: 12, color: "var(--text-secondary)", margin: 0 }}>
         Stamp the latest point, then let the stream run. The annotation
-        was created with <code>withCurrentProvenance</code> — once it
-        falls outside the chart's data window plus a few seconds, the
-        lifecycle treatment dims it, then dashes it, then drops it.
+        has a 3-second TTL — at 3s past the latest data point it goes{" "}
+        <strong>aging</strong>, at 4.5s <strong>stale</strong> (dashed),
+        at 9s it's filtered out. Pause the stream and the annotation
+        stops aging too: chart-time is the data, not the wall.
       </p>
     </div>
   )
@@ -363,13 +369,22 @@ bandFromAge(20_000, 8000, { fresh: 2, aging: 3, stale: 6 }) // "fresh"`}
   withCurrentProvenance,
 } from "semiotic/ai"
 
-// Stamp the annotation at the moment of creation.
+// Stamp createdAt at the moment of creation; attach a ttlHint so the
+// lifecycle pass has something to age against.
 const ann = withCurrentProvenance(
-  { type: "callout", t: latestTimestamp, value: latestValue, label: "Spike" },
+  {
+    type: "callout",
+    t: latestTimestamp,
+    value: latestValue,
+    label: "Spike",
+    lifecycle: { ttlHint: 3000 }, // 3 seconds
+  },
   { author: "you", source: "user" }
 )
 
-// Pass the chart's data extent so aging tracks chart-time.
+// Pass the chart's data extent so "now" tracks chart-time. When the
+// stream pauses, the latest data timestamp stops advancing, and the
+// annotation stops aging too.
 <LineChart
   data={streamingData}
   xAccessor="t"

--- a/etc/api-surface/semiotic-ai.api.md
+++ b/etc/api-surface/semiotic-ai.api.md
@@ -16,6 +16,7 @@ const ChordDiagramCapability
 const ChoroplethMapCapability
 const CirclePackCapability
 const ConnectedScatterplotCapability
+const DEFAULT_LIFECYCLE_THRESHOLDS
 const DifferenceChartCapability
 const DistanceCartogramCapability
 const DonutChartCapability
@@ -100,10 +101,15 @@ function TooltipProvider
 function TreeDiagram
 function Treemap
 function ViolinPlot
+function annotationFreshnessFor
+function applyAnnotationLifecycle
 function applyAudienceBias
+function bandFromAge
 function clearVariantDiscovery
+function computeAnnotationFreshness
 function configToJSX
 function copyConfig
+function currentTimestamp
 function deserializeSelections
 function diagnoseConfig
 function diffProfile
@@ -155,8 +161,10 @@ function useLinkedHover
 function useSelection
 function useTheme
 function validateProps
+function withCurrentProvenance
 function withProvenance
 interface AnnotationLifecycle
+interface AnnotationLifecycleTreatment
 interface AnnotationProvenance
 interface AnomalyConfig
 interface AudienceBiasResult
@@ -182,6 +190,7 @@ interface ChartRubric
 interface ChartVariant
 interface ClickEndObservation
 interface ClickObservation
+interface ComputeAnnotationFreshnessOptions
 interface ContextLayoutProps
 interface ConversationArcStore
 interface DashboardPanel
@@ -204,6 +213,7 @@ interface InterrogationContext
 interface InterrogationFocus
 interface InterrogationMessage
 interface InterrogationResult
+interface LifecycleBandThresholds
 interface NumericFieldSummary
 interface PerCapabilityScore
 interface PerFixtureScore
@@ -252,6 +262,7 @@ type Annotated
 type AnnotationAnchor
 type AnnotationFreshness
 type AnnotationSource
+type ApplyAnnotationLifecycleOptions
 type BuiltInIntentId
 type CategoryColorMap
 type ChartFamily
@@ -270,6 +281,7 @@ type FitResult
 type IntentId
 type IntentScorer
 type InterrogationQuery
+type LifecycleBand
 type OnObservationCallback
 type PrimaryRole
 type ProposeVariantFn

--- a/etc/api-surface/semiotic-realtime.api.md
+++ b/etc/api-surface/semiotic-realtime.api.md
@@ -6,6 +6,7 @@ _Edit dist/semiotic-realtime.d.ts's sources, then re-run `npm run docs:api-surfa
 ```
 class IncrementalExtent
 class RingBuffer
+const DEFAULT_LIFECYCLE_THRESHOLDS
 function RealtimeHeatmap
 function RealtimeHistogram
 function RealtimeLineChart
@@ -14,12 +15,14 @@ function RealtimeWaterfallChart
 function StreamNetworkFrame
 function StreamXYFrame
 function TemporalHistogram
+function bandFromAge
 function useStreamStatus
 interface AnnotationContext
 interface BarStyle
 interface CrosshairStyle
 interface HoverAnnotationConfig
 interface HoverData
+interface LifecycleBandThresholds
 interface LineStyle
 interface RealtimeHeatmapProps
 interface RealtimeHistogramProps
@@ -36,6 +39,7 @@ interface SwarmStyle
 interface TemporalHistogramProps
 interface WaterfallStyle
 type ArrowOfTime
+type LifecycleBand
 type NetworkChartType
 type StreamChartType
 type StreamStatus

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -29,6 +29,10 @@ export interface AnnotationProps {
     color?: string
     className?: string
     disable?: string[]
+    /** SVG opacity cascaded to every stroked/filled child of the annotation. */
+    opacity?: number
+    /** SVG stroke-dasharray cascaded to every stroked child of the annotation. */
+    strokeDasharray?: string
     [key: string]: unknown
   }
 }
@@ -516,6 +520,8 @@ function AnnotationRenderer(props: any) {
     color,
     className,
     disable,
+    opacity,
+    strokeDasharray,
     events = {},
     "data-testid": dataTestId
   } = props
@@ -543,11 +549,18 @@ function AnnotationRenderer(props: any) {
     }
   }
 
+  // `opacity` and `strokeDasharray` cascade as SVG presentation
+  // attributes from the wrapping <g> to every stroked/filled child,
+  // which is exactly what the freshness lifecycle treatment needs:
+  // dim aging, dash stale, etc., without touching every subject/
+  // connector/note renderer.
   return (
     <g
       className={`annotation ${className || ""}`.trim()}
       transform={`translate(${x},${y})`}
       data-testid={dataTestId}
+      {...(opacity != null && { opacity })}
+      {...(strokeDasharray && { strokeDasharray })}
       {...events}
     >
       {!disableSet.has("connector") && renderConnector(dx, dy, connector, color, resolvedType, subject)}

--- a/src/components/ai/annotationProvenance.test.ts
+++ b/src/components/ai/annotationProvenance.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest"
 import {
+  annotationFreshnessFor,
+  applyAnnotationLifecycle,
+  computeAnnotationFreshness,
+  currentTimestamp,
+  withCurrentProvenance,
   withProvenance,
   type Annotated,
   type AnnotationAnchor,
@@ -8,6 +13,22 @@ import {
   type AnnotationProvenance,
   type AnnotationSource,
 } from "./annotationProvenance"
+
+const DAY = 24 * 60 * 60 * 1000
+const DAY_ZERO = Date.parse("2026-01-01T00:00:00Z")
+// day(1) → 2026-01-01, day(40) → 2026-02-09, etc. Done via timestamp
+// arithmetic so we don't have to think about month rollovers in tests.
+const day = (n: number) => new Date(DAY_ZERO + (n - 1) * DAY).toISOString()
+
+function ann(createdAt: string, ttlHint: string | number = "P30D", extra: Record<string, unknown> = {}) {
+  return withProvenance(
+    { type: "callout", label: "x", ...extra },
+    {
+      provenance: { author: "alice", source: "user", createdAt },
+      lifecycle: { ttlHint },
+    }
+  )
+}
 
 describe("annotationProvenance — withProvenance()", () => {
   it("attaches provenance + lifecycle without mutating the input", () => {
@@ -102,5 +123,208 @@ describe("annotationProvenance — type surface", () => {
     expect(freshness).toHaveLength(4)
     expect(l.anchor).toBe("semantic")
     expect(lMs.ttlHint).toBe(86_400_000)
+  })
+})
+
+describe("annotationProvenance — computeAnnotationFreshness", () => {
+  it("classifies bands from createdAt + ttlHint relative to `now`", () => {
+    const a = ann(day(1), "P10D") // created Jan 1, TTL 10 days
+    // age 5 days → < 1× TTL → fresh
+    expect(annotationFreshnessFor(a, Date.parse(day(6)))).toBe("fresh")
+    // age 12 days → < 1.5× TTL → aging
+    expect(annotationFreshnessFor(a, Date.parse("2026-01-13T00:00:00Z"))).toBe("aging")
+    // age 20 days → < 3× TTL → stale
+    expect(annotationFreshnessFor(a, Date.parse("2026-01-21T00:00:00Z"))).toBe("stale")
+    // age 35 days → > 3× TTL → expired
+    expect(annotationFreshnessFor(a, Date.parse("2026-02-05T00:00:00Z"))).toBe("expired")
+  })
+
+  it("resolves `now` from dataExtent's max when no explicit now is given", () => {
+    const a = ann(day(1), "P10D")
+    const out = computeAnnotationFreshness([a], {
+      dataExtent: [day(1), day(30)],
+    })
+    // age 29 days → > 1.5×, < 3× → stale
+    expect(out[0].lifecycle?.freshness).toBe("stale")
+  })
+
+  it("supports the object form of dataExtent", () => {
+    const a = ann(day(1), "P10D")
+    const out = computeAnnotationFreshness([a], {
+      dataExtent: { min: day(1), max: day(40) },
+    })
+    expect(out[0].lifecycle?.freshness).toBe("expired")
+  })
+
+  it("falls back to Date.now() when neither now nor dataExtent is given", () => {
+    // An annotation created very recently → fresh, regardless of when
+    // the test runs.
+    const recent = withProvenance(
+      { type: "callout", label: "x" },
+      {
+        provenance: { author: "bot", source: "ai", createdAt: new Date().toISOString() },
+        lifecycle: { ttlHint: "P30D" },
+      }
+    )
+    const out = computeAnnotationFreshness([recent])
+    expect(out[0].lifecycle?.freshness).toBe("fresh")
+  })
+
+  it("accepts ISO durations and millisecond numbers for ttlHint", () => {
+    const isoForm = ann(day(1), "P7D")
+    const msForm = ann(day(1), 7 * DAY)
+    const refNow = Date.parse(day(8)) // 7 days later → exactly at threshold
+    expect(annotationFreshnessFor(isoForm, refNow)).toBe("aging")
+    expect(annotationFreshnessFor(msForm, refNow)).toBe("aging")
+  })
+
+  it("preserves existing freshness when createdAt or ttlHint is missing", () => {
+    const handAssigned: Annotated<{ type: string }> = {
+      type: "callout",
+      lifecycle: { freshness: "stale" },
+    }
+    expect(annotationFreshnessFor(handAssigned, Date.now())).toBe("stale")
+
+    const noLifecycle: Annotated<{ type: string }> = { type: "callout" }
+    expect(annotationFreshnessFor(noLifecycle, Date.now())).toBe("fresh")
+  })
+
+  it("honors custom thresholds", () => {
+    const a = ann(day(1), "P10D")
+    // Without custom thresholds: 12 days = aging. With aging at 2×: still fresh.
+    const refNow = Date.parse(day(13))
+    expect(annotationFreshnessFor(a, refNow)).toBe("aging")
+    expect(annotationFreshnessFor(a, refNow, { fresh: 2 })).toBe("fresh")
+  })
+
+  it("does not mutate the input array", () => {
+    const a = ann(day(1), "P10D")
+    const before = { ...a, lifecycle: { ...a.lifecycle } }
+    computeAnnotationFreshness([a], { now: day(20) })
+    expect(a).toEqual(before)
+  })
+})
+
+describe("annotationProvenance — applyAnnotationLifecycle", () => {
+  it("applies the default visual treatment per band", () => {
+    const annotations = [
+      ann(day(1), "P10D", { id: "a" }),  // fresh at day 5
+      ann(day(1), "P3D", { id: "b" }),   // aging at day 5 (age=4, 1×=3, <1.5×=4.5)
+      ann(day(1), "P2D", { id: "c" }),   // stale at day 5 (age=4, 1×=2, 1.5×=3, 3×=6)
+    ]
+    const out = applyAnnotationLifecycle(annotations, { now: day(5) })
+
+    const byId = Object.fromEntries(
+      out.map((a) => {
+        const styled = a as unknown as { id: string; opacity?: number; strokeDasharray?: string }
+        return [styled.id, styled]
+      })
+    )
+    expect(out).toHaveLength(3)
+    expect(byId.a.opacity).toBeUndefined()
+    expect(byId.b.opacity).toBeCloseTo(0.55)
+    expect(byId.c.opacity).toBeCloseTo(0.35)
+    expect(byId.c.strokeDasharray).toBe("4 4")
+  })
+
+  it("filters expired annotations by default", () => {
+    const a = ann(day(1), "P5D", { id: "expired" }) // expired at day 20 (age=19, 3×=15)
+    const out = applyAnnotationLifecycle([a], { now: day(20) })
+    expect(out).toHaveLength(0)
+  })
+
+  it("keeps expired annotations when showExpiredAnnotations is true", () => {
+    const a = ann(day(1), "P5D", { id: "expired" })
+    const out = applyAnnotationLifecycle([a], {
+      now: day(20),
+      showExpiredAnnotations: true,
+    })
+    expect(out).toHaveLength(1)
+    const styled = out[0] as unknown as { opacity?: number; strokeDasharray?: string }
+    expect(styled.opacity).toBeCloseTo(0.2)
+    expect(styled.strokeDasharray).toBe("2 4")
+  })
+
+  it("respects existing opacity/strokeDasharray on the annotation", () => {
+    const a = withProvenance(
+      { type: "callout", label: "x", id: "z", opacity: 0.9, strokeDasharray: "1 1" },
+      {
+        provenance: { author: "alice", source: "user", createdAt: day(1) },
+        lifecycle: { ttlHint: "P3D" }, // 4 days later → aging
+      }
+    )
+    const out = applyAnnotationLifecycle([a], { now: day(5) })
+    // The annotation's own opacity / dasharray win over the treatment.
+    const styled = out[0] as unknown as { opacity: number; strokeDasharray: string }
+    expect(styled.opacity).toBe(0.9)
+    expect(styled.strokeDasharray).toBe("1 1")
+  })
+
+  it("appends labelSuffix per band when provided", () => {
+    const a = ann(day(1), "P3D", { id: "b" })
+    const out = applyAnnotationLifecycle([a], {
+      now: day(5),
+      labelSuffix: { aging: " (aging)" },
+    })
+    expect((out[0] as { label: string }).label).toBe("x (aging)")
+  })
+
+  it("allows callers to disable a default per-band treatment via null", () => {
+    const a = ann(day(1), "P3D", { id: "b" })
+    const out = applyAnnotationLifecycle([a], {
+      now: day(5),
+      opacity: { aging: null },
+    })
+    const styled = out[0] as unknown as { opacity?: number }
+    expect(styled.opacity).toBeUndefined()
+  })
+})
+
+describe("annotationProvenance — currentTimestamp / withCurrentProvenance", () => {
+  it("currentTimestamp returns a valid ISO 8601 string parseable as a date", () => {
+    const before = Date.now()
+    const ts = currentTimestamp()
+    const after = Date.now()
+    const parsed = Date.parse(ts)
+    expect(Number.isFinite(parsed)).toBe(true)
+    expect(parsed).toBeGreaterThanOrEqual(before)
+    expect(parsed).toBeLessThanOrEqual(after)
+    expect(ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+  })
+
+  it("withCurrentProvenance stamps createdAt when missing", () => {
+    const base = { type: "callout", label: "x" }
+    const before = Date.now()
+    const out = withCurrentProvenance(base, { author: "stream", source: "computed" })
+    const after = Date.now()
+
+    expect(out.provenance?.author).toBe("stream")
+    expect(out.provenance?.source).toBe("computed")
+    const parsed = Date.parse(out.provenance!.createdAt!)
+    expect(parsed).toBeGreaterThanOrEqual(before)
+    expect(parsed).toBeLessThanOrEqual(after)
+    // Original annotation isn't mutated.
+    expect((base as Annotated<typeof base>).provenance).toBeUndefined()
+  })
+
+  it("withCurrentProvenance preserves an existing createdAt", () => {
+    const base = withProvenance(
+      { type: "callout", label: "x" },
+      { provenance: { author: "alice", createdAt: "2026-01-01T00:00:00Z" } }
+    )
+    const out = withCurrentProvenance(base, { source: "ai" })
+    // Author and createdAt from the original survive; source is added.
+    expect(out.provenance?.author).toBe("alice")
+    expect(out.provenance?.createdAt).toBe("2026-01-01T00:00:00Z")
+    expect(out.provenance?.source).toBe("ai")
+  })
+
+  it("withCurrentProvenance accepts an explicit createdAt override", () => {
+    const base = { type: "callout", label: "x" }
+    const out = withCurrentProvenance(base, {
+      author: "stream",
+      createdAt: "2026-04-15T12:00:00Z",
+    })
+    expect(out.provenance?.createdAt).toBe("2026-04-15T12:00:00Z")
   })
 })

--- a/src/components/ai/annotationProvenance.test.ts
+++ b/src/components/ai/annotationProvenance.test.ts
@@ -278,6 +278,34 @@ describe("annotationProvenance — applyAnnotationLifecycle", () => {
     const styled = out[0] as unknown as { opacity?: number }
     expect(styled.opacity).toBeUndefined()
   })
+
+  it("mirrors lifecycle.anchor onto top-level anchor so the resolver picks it up", () => {
+    // The streaming annotation resolver reads `ann.anchor`, not
+    // `ann.lifecycle.anchor`. Without this bridge, setting
+    // `lifecycle.anchor: "latest"` would silently fall through to
+    // fixed behavior at runtime.
+    const a = withProvenance(
+      { type: "callout", label: "x", id: "anchored" },
+      {
+        provenance: { author: "alice", createdAt: day(1) },
+        lifecycle: { ttlHint: "P30D", anchor: "latest" },
+      }
+    )
+    const out = applyAnnotationLifecycle([a], { now: day(5) })
+    expect((out[0] as unknown as { anchor?: string }).anchor).toBe("latest")
+  })
+
+  it("preserves an explicit top-level anchor over lifecycle.anchor", () => {
+    const a = withProvenance(
+      { type: "callout", label: "x", id: "anchored", anchor: "sticky" },
+      {
+        provenance: { author: "alice", createdAt: day(1) },
+        lifecycle: { ttlHint: "P30D", anchor: "latest" },
+      }
+    )
+    const out = applyAnnotationLifecycle([a], { now: day(5) })
+    expect((out[0] as unknown as { anchor?: string }).anchor).toBe("sticky")
+  })
 })
 
 describe("annotationProvenance — currentTimestamp / withCurrentProvenance", () => {

--- a/src/components/ai/annotationProvenance.ts
+++ b/src/components/ai/annotationProvenance.ts
@@ -401,7 +401,12 @@ export function applyAnnotationLifecycle<T>(
     const dashArray = pick(options.strokeDasharray, DEFAULT_DASHARRAY, freshness)
     const suffix = options.labelSuffix?.[freshness]
 
-    const next: Annotated<T> & { opacity?: number; strokeDasharray?: string; label?: string } = {
+    const next: Annotated<T> & {
+      opacity?: number
+      strokeDasharray?: string
+      label?: string
+      anchor?: AnnotationAnchor
+    } = {
       ...annotation,
       lifecycle: { ...annotation.lifecycle, freshness },
     }
@@ -416,6 +421,15 @@ export function applyAnnotationLifecycle<T>(
     }
     if (suffix && typeof (next as { label?: string }).label === "string") {
       next.label = (next as { label: string }).label + suffix
+    }
+
+    // Mirror `lifecycle.anchor` onto the top-level `anchor` field so
+    // the streaming annotation resolver (which reads `ann.anchor`,
+    // not `ann.lifecycle.anchor`) picks up the requested mode. The
+    // top-level field still wins if a caller set it explicitly.
+    const lifecycleAnchor = annotation.lifecycle?.anchor
+    if (lifecycleAnchor && (next as { anchor?: AnnotationAnchor }).anchor == null) {
+      next.anchor = lifecycleAnchor
     }
 
     out.push(next)

--- a/src/components/ai/annotationProvenance.ts
+++ b/src/components/ai/annotationProvenance.ts
@@ -61,20 +61,29 @@ export type AnnotationSource =
  * draws a dashed border, `expired` is hidden unless
  * `showExpiredAnnotations` is on.
  */
-export type AnnotationFreshness = "fresh" | "aging" | "stale" | "expired"
+// Alias of `LifecycleBand` (which lives next to `bandFromAge` in the
+// realtime runtime). Keeping the public name `AnnotationFreshness`
+// for the AI surface but pointing it at the shared union prevents
+// drift if future bands are added.
+export type AnnotationFreshness = LifecycleBand
 
-/**
- * How the annotation's anchor is resolved when data updates.
- *
- * - `fixed` — keeps the recorded coordinate verbatim.
- * - `latest` — re-pins to the most recent data point on each refresh.
- * - `sticky` — keeps its position until explicitly removed (same
- *   semantics as `RealtimeLineChart`'s `sticky` annotation anchor).
- * - `semantic` — re-resolves via `provenance.stableId`, falling
- *   back to the recorded coordinate when the anchor can no longer
- *   be located. Implementation lands in M3.
- */
-export type AnnotationAnchor = "fixed" | "latest" | "sticky" | "semantic"
+// Re-export the canonical anchor type from the streaming runtime,
+// which owns the resolution implementation. Same union of modes
+// either way — defining once means the AI lifecycle vocabulary and
+// the streaming runtime can't drift. Imported locally because
+// `AnnotationLifecycle` below references it.
+import type { AnnotationAnchor } from "../realtime/types"
+export type { AnnotationAnchor } from "../realtime/types"
+
+// `bandFromAge` is the shared lifecycle-classification primitive.
+// Same algorithm whether we're tagging annotations (today),
+// classifying datums in a streaming buffer (banded decay, future),
+// or surfacing staleness bands instead of binary live/stale (future).
+// Imported locally because `annotationFreshnessFor` wraps it.
+import { bandFromAge } from "../realtime/lifecycleBands"
+import type { LifecycleBand, LifecycleBandThresholds } from "../realtime/lifecycleBands"
+export { bandFromAge, DEFAULT_LIFECYCLE_THRESHOLDS } from "../realtime/lifecycleBands"
+export type { LifecycleBand, LifecycleBandThresholds } from "../realtime/lifecycleBands"
 
 /**
  * Lifecycle state for an annotation. Lives on `annotation.lifecycle`.
@@ -136,4 +145,280 @@ export function withProvenance<T extends object>(
   if (blocks.provenance) next.provenance = blocks.provenance
   if (blocks.lifecycle) next.lifecycle = blocks.lifecycle
   return next
+}
+
+/**
+ * Returns an ISO 8601 wall-clock timestamp suitable for stamping
+ * `provenance.createdAt`. Sugar over `new Date().toISOString()`, but
+ * named to make intent obvious in streaming consumers: "mark this
+ * annotation as created now, so the lifecycle helpers can age it."
+ *
+ * Pair with `applyAnnotationLifecycle({ dataExtent })` on time-series
+ * charts to have annotations age against chart-time rather than
+ * wall-clock — the chart's latest data point becomes the "now"
+ * reference, and recently-stamped annotations stay fresh for as long
+ * as new data is flowing.
+ */
+export function currentTimestamp(): string {
+  return new Date().toISOString()
+}
+
+/**
+ * Stamp an annotation with `provenance.createdAt = currentTimestamp()`
+ * (unless it already has a `createdAt`) and optional additional
+ * provenance fields. Intended for the streaming "I'm marking the
+ * latest data point" pattern, where the annotation's age should be
+ * measured from when the consumer added it.
+ *
+ * Equivalent to:
+ *   ```ts
+ *   withProvenance(ann, {
+ *     provenance: { createdAt: currentTimestamp(), ...rest },
+ *     lifecycle: ann.lifecycle,
+ *   })
+ *   ```
+ * — but reads cleaner at call sites and preserves any existing
+ * `createdAt`.
+ */
+export function withCurrentProvenance<T extends object>(
+  annotation: T,
+  rest: Omit<AnnotationProvenance, "createdAt"> & { createdAt?: string } = {}
+): Annotated<T> {
+  const existing = (annotation as Annotated<T>).provenance
+  return {
+    ...annotation,
+    provenance: {
+      ...existing,
+      ...rest,
+      createdAt: rest.createdAt ?? existing?.createdAt ?? currentTimestamp(),
+    },
+  } as Annotated<T>
+}
+
+// ── Freshness computation (M2) ────────────────────────────────────────
+
+/**
+ * Options accepted by `computeAnnotationFreshness` and
+ * `applyAnnotationLifecycle`.
+ */
+export interface ComputeAnnotationFreshnessOptions {
+  /**
+   * "Now" reference for age calculations. Number is epoch ms; string is
+   * any value `Date.parse` accepts. When omitted, defaults to the max
+   * of `dataExtent`, falling back to `Date.now()`.
+   */
+  now?: number | Date | string
+  /**
+   * The chart's current temporal extent — typically `[oldest, newest]`
+   * x values. Used to derive a sensible "now" for streaming charts
+   * (where wall-clock time and the data's notion of "now" can drift).
+   */
+  dataExtent?:
+    | ReadonlyArray<number | Date | string>
+    | { min: number | Date | string; max: number | Date | string }
+  /**
+   * Override the default age thresholds. Each value is a multiplier of
+   * `ttlHint`. Defaults: aging at 1×, stale at 1.5×, expired at 3×.
+   * Same shape as `LifecycleBandThresholds` from the shared primitive.
+   */
+  thresholds?: LifecycleBandThresholds
+}
+
+function toMs(value: number | Date | string | undefined): number | null {
+  if (value == null) return null
+  if (typeof value === "number") return value
+  if (value instanceof Date) return value.getTime()
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function resolveNow(options?: ComputeAnnotationFreshnessOptions): number {
+  const explicit = toMs(options?.now)
+  if (explicit != null) return explicit
+  const extent = options?.dataExtent
+  if (extent) {
+    // `Array.isArray` does narrow ReadonlyArray vs. object in modern TS,
+    // but the union including `{ min, max }` confuses it; fall back to
+    // `"max" in extent` for the object branch.
+    if (Array.isArray(extent)) {
+      const last = extent[extent.length - 1]
+      const ms = toMs(last)
+      if (ms != null) return ms
+    } else if ("max" in extent) {
+      const ms = toMs(extent.max)
+      if (ms != null) return ms
+    }
+  }
+  return Date.now()
+}
+
+function parseIsoDuration(s: string): number {
+  const m = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/.exec(s)
+  if (!m) return 0
+  const days = parseInt(m[1] || "0", 10)
+  const hours = parseInt(m[2] || "0", 10)
+  const minutes = parseInt(m[3] || "0", 10)
+  const seconds = parseInt(m[4] || "0", 10)
+  return ((days * 24 + hours) * 3600 + minutes * 60 + seconds) * 1000
+}
+
+function ttlToMs(ttl: string | number | undefined): number | null {
+  if (ttl == null) return null
+  if (typeof ttl === "number") return ttl
+  const parsed = parseIsoDuration(ttl)
+  return parsed > 0 ? parsed : null
+}
+
+/**
+ * Classify an annotation into a freshness band. Exported for tests and
+ * for consumers that want the per-annotation band without rebuilding
+ * the entire array.
+ *
+ * Returns the annotation's existing `lifecycle.freshness` verbatim if
+ * the annotation lacks the `createdAt` or `ttlHint` needed to compute
+ * a band — i.e. an explicit assignment always wins over inference.
+ */
+export function annotationFreshnessFor<T>(
+  annotation: Annotated<T>,
+  nowMs: number,
+  thresholds: LifecycleBandThresholds = {}
+): AnnotationFreshness {
+  const existing = annotation?.lifecycle?.freshness
+  const createdMs = toMs(annotation?.provenance?.createdAt)
+  const ttlMs = ttlToMs(annotation?.lifecycle?.ttlHint)
+  if (createdMs == null || ttlMs == null) {
+    return existing ?? "fresh"
+  }
+  // Defer to the shared lifecycle classifier — same algorithm any
+  // future banded-decay / banded-staleness opt-in will use.
+  return bandFromAge(nowMs - createdMs, ttlMs, thresholds)
+}
+
+/**
+ * Walk an annotations array and populate `lifecycle.freshness` on each
+ * entry from its `provenance.createdAt` and `lifecycle.ttlHint`.
+ *
+ * Pure function — returns a new array; does not mutate input. Safe
+ * to call in SSR. Annotations missing the inputs needed to compute a
+ * band keep whatever `lifecycle.freshness` they already had (so an
+ * explicit assignment always wins).
+ *
+ * For non-temporal charts, pass `now` explicitly. For streaming /
+ * time-series charts, pass `dataExtent` — the helper picks the latest
+ * value as "now" so freshness tracks chart-time, not wall-clock.
+ */
+export function computeAnnotationFreshness<T>(
+  annotations: ReadonlyArray<Annotated<T>>,
+  options: ComputeAnnotationFreshnessOptions = {}
+): Annotated<T>[] {
+  const nowMs = resolveNow(options)
+  return annotations.map((a) => {
+    const freshness = annotationFreshnessFor(a, nowMs, options.thresholds)
+    return {
+      ...a,
+      lifecycle: { ...a.lifecycle, freshness },
+    }
+  })
+}
+
+// ── Default visual treatment (M2) ─────────────────────────────────────
+
+/**
+ * Style overrides per freshness band. Each map is partial — bands not
+ * present fall back to the defaults below. `null` for a value removes
+ * the default rather than applying it (e.g. `{ opacity: { aging: null } }`
+ * disables dimming aging annotations).
+ */
+export interface AnnotationLifecycleTreatment {
+  opacity?: Partial<Record<AnnotationFreshness, number | null>>
+  strokeDasharray?: Partial<Record<AnnotationFreshness, string | null>>
+  /** Suffix appended to `label` for that band. Default suffixes are off. */
+  labelSuffix?: Partial<Record<AnnotationFreshness, string>>
+  /**
+   * When true, expired annotations stay in the returned array (with
+   * the expired treatment applied). When false (default), expired
+   * annotations are filtered out — matching the "hidden by default"
+   * contract from the talk-readiness roadmap.
+   */
+  showExpiredAnnotations?: boolean
+}
+
+export type ApplyAnnotationLifecycleOptions =
+  ComputeAnnotationFreshnessOptions & AnnotationLifecycleTreatment
+
+const DEFAULT_OPACITY: Record<AnnotationFreshness, number | null> = {
+  fresh: null,
+  aging: 0.55,
+  stale: 0.35,
+  expired: 0.2,
+}
+
+const DEFAULT_DASHARRAY: Record<AnnotationFreshness, string | null> = {
+  fresh: null,
+  aging: null,
+  stale: "4 4",
+  expired: "2 4",
+}
+
+function pick<V>(
+  overrides: Partial<Record<AnnotationFreshness, V | null>> | undefined,
+  defaults: Record<AnnotationFreshness, V | null>,
+  band: AnnotationFreshness
+): V | null {
+  if (overrides && band in overrides) return overrides[band] as V | null
+  return defaults[band]
+}
+
+/**
+ * Compute freshness and apply the default visual treatment in one pass.
+ *
+ * Behavior per band (overridable via options):
+ * - **fresh** — no change
+ * - **aging** — `opacity` 0.55
+ * - **stale** — `opacity` 0.35, `strokeDasharray` `"4 4"` (cascades
+ *   through the annotation's stroked children)
+ * - **expired** — filtered out by default; pass
+ *   `showExpiredAnnotations: true` to keep them with `opacity` 0.2 and
+ *   `strokeDasharray` `"2 4"`
+ *
+ * Treatment composes cleanly with annotations that already carry their
+ * own `color` / `opacity` — explicit fields on the annotation win,
+ * the treatment only fills in what isn't already set.
+ */
+export function applyAnnotationLifecycle<T>(
+  annotations: ReadonlyArray<Annotated<T>>,
+  options: ApplyAnnotationLifecycleOptions = {}
+): Annotated<T>[] {
+  const nowMs = resolveNow(options)
+  const showExpired = options.showExpiredAnnotations === true
+
+  const out: Annotated<T>[] = []
+  for (const annotation of annotations) {
+    const freshness = annotationFreshnessFor(annotation, nowMs, options.thresholds)
+    if (freshness === "expired" && !showExpired) continue
+
+    const opacity = pick(options.opacity, DEFAULT_OPACITY, freshness)
+    const dashArray = pick(options.strokeDasharray, DEFAULT_DASHARRAY, freshness)
+    const suffix = options.labelSuffix?.[freshness]
+
+    const next: Annotated<T> & { opacity?: number; strokeDasharray?: string; label?: string } = {
+      ...annotation,
+      lifecycle: { ...annotation.lifecycle, freshness },
+    }
+
+    // Only fill the prop when the caller hasn't already set it on the
+    // annotation itself — explicit annotation fields win.
+    if (opacity != null && (next as { opacity?: number }).opacity == null) {
+      next.opacity = opacity
+    }
+    if (dashArray != null && (next as { strokeDasharray?: string }).strokeDasharray == null) {
+      next.strokeDasharray = dashArray
+    }
+    if (suffix && typeof (next as { label?: string }).label === "string") {
+      next.label = (next as { label: string }).label + suffix
+    }
+
+    out.push(next)
+  }
+  return out
 }

--- a/src/components/realtime/lifecycleBands.test.ts
+++ b/src/components/realtime/lifecycleBands.test.ts
@@ -27,13 +27,15 @@ describe("bandFromAge", () => {
     expect(bandFromAge(20 * DAY, ttl, { aging: 3, stale: 5 })).toBe("aging")
   })
 
-  it("treats negative or non-finite ages as fresh (safest default — expired can be hidden)", () => {
+  it("treats negative and NaN ages as fresh (parse-failure sentinel)", () => {
     expect(bandFromAge(-100, 1000)).toBe("fresh")
     expect(bandFromAge(NaN, 1000)).toBe("fresh")
-    // Infinity is treated as a parse-failure sentinel rather than
-    // "infinitely old," since callers commonly forward through
-    // upstream `?? Infinity` defaults.
-    expect(bandFromAge(Infinity, 1000)).toBe("fresh")
+  })
+
+  it("classifies +Infinity age as expired (monotonic-in-age contract)", () => {
+    // Real "older than any finite TTL multiple" signal — must land in
+    // the oldest band, not silently be re-classified as fresh.
+    expect(bandFromAge(Infinity, 1000)).toBe("expired")
   })
 
   it("treats non-positive or non-finite TTLs as fresh (no divide-by-zero)", () => {

--- a/src/components/realtime/lifecycleBands.test.ts
+++ b/src/components/realtime/lifecycleBands.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+import {
+  DEFAULT_LIFECYCLE_THRESHOLDS,
+  bandFromAge,
+  type LifecycleBand,
+} from "./lifecycleBands"
+
+const DAY = 24 * 60 * 60 * 1000
+
+describe("bandFromAge", () => {
+  it("classifies the default schedule (1×/1.5×/3× TTL)", () => {
+    const ttl = 10 * DAY
+    expect(bandFromAge(0, ttl)).toBe("fresh")
+    expect(bandFromAge(5 * DAY, ttl)).toBe("fresh")
+    expect(bandFromAge(12 * DAY, ttl)).toBe("aging")
+    expect(bandFromAge(20 * DAY, ttl)).toBe("stale")
+    expect(bandFromAge(35 * DAY, ttl)).toBe("expired")
+  })
+
+  it("honors custom thresholds", () => {
+    const ttl = 10 * DAY
+    // With aging at 2×, age=12 days (which would be aging by default)
+    // is still fresh.
+    expect(bandFromAge(12 * DAY, ttl, { fresh: 2 })).toBe("fresh")
+    // Push stale boundary out — age=20 days now lands in aging instead
+    // of stale.
+    expect(bandFromAge(20 * DAY, ttl, { aging: 3, stale: 5 })).toBe("aging")
+  })
+
+  it("treats negative or non-finite ages as fresh (safest default — expired can be hidden)", () => {
+    expect(bandFromAge(-100, 1000)).toBe("fresh")
+    expect(bandFromAge(NaN, 1000)).toBe("fresh")
+    // Infinity is treated as a parse-failure sentinel rather than
+    // "infinitely old," since callers commonly forward through
+    // upstream `?? Infinity` defaults.
+    expect(bandFromAge(Infinity, 1000)).toBe("fresh")
+  })
+
+  it("treats non-positive or non-finite TTLs as fresh (no divide-by-zero)", () => {
+    expect(bandFromAge(5000, 0)).toBe("fresh")
+    expect(bandFromAge(5000, -1)).toBe("fresh")
+    expect(bandFromAge(5000, NaN)).toBe("fresh")
+  })
+
+  it("returns the four named bands and only those", () => {
+    const ttl = 100
+    const seen = new Set<LifecycleBand>()
+    for (let age = 0; age <= 500; age += 10) {
+      seen.add(bandFromAge(age, ttl))
+    }
+    expect(seen).toEqual(new Set<LifecycleBand>(["fresh", "aging", "stale", "expired"]))
+  })
+
+  it("exposes the default thresholds for downstream introspection", () => {
+    expect(DEFAULT_LIFECYCLE_THRESHOLDS).toEqual({ fresh: 1.0, aging: 1.5, stale: 3.0 })
+  })
+
+  it("is pure — same inputs always return same band", () => {
+    const a = bandFromAge(7 * DAY, 5 * DAY)
+    const b = bandFromAge(7 * DAY, 5 * DAY)
+    expect(a).toBe(b)
+  })
+})

--- a/src/components/realtime/lifecycleBands.ts
+++ b/src/components/realtime/lifecycleBands.ts
@@ -1,0 +1,79 @@
+// Temporal lifecycle bands — shared primitive.
+//
+// Semiotic ships three time-as-encoding systems that all answer "how
+// does this thing look as it ages?":
+//
+//   • `DecayConfig` — continuous opacity ramp keyed on buffer position
+//     (per-datum, in the streaming runtime)
+//   • `StalenessConfig` — binary live/stale on wall-clock idle
+//     (chart-wide, in the streaming runtime)
+//   • Annotation lifecycle — 4 named bands on `createdAt` + `ttlHint`
+//     (per-annotation, in `semiotic/ai`)
+//
+// `bandFromAge` is the small piece they can share: a pure classifier
+// that maps an age + TTL into one of four named bands. Today it
+// powers `annotationFreshnessFor` directly; future per-datum "banded
+// decay" (instead of the continuous ramp) and a banded staleness mode
+// (instead of binary live/stale) can opt in without each system
+// inventing its own thresholds.
+
+/**
+ * Named lifecycle bands. Shared by the annotation freshness surface
+ * today and available to other temporal-lifecycle policies that opt
+ * into banded classification.
+ */
+export type LifecycleBand = "fresh" | "aging" | "stale" | "expired"
+
+/**
+ * Multipliers of `ttlMs` that mark the upper edge of each band. The
+ * default schedule:
+ *
+ *   • `fresh`   — `age < 1.0 × ttl`
+ *   • `aging`   — `age < 1.5 × ttl`
+ *   • `stale`   — `age < 3.0 × ttl`
+ *   • `expired` — `age ≥ 3.0 × ttl`
+ *
+ * Override individual thresholds; missing entries fall back to the
+ * defaults. Setting a smaller value than the previous band's
+ * threshold is allowed but produces an unreachable band.
+ */
+export interface LifecycleBandThresholds {
+  /** Upper edge of the `fresh` band, as a multiple of `ttlMs`. Default `1.0`. */
+  fresh?: number
+  /** Upper edge of the `aging` band, as a multiple of `ttlMs`. Default `1.5`. */
+  aging?: number
+  /** Upper edge of the `stale` band, as a multiple of `ttlMs`. Default `3.0`. */
+  stale?: number
+}
+
+export const DEFAULT_LIFECYCLE_THRESHOLDS: Required<LifecycleBandThresholds> = {
+  fresh: 1.0,
+  aging: 1.5,
+  stale: 3.0,
+}
+
+/**
+ * Classify an age into a named band given a TTL.
+ *
+ * Pure function. Negative `ageMs` (future-dated items) classifies as
+ * `fresh`. Non-finite or non-positive `ttlMs` returns `fresh` rather
+ * than diving by zero — callers that need stricter handling should
+ * gate `ttlMs` before calling.
+ */
+export function bandFromAge(
+  ageMs: number,
+  ttlMs: number,
+  thresholds: LifecycleBandThresholds = {}
+): LifecycleBand {
+  if (!Number.isFinite(ttlMs) || ttlMs <= 0) return "fresh"
+  if (!Number.isFinite(ageMs) || ageMs < 0) return "fresh"
+
+  const fresh = thresholds.fresh ?? DEFAULT_LIFECYCLE_THRESHOLDS.fresh
+  const aging = thresholds.aging ?? DEFAULT_LIFECYCLE_THRESHOLDS.aging
+  const stale = thresholds.stale ?? DEFAULT_LIFECYCLE_THRESHOLDS.stale
+
+  if (ageMs < ttlMs * fresh) return "fresh"
+  if (ageMs < ttlMs * aging) return "aging"
+  if (ageMs < ttlMs * stale) return "stale"
+  return "expired"
+}

--- a/src/components/realtime/lifecycleBands.ts
+++ b/src/components/realtime/lifecycleBands.ts
@@ -55,10 +55,17 @@ export const DEFAULT_LIFECYCLE_THRESHOLDS: Required<LifecycleBandThresholds> = {
 /**
  * Classify an age into a named band given a TTL.
  *
- * Pure function. Negative `ageMs` (future-dated items) classifies as
- * `fresh`. Non-finite or non-positive `ttlMs` returns `fresh` rather
- * than diving by zero — callers that need stricter handling should
- * gate `ttlMs` before calling.
+ * Pure function. Edge cases:
+ *
+ * - **Negative age** (future-dated items): classifies as `fresh`.
+ * - **`NaN` age** (parse failure or `now - undefined`): classifies as
+ *   `fresh` — the safer default, since `expired` is filtered by the
+ *   visual treatment.
+ * - **`+Infinity` age**: classifies as `expired`. Monotonic in age —
+ *   "older than any finite TTL multiple" should be the oldest band.
+ * - **Non-finite / non-positive TTL**: classifies as `fresh`, since
+ *   there's no meaningful interval to age against. Callers that need
+ *   stricter handling should gate `ttlMs` before calling.
  */
 export function bandFromAge(
   ageMs: number,
@@ -66,7 +73,11 @@ export function bandFromAge(
   thresholds: LifecycleBandThresholds = {}
 ): LifecycleBand {
   if (!Number.isFinite(ttlMs) || ttlMs <= 0) return "fresh"
-  if (!Number.isFinite(ageMs) || ageMs < 0) return "fresh"
+  // `NaN` is the parse-failure sentinel — be lenient. `+Infinity` is a
+  // real "older than possible" signal — be strict.
+  if (Number.isNaN(ageMs)) return "fresh"
+  if (ageMs === Infinity) return "expired"
+  if (ageMs < 0) return "fresh"
 
   const fresh = thresholds.fresh ?? DEFAULT_LIFECYCLE_THRESHOLDS.fresh
   const aging = thresholds.aging ?? DEFAULT_LIFECYCLE_THRESHOLDS.aging

--- a/src/components/realtime/types.ts
+++ b/src/components/realtime/types.ts
@@ -14,15 +14,31 @@ export interface LineStyle {
 }
 
 /**
- * Anchoring mode for streaming annotations.
- * - `"fixed"` (default): anchored to specific datum coordinates; disappears when out of view.
- * - `"latest"`: annotation attaches to the most recent datum in the buffer.
- *   On each frame, the annotation's position is re-resolved to the latest data point.
- *   Useful for "current value" labels.
- * - `"sticky"`: annotation stays at its last known pixel position after the target datum
- *   is evicted from the window. It freezes in place rather than disappearing.
+ * How an annotation's anchor is resolved across renders. Shared between
+ * the streaming runtime (which implements the resolution) and the
+ * `semiotic/ai` annotation lifecycle surface (which exposes the choice
+ * to authors via `lifecycle.anchor`).
+ *
+ * - `"fixed"` (default): anchored to specific datum coordinates;
+ *   disappears when out of view.
+ * - `"latest"`: annotation re-pins to the most recent datum each frame.
+ * - `"sticky"`: annotation stays at its last known pixel position
+ *   after the target datum scrolls off; uses `stickyPositionCache`
+ *   on `AnnotationContext`.
+ * - `"semantic"`: re-resolves via `provenance.stableId` when new data
+ *   arrives, falling back to the recorded coordinate if the anchor
+ *   can no longer be located. Runtime implementation lands incrementally
+ *   alongside the AI annotation lifecycle work; today it behaves like
+ *   `"fixed"`.
  */
-export type AnnotationAnchorMode = "fixed" | "latest" | "sticky"
+export type AnnotationAnchor = "fixed" | "latest" | "sticky" | "semantic"
+
+/**
+ * @deprecated Use {@link AnnotationAnchor}. Kept as a back-compat alias
+ * because earlier 3.x releases shipped this name from the streaming
+ * surface; the `Mode` suffix added nothing semantically.
+ */
+export type AnnotationAnchorMode = AnnotationAnchor
 
 export interface AnnotationContext {
   scales?: {

--- a/src/components/semiotic-ai.ts
+++ b/src/components/semiotic-ai.ts
@@ -297,10 +297,21 @@ export type {
   EvaluateVariantProposalFn,
 } from "./ai/variantDiscovery"
 
-// Annotation provenance + lifecycle — type surface only (M1).
-// Behavior (`computeAnnotationFreshness`, default visual treatment,
-// stable-id anchor resolution) lands in subsequent milestones.
-export { withProvenance } from "./ai/annotationProvenance"
+// Annotation provenance + lifecycle.
+// M1: type surface + withProvenance builder.
+// M2: computeAnnotationFreshness + applyAnnotationLifecycle (default
+// visual treatment, overridable per band; expired hidden by default).
+// M3 still owed: stable-id anchor resolution after data refresh.
+export {
+  withProvenance,
+  withCurrentProvenance,
+  currentTimestamp,
+  computeAnnotationFreshness,
+  applyAnnotationLifecycle,
+  annotationFreshnessFor,
+  bandFromAge,
+  DEFAULT_LIFECYCLE_THRESHOLDS,
+} from "./ai/annotationProvenance"
 export type {
   AnnotationProvenance,
   AnnotationSource,
@@ -308,6 +319,11 @@ export type {
   AnnotationFreshness,
   AnnotationAnchor,
   Annotated,
+  ComputeAnnotationFreshnessOptions,
+  AnnotationLifecycleTreatment,
+  ApplyAnnotationLifecycleOptions,
+  LifecycleBand,
+  LifecycleBandThresholds,
 } from "./ai/annotationProvenance"
 
 // Conversation-arc telemetry — opt-in event vocabulary + ring-buffer store.

--- a/src/components/semiotic-realtime.ts
+++ b/src/components/semiotic-realtime.ts
@@ -72,3 +72,9 @@ export type {
   StreamStatusOptions,
   StreamStatusResult,
 } from "./charts/shared/useStreamStatus"
+
+// Shared lifecycle classifier — used by the annotation freshness
+// surface today, available to future banded-decay / banded-staleness
+// opt-ins without each system re-implementing the schedule.
+export { bandFromAge, DEFAULT_LIFECYCLE_THRESHOLDS } from "./realtime/lifecycleBands"
+export type { LifecycleBand, LifecycleBandThresholds } from "./realtime/lifecycleBands"


### PR DESCRIPTION
Introduce a Temporal Lifecycle feature and integrate annotation lifecycle primitives across docs and code. Adds docs/content: new TemporalLifecyclePage, nav entry, route, and expanded CLAUDE.md notes (including the "semantic" anchor and lifecycle helpers). Replace page-local freshness logic in blog and ConversationArc demos with exported helpers (applyAnnotationLifecycle, annotationFreshnessFor) and wire the demo UIs to the shared behavior. Code changes: add realtime lifecycleBands implementation and tests, expose lifecycle-related types/APIs (semiotic-ai / semiotic-realtime), and extend Annotation props to accept opacity and strokeDasharray so lifecycle visual treatments cascade. The changes unify banded freshness classification (bandFromAge) and provide a default visual treatment for aging/stale/expired annotations.

This pull request introduces a major update to the annotation lifecycle and freshness system in the documentation and demo code. It replaces local, ad-hoc annotation aging logic with the new shipped library helpers (`applyAnnotationLifecycle`, `annotationFreshnessFor`), ensuring consistency between documentation, demos, and the underlying library behavior. Additionally, it documents and surfaces the new temporal lifecycle system in the docs site navigation.

**Annotation Lifecycle and Freshness System**

- Replaces all local annotation freshness and styling logic in demos with the new `applyAnnotationLifecycle` and `annotationFreshnessFor` helpers, ensuring annotations fade, dash, and expire according to the library's default treatment. Expired annotations are filtered by default, and per-band label suffixes are supported. (`docs/src/blog/entries/talk-track-intelligence.js`, `docs/src/pages/features/ConversationArcPage.js`) [[1]](diffhunk://#diff-6d5c95b74546e731bc45068fc1aa1c1a9be758f657c1ca153d3cb33c1a64bc59L270-R297) [[2]](diffhunk://#diff-6d5c95b74546e731bc45068fc1aa1c1a9be758f657c1ca153d3cb33c1a64bc59L496-R476) [[3]](diffhunk://#diff-1ecb2ddfe2f3ae239d9350d1504b388fc16f6c0b18f40b098ee219662217d347L459-R477)
- Removes custom ISO duration parsing and local freshness computation methods in favor of the new helpers. (`docs/src/blog/entries/talk-track-intelligence.js`, `docs/src/pages/features/ConversationArcPage.js`) [[1]](diffhunk://#diff-6d5c95b74546e731bc45068fc1aa1c1a9be758f657c1ca153d3cb33c1a64bc59L270-R297) [[2]](diffhunk://#diff-1ecb2ddfe2f3ae239d9350d1504b388fc16f6c0b18f40b098ee219662217d347L381-L427)

**Documentation and Navigation**

- Expands the `CLAUDE.md` documentation to describe the new annotation lifecycle, freshness helpers, and temporal lifecycle policies, including API examples and a comparison table for different aging policies. (`CLAUDE.md`) [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L242-R242) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L345-R401)
- Adds a dedicated Temporal Lifecycle documentation page and links it in the site navigation and routing. (`docs/src/App.js`, `docs/src/components/navData.js`) [[1]](diffhunk://#diff-0a39c0f0ea64594aef352a62c1b59bc44814bbfb1dc3c9e2511acd9770a281f2R100) [[2]](diffhunk://#diff-0a39c0f0ea64594aef352a62c1b59bc44814bbfb1dc3c9e2511acd9770a281f2R405) [[3]](diffhunk://#diff-0e9b4495873193679d9f273691fe01757f807fcafbf78074bdb2c758b56986a1R133)

**Code Quality and Consistency**

- Refactors demo and page code to use consistent, modern React patterns (e.g., effect dependencies, style props) and cleans up formatting for better readability. (`docs/src/pages/features/ConversationArcPage.js`) [[1]](diffhunk://#diff-1ecb2ddfe2f3ae239d9350d1504b388fc16f6c0b18f40b098ee219662217d347L154-R162) [[2]](diffhunk://#diff-1ecb2ddfe2f3ae239d9350d1504b388fc16f6c0b18f40b098ee219662217d347L181-R196) [[3]](diffhunk://#diff-1ecb2ddfe2f3ae239d9350d1504b388fc16f6c0b18f40b098ee219662217d347L229-R244) [[4]](diffhunk://#diff-1ecb2ddfe2f3ae239d9350d1504b388fc16f6c0b18f40b098ee219662217d347L273-R289) [[5]](diffhunk://#diff-1ecb2ddfe2f3ae239d9350d1504b388fc16f6c0b18f40b098ee219662217d347L282-R319) [[6]](diffhunk://#diff-1ecb2ddfe2f3ae239d9350d1504b388fc16f6c0b18f40b098ee219662217d347L324-R347) [[7]](diffhunk://#diff-1ecb2ddfe2f3ae239d9350d1504b388fc16f6c0b18f40b098ee219662217d347L360-R381) [[8]](diffhunk://#diff-1ecb2ddfe2f3ae239d9350d1504b388fc16f6c0b18f40b098ee219662217d347L501-R497)

These changes ensure that annotation lifecycle behavior is accurate, consistent, and easy to maintain across the documentation and demos, while making the new temporal lifecycle features discoverable to users.