### PR TITLE
AccessibleDataTable: paging, datum extraction

### DIFF
--- a/docs/src/pages/features/AccessibilityPage.js
+++ b/docs/src/pages/features/AccessibilityPage.js
@@ -251,7 +251,7 @@ export default function AccessibilityPage() {
 </ChartContainer>
 
 // The summary shows:
-// "72 data points. month: 1 to 12, mean 6.5. sales: 12000 to 27000, mean 18500."
+// "72 data points. month: 1 to 12, mean 6.5. revenue: 12000 to 27000, mean 18500."
 // + a sample table of the real data values, pageable to all 72 rows
 
 // For screen readers, the summary is always available via a hidden button

--- a/docs/src/pages/features/AccessibilityPage.js
+++ b/docs/src/pages/features/AccessibilityPage.js
@@ -218,13 +218,18 @@ export default function AccessibilityPage() {
       <h3 id="data-summary">Data Summary</h3>
 
       <p>
-        Every chart includes a JIT data summary — a statistical overview plus 5
-        sample rows, computed on demand (not on every render). Screen reader users
-        can activate a "View data summary" button inside the chart; sighted users
-        can trigger it from the ChartContainer toolbar. Either way, the summary
-        describes the data shape the way <code>.describe()</code> and{" "}
-        <code>.head()</code> do in pandas: field ranges, means, unique categories,
-        then a small sample table.
+        Every chart includes a JIT data summary — a statistical overview plus a
+        sample of rows (5 to start), computed on demand (not on every render).
+        Screen reader users can activate a "View data summary" button inside the
+        chart; sighted users can trigger it from the ChartContainer toolbar.
+        Either way, the summary describes the data shape the way{" "}
+        <code>.describe()</code> and <code>.head()</code> do in pandas: field
+        ranges, means, unique categories, then a sample table. The table shows
+        the <strong>actual data values</strong> (your accessor fields, e.g.{" "}
+        <code>month</code> / <code>sales</code>), not pixel coordinates, and a{" "}
+        <strong>"Show more rows"</strong> button pages through to the full dataset
+        in bounded chunks — so a 50k-row chart never instantiates a giant table at
+        once, but the data is never hidden either.
       </p>
 
       <p>
@@ -246,8 +251,8 @@ export default function AccessibilityPage() {
 </ChartContainer>
 
 // The summary shows:
-// "72 data points. x: 1 to 12, mean 6.5. y: 12000 to 27000, mean 18500."
-// + a 5-row sample table
+// "72 data points. month: 1 to 12, mean 6.5. sales: 12000 to 27000, mean 18500."
+// + a sample table of the real data values, pageable to all 72 rows
 
 // For screen readers, the summary is always available via a hidden button
 // (accessibleTable={true} by default). The ChartContainer action just
@@ -472,7 +477,7 @@ const result = diagnoseConfig("LineChart", {
             ["title", "string | ReactNode", "-", "Visible heading; fallback aria-label when description is not set"],
             ["description", "string", "-", "Overrides the auto-generated aria-label with a detailed description"],
             ["summary", "string", "-", "Screen-reader-only note (role=\"note\") for trends or key takeaways"],
-            ["accessibleTable", "boolean", "true", "Enable JIT data summary (stats + 5 sample rows) for screen readers"],
+            ["accessibleTable", "boolean", "true", "Enable JIT data summary (stats + pageable sample rows) for screen readers"],
             ["actions.dataSummary", "boolean", "false", "ChartContainer: toolbar button to show data summary visibly"],
           ].map(([prop, type, def, desc], i) => (
             <tr key={i} style={{ borderBottom: "1px solid var(--surface-3)" }}>

--- a/src/components/stream/AccessibleDataTable.test.tsx
+++ b/src/components/stream/AccessibleDataTable.test.tsx
@@ -211,6 +211,18 @@ describe("AccessibleDataTable — focus & pagination", () => {
     // No further "Show more" once everything is shown.
     expect(screen.queryByRole("button", { name: /show .* more/i })).toBeNull()
   })
+
+  it("resets paging back to the initial sample after the panel collapses", () => {
+    render(<AccessibleDataTable tableId="t4" chartType="line chart" scene={lineScene(40)} />)
+    fireEvent.click(screen.getByRole("button", { name: /view data summary/i }))
+    fireEvent.click(screen.getByRole("button", { name: /show .* more rows/i }))
+    expect(screen.getAllByRole("row")).toHaveLength(30 + 1)
+
+    // Collapse, then reopen — must be back to the bounded 5-row sample, not 30.
+    fireEvent.click(screen.getByRole("button", { name: /close data summary/i }))
+    fireEvent.click(screen.getByRole("button", { name: /view data summary/i }))
+    expect(screen.getAllByRole("row")).toHaveLength(5 + 1)
+  })
 })
 
 // ── extractAllRows logic ────────────────────────────────────────────────

--- a/src/components/stream/AccessibleDataTable.test.tsx
+++ b/src/components/stream/AccessibleDataTable.test.tsx
@@ -5,6 +5,7 @@ import {
   NetworkAccessibleDataTable,
   computeCanvasAriaLabel,
   computeNetworkAriaLabel,
+  extractAllRows,
 } from "./AccessibleDataTable"
 import type { Datum } from "../charts/shared/datumTypes"
 
@@ -168,154 +169,164 @@ describe("AccessibleDataTable styling hooks", () => {
   })
 })
 
-// ── extractAllRows logic (tested via internal behavior) ─────────────────
+// ── interaction fixes (issue #971) ──────────────────────────────────────
 
-// Since extractAllRows is not exported, we test it indirectly by exercising
-// the same data shapes that would flow through AccessibleDataTable.
-// We test the extraction patterns inline here.
-
-describe("extractAllRows — data shape resilience", () => {
-  // We recreate the extraction logic to test it in isolation
-  function extractRow(node: any): any | null {
-    switch (node.type) {
-      case "point":
-        return { label: "Point", values: { x: node.x, y: node.y } }
-      case "line": {
-        const path = node.path
-        const data = Array.isArray(node.datum) ? node.datum : []
-        if (!path) return null
-        const rows = []
-        for (let i = 0; i < path.length && i < data.length; i++) {
-          rows.push({ label: "Line point", values: { x: path[i][0], y: path[i][1] } })
-        }
-        return rows
-      }
-      case "rect": {
-        const datum = node.datum ?? {}
-        const category = datum.category ?? node.group ?? ""
-        const rawValue = datum.value ?? datum.__aggregateValue ?? datum.total
-        return { label: "Bar", values: { category, value: rawValue ?? "" } }
-      }
-      case "wedge":
-        return {
-          label: "Wedge",
-          values: {
-            category: node.datum?.category ?? node.datum?.label ?? "",
-            value: node.datum?.value ?? "",
-          },
-        }
-      case "circle":
-        return {
-          label: "Node",
-          values: { id: node.datum?.id || "", x: node.cx ?? node.x, y: node.cy ?? node.y },
-        }
-      default:
-        return null
-    }
-  }
-
-  it("handles point with undefined x/y", () => {
-    const row = extractRow({ type: "point" })
-    expect(row).toEqual({ label: "Point", values: { x: undefined, y: undefined } })
-  })
-
-  it("handles point with NaN values", () => {
-    const row = extractRow({ type: "point", x: NaN, y: NaN })
-    expect(row).toEqual({ label: "Point", values: { x: NaN, y: NaN } })
-  })
-
-  it("handles point with Infinity", () => {
-    const row = extractRow({ type: "point", x: Infinity, y: -Infinity })
-    expect(row!.values.x).toBe(Infinity)
-    expect(row!.values.y).toBe(-Infinity)
-  })
-
-  it("handles point with string coordinates (mistyped data)", () => {
-    const row = extractRow({ type: "point", x: "hello", y: "world" })
-    expect(row!.values.x).toBe("hello")
-    expect(row!.values.y).toBe("world")
-  })
-
-  it("handles line with null path", () => {
-    const row = extractRow({ type: "line", path: null, datum: [] })
-    expect(row).toBeNull()
-  })
-
-  it("handles line with undefined path", () => {
-    const row = extractRow({ type: "line", datum: [] })
-    expect(row).toBeNull()
-  })
-
-  it("handles line with empty path/datum arrays", () => {
-    const rows = extractRow({ type: "line", path: [], datum: [] })
-    expect(rows).toEqual([])
-  })
-
-  it("handles line where datum is not an array", () => {
-    const rows = extractRow({ type: "line", path: [[0, 0], [1, 1]], datum: "not-an-array" })
-    expect(rows).toEqual([]) // data becomes [], so loop never runs
-  })
-
-  it("handles line with mismatched path/datum lengths", () => {
-    const rows = extractRow({
+describe("AccessibleDataTable — focus & pagination", () => {
+  const lineScene = (n: number) => [
+    {
       type: "line",
-      path: [[0, 0], [1, 1], [2, 2], [3, 3]],
-      datum: [{ x: 0 }, { x: 1 }], // only 2 datums for 4 path points
-    })
-    expect(rows).toHaveLength(2) // min(4, 2)
+      path: Array.from({ length: n }, (_, i) => [i, i]),
+      datum: Array.from({ length: n }, (_, i) => ({ month: i + 1, sales: 100 * (i + 1) })),
+    },
+  ]
+
+  it("does NOT auto-expand when focus bubbles up from the trigger button", () => {
+    render(<AccessibleDataTable tableId="t1" chartType="line chart" scene={lineScene(3)} />)
+    // Focusing the inner button (target !== region container) must not expand.
+    fireEvent.focus(screen.getByRole("button", { name: /view data summary/i }))
+    expect(screen.queryByRole("table")).toBeNull()
   })
 
-  it("handles rect with no datum at all", () => {
-    const row = extractRow({ type: "rect" })
-    expect(row).toEqual({ label: "Bar", values: { category: "", value: "" } })
+  it("auto-expands when the region container itself receives focus (skip-link path)", () => {
+    render(<AccessibleDataTable tableId="t2" chartType="line chart" scene={lineScene(3)} />)
+    const region = screen.getByRole("region", { name: /data summary for line chart/i })
+    fireEvent.focus(region) // target === currentTarget
+    expect(screen.getByRole("table")).toBeInTheDocument()
   })
 
-  it("handles rect where datum is a primitive", () => {
-    const row = extractRow({ type: "rect", datum: 42 })
-    // datum ?? {} → 42, then 42.category → undefined, node.group → undefined
-    expect(row!.label).toBe("Bar")
+  it("pages through rows beyond the initial sample via Show more", () => {
+    render(<AccessibleDataTable tableId="t3" chartType="line chart" scene={lineScene(40)} />)
+    fireEvent.click(screen.getByRole("button", { name: /view data summary/i }))
+
+    // Initial sample is 5 rows (+1 header row).
+    expect(screen.getAllByRole("row")).toHaveLength(5 + 1)
+    expect(screen.getByText(/first 5 of 40 data points/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: /show .* more rows/i }))
+    expect(screen.getAllByRole("row")).toHaveLength(30 + 1) // 5 + 25 page
+
+    fireEvent.click(screen.getByRole("button", { name: /show .* more rows/i }))
+    expect(screen.getAllByRole("row")).toHaveLength(40 + 1) // capped at total
+    expect(screen.getByText(/all 40 data points/i)).toBeInTheDocument()
+    // No further "Show more" once everything is shown.
+    expect(screen.queryByRole("button", { name: /show .* more/i })).toBeNull()
+  })
+})
+
+// ── extractAllRows logic ────────────────────────────────────────────────
+
+describe("extractAllRows — surfaces raw data, not pixels", () => {
+  it("emits a scatter point's raw datum fields, not pixel x/y", () => {
+    // The scene node carries pixel x/y for rendering; the table must show data.
+    const rows = extractAllRows([
+      { type: "point", x: 412, y: 88, datum: { month: 1, sales: 4200 } },
+    ])
+    expect(rows).toEqual([{ label: "Point", values: { month: 1, sales: 4200 } }])
   })
 
-  it("handles rect with __aggregateValue fallback", () => {
-    const row = extractRow({ type: "rect", datum: { __aggregateValue: 99 } })
-    expect(row!.values.value).toBe(99)
+  it("emits each line vertex from the datum array (data, not path pixels)", () => {
+    const rows = extractAllRows([
+      {
+        type: "line",
+        path: [[0, 0], [50, 50]], // pixel path — must be ignored
+        datum: [{ month: 1, sales: 4200 }, { month: 2, sales: 5100 }],
+      },
+    ])
+    expect(rows).toEqual([
+      { label: "Line point", values: { month: 1, sales: 4200 } },
+      { label: "Line point", values: { month: 2, sales: 5100 } },
+    ])
   })
 
-  it("handles rect with total fallback", () => {
-    const row = extractRow({ type: "rect", datum: { total: 50 } })
-    expect(row!.values.value).toBe(50)
+  it("emits area vertices from the datum array", () => {
+    const rows = extractAllRows([
+      { type: "area", topPath: [[0, 0]], datum: [{ x: 1, y: 2 }] },
+    ])
+    expect(rows).toEqual([{ label: "Area point", values: { x: 1, y: 2 } }])
   })
 
-  it("handles wedge with no datum", () => {
-    const row = extractRow({ type: "wedge" })
-    expect(row).toEqual({ label: "Wedge", values: { category: "", value: "" } })
+  it("skips redundant point nodes when a series node carries the same data", () => {
+    // showPoints=true emits both a line node and per-point nodes; the points
+    // are decorative duplicates and must not double-count.
+    const rows = extractAllRows([
+      { type: "line", path: [[0, 0]], datum: [{ month: 1, sales: 4200 }] },
+      { type: "point", x: 412, y: 88, datum: { month: 1, sales: 4200 } },
+    ])
+    expect(rows).toEqual([{ label: "Line point", values: { month: 1, sales: 4200 } }])
   })
 
-  it("handles wedge where datum.category is 0 (falsy but valid)", () => {
-    const row = extractRow({ type: "wedge", datum: { category: 0, value: 100 } })
-    // ?? preserves 0 (unlike ||)
-    expect(row!.values.category).toBe(0)
-    expect(row!.values.value).toBe(100)
+  it("emits a candlestick's raw OHLC datum, not undefined node fields", () => {
+    // The node only carries openY/closeY pixels — node.open etc. don't exist.
+    const rows = extractAllRows([
+      {
+        type: "candlestick",
+        x: 100, openY: 50, closeY: 20, highY: 10, lowY: 60,
+        datum: { date: "2024-01-01", open: 10, high: 15, low: 8, close: 12 },
+      },
+    ])
+    expect(rows[0].values).toEqual({ date: "2024-01-01", open: 10, high: 15, low: 8, close: 12 })
   })
 
-  it("handles circle with cx/cy", () => {
-    const row = extractRow({ type: "circle", cx: 10, cy: 20, datum: { id: "a" } })
-    expect(row!.values).toEqual({ id: "a", x: 10, y: 20 })
+  it("falls back to the rendered cell value when a heatcell datum omits it", () => {
+    const rows = extractAllRows([
+      { type: "heatcell", x: 5, y: 9, value: 42, datum: { row: "A", col: "B" } },
+    ])
+    expect(rows[0].values).toEqual({ row: "A", col: "B", value: 42 })
   })
 
-  it("handles circle with x/y fallback", () => {
-    const row = extractRow({ type: "circle", x: 5, y: 15, datum: { id: "b" } })
-    expect(row!.values).toEqual({ id: "b", x: 5, y: 15 })
+  it("skips synthetic underscore-prefixed keys", () => {
+    const rows = extractAllRows([
+      { type: "point", x: 1, y: 2, datum: { month: 1, _transitionKey: "k", _decayOpacity: 0.5 } },
+    ])
+    expect(rows[0].values).toEqual({ month: 1 })
   })
 
-  it("handles circle with no datum", () => {
-    const row = extractRow({ type: "circle", cx: 0, cy: 0 })
-    expect(row!.values).toEqual({ id: "", x: 0, y: 0 })
+  it("preserves a falsy-but-valid 0 value", () => {
+    const rows = extractAllRows([
+      { type: "point", x: 1, y: 2, datum: { month: 0, sales: 4200 } },
+    ])
+    expect(rows[0].values).toEqual({ month: 0, sales: 4200 })
+  })
+})
+
+describe("extractAllRows — data shape resilience (never throws)", () => {
+  it("returns [] for a non-array scene", () => {
+    expect(extractAllRows(null as any)).toEqual([])
+    expect(extractAllRows("nope" as any)).toEqual([])
   })
 
-  it("handles unknown type gracefully", () => {
-    const row = extractRow({ type: "hologram" })
-    expect(row).toBeNull()
+  it("skips nodes with null datum", () => {
+    expect(extractAllRows([{ type: "point", datum: null }])).toEqual([])
+  })
+
+  it("handles a point with no datum (empty values, no throw)", () => {
+    const rows = extractAllRows([{ type: "point", x: NaN, y: NaN }])
+    expect(rows).toEqual([{ label: "Point", values: {} }])
+  })
+
+  it("handles a line whose datum is not an array", () => {
+    expect(extractAllRows([{ type: "line", path: [[0, 0]], datum: "not-an-array" }])).toEqual([])
+  })
+
+  it("drops non-finite and non-primitive datum fields", () => {
+    const rows = extractAllRows([
+      { type: "point", x: 1, y: 2, datum: { a: Infinity, b: NaN, c: { nested: 1 }, d: 5 } },
+    ])
+    expect(rows[0].values).toEqual({ d: 5 })
+  })
+
+  it("keeps the rect aggregate-value fallbacks", () => {
+    expect(extractAllRows([{ type: "rect", datum: { __aggregateValue: 99 } }])[0].values.value).toBe(99)
+    expect(extractAllRows([{ type: "rect", datum: { total: 50 } }])[0].values.value).toBe(50)
+  })
+
+  it("preserves a wedge category of 0", () => {
+    const rows = extractAllRows([{ type: "wedge", datum: { category: 0, value: 100 } }])
+    expect(rows[0].values).toEqual({ category: 0, value: 100 })
+  })
+
+  it("skips unknown node types", () => {
+    expect(extractAllRows([{ type: "hologram", datum: { a: 1 } }])).toEqual([])
   })
 })
 

--- a/src/components/stream/AccessibleDataTable.tsx
+++ b/src/components/stream/AccessibleDataTable.tsx
@@ -92,39 +92,62 @@ const fmt = (v: number | undefined | null): string => {
 
 interface DataRow { label: string; values: Record<string, string | number> }
 
-/** Extract a flat list of typed rows from scene nodes, preserving raw numeric values.
- *  Defensively handles missing/malformed data — never throws. */
-function extractAllRows(scene: AnySceneNode[]): DataRow[] {
+/** Pull primitive, user-facing fields from a raw datum into a display row.
+ *  Skips synthetic/internal keys (leading underscore) and non-primitive
+ *  values. This surfaces the original data (e.g. `month`, `sales`) rather
+ *  than the pixel coordinates the scene node carries for rendering. */
+function datumToValues(datum: unknown): Record<string, string | number> {
+  const values: Record<string, string | number> = {}
+  if (datum == null || typeof datum !== "object") return values
+  for (const [k, v] of Object.entries(datum as Record<string, unknown>)) {
+    if (k.startsWith("_")) continue // synthetic/internal keys
+    if (v == null || v === "") continue
+    if (typeof v === "number") {
+      if (Number.isFinite(v)) values[k] = v
+    } else if (typeof v === "string") {
+      values[k] = v
+    } else if (typeof v === "boolean") {
+      values[k] = String(v)
+    } else if (v instanceof Date) {
+      values[k] = v.toISOString().slice(0, 10)
+    }
+    // nested objects / functions are not meaningful in a flat table — skip
+  }
+  return values
+}
+
+/** Extract a flat list of typed rows from scene nodes, surfacing the raw datum
+ *  fields (not pixel coordinates). Defensively handles missing/malformed data —
+ *  never throws. Exported for direct testing. */
+export function extractAllRows(scene: AnySceneNode[]): DataRow[] {
   const rows: DataRow[] = []
   if (!Array.isArray(scene)) return rows
+
+  // When a chart draws line/area series, each series node already carries its
+  // full datum array — the standalone point nodes (emitted only when
+  // `showPoints` is on) are decorative duplicates of the same data. Extract
+  // the series rows and skip the redundant points. Scatterplots have points
+  // and no series, so they still flow through the "point" case below.
+  const hasSeriesNodes = scene.some(
+    (n) => n && (n.type === "line" || n.type === "area")
+  )
 
   for (const node of scene) {
     if (!node || typeof node !== "object") continue
     if (node.datum === null) continue
     try {
       switch (node.type) {
-        case "point":
-          rows.push({ label: "Point", values: { x: node.x, y: node.y } })
-          break
-        case "line": {
-          const path = node.path
-          const data = Array.isArray(node.datum) ? node.datum : []
-          if (!Array.isArray(path)) break
-          for (let i = 0; i < path.length && i < data.length; i++) {
-            const pt = path[i]
-            if (!Array.isArray(pt)) continue
-            rows.push({ label: "Line point", values: { x: pt[0], y: pt[1] } })
-          }
+        case "point": {
+          if (hasSeriesNodes) break
+          rows.push({ label: "Point", values: datumToValues(node.datum) })
           break
         }
+        case "line":
         case "area": {
-          const topPath = node.topPath
           const data = Array.isArray(node.datum) ? node.datum : []
-          if (!Array.isArray(topPath)) break
-          for (let i = 0; i < topPath.length && i < data.length; i++) {
-            const pt = topPath[i]
-            if (!Array.isArray(pt)) continue
-            rows.push({ label: "Area point", values: { x: pt[0], y: pt[1] } })
+          const label = node.type === "line" ? "Line point" : "Area point"
+          for (const d of data) {
+            rows.push({ label, values: datumToValues(d) })
           }
           break
         }
@@ -135,9 +158,15 @@ function extractAllRows(scene: AnySceneNode[]): DataRow[] {
           rows.push({ label: "Bar", values: { category, value: rawValue ?? "" } })
           break
         }
-        case "heatcell":
-          rows.push({ label: "Cell", values: { x: node.x, y: node.y, value: node.value } })
+        case "heatcell": {
+          const values = datumToValues(node.datum)
+          // Fall back to the rendered cell value when datum omits it
+          if (values.value == null && typeof node.value === "number" && Number.isFinite(node.value)) {
+            values.value = node.value
+          }
+          rows.push({ label: "Cell", values })
           break
+        }
         case "wedge":
           rows.push({
             label: "Wedge",
@@ -148,22 +177,13 @@ function extractAllRows(scene: AnySceneNode[]): DataRow[] {
           })
           break
         case "circle":
-          rows.push({
-            label: "Node",
-            values: { id: node.datum?.id ?? "", x: node.cx ?? node.x, y: node.cy ?? node.y },
-          })
+          rows.push({ label: "Node", values: datumToValues(node.datum) })
           break
         case "arc":
-          rows.push({
-            label: "Arc",
-            values: { id: node.datum?.id ?? "", x: node.cx ?? node.x, y: node.cy ?? node.y },
-          })
+          rows.push({ label: "Arc", values: datumToValues(node.datum) })
           break
         case "candlestick":
-          rows.push({
-            label: "Candlestick",
-            values: { x: node.x, open: node.open, high: node.high, low: node.low, close: node.close },
-          })
+          rows.push({ label: "Candlestick", values: datumToValues(node.datum) })
           break
         case "geoarea":
           rows.push({
@@ -271,6 +291,10 @@ interface AccessibleDataTableProps {
 }
 
 const SAMPLE_SIZE = 5
+/** Rows revealed per "Show more" click. Bounded paging keeps a 50k-row dataset
+ *  from instantiating a giant table in one go while still letting a determined
+ *  user page all the way through their data. */
+const PAGE_SIZE = 25
 const DATA_TABLE_CLASS = "semiotic-accessible-data-table"
 const DATA_TABLE_HIDDEN_CLASS = `${DATA_TABLE_CLASS} semiotic-accessible-data-table-hidden`
 const DATA_TABLE_VISIBLE_CLASS = `${DATA_TABLE_CLASS} semiotic-accessible-data-table-visible`
@@ -351,6 +375,18 @@ const CAPTION_STYLE: React.CSSProperties = {
   fontStyle: "italic",
 }
 
+const SHOW_MORE_BUTTON_STYLE: React.CSSProperties = {
+  marginTop: 8,
+  padding: "4px 10px",
+  fontSize: 12,
+  cursor: "pointer",
+  border: "1px solid var(--semiotic-data-table-border, var(--semiotic-border, #e0e0e0))",
+  borderRadius: "var(--semiotic-border-radius, 4px)",
+  background: "var(--semiotic-data-table-bg, var(--semiotic-surface, var(--semiotic-bg, #fff)))",
+  color: "var(--semiotic-data-table-text, var(--semiotic-text, #333))",
+  fontFamily: "inherit",
+}
+
 function fmtCell(v: unknown): string {
   if (v == null || v === "") return "—"
   if (typeof v === "number") {
@@ -365,18 +401,24 @@ function fmtCell(v: unknown): string {
 /**
  * JIT accessible data summary. Renders a lightweight sr-only button by default.
  * On activation (or when ChartContainer's dataSummary action is toggled),
- * computes a statistical summary (.describe()-style) and shows 5 sample rows.
+ * computes a statistical summary (.describe()-style) and shows a sample of rows
+ * (5 to start), pageable to the full dataset via "Show more".
  */
 export function AccessibleDataTable({ scene, chartType, tableId, chartTitle }: AccessibleDataTableProps) {
   const [srExpanded, setSrExpanded] = React.useState(false)
+  const [visibleCount, setVisibleCount] = React.useState(SAMPLE_SIZE)
   const dataSummary = useDataSummary()
   const visible = dataSummary?.visible ?? false
   const isExpanded = srExpanded || visible
   const containerRef = React.useRef<HTMLDivElement>(null)
   const regionLabel = chartTitle ? `Data summary for ${chartTitle}` : tableId ? `Data summary for ${chartType} ${tableId}` : `Data summary for ${chartType}`
 
-  // When the skip link targets this element, expand visibly.
-  const handleFocus = React.useCallback(() => {
+  // Expand only when focus lands on the region container itself (the skip-link
+  // path programmatically focuses it). Focus bubbling up from the inner trigger
+  // button must NOT auto-expand — otherwise merely tabbing onto the button
+  // forces the screen reader through the entire table without the user opting in.
+  const handleFocus = React.useCallback((e: React.FocusEvent) => {
+    if (e.target !== e.currentTarget) return
     if (!srExpanded && !visible) setSrExpanded(true)
   }, [srExpanded, visible])
 
@@ -408,7 +450,9 @@ export function AccessibleDataTable({ scene, chartType, tableId, chartTitle }: A
   const allRows = extractAllRows(scene)
   const fieldStats = computeFieldStats(allRows)
   const summary = formatSummary(allRows.length, fieldStats)
-  const sampleRows = allRows.slice(0, SAMPLE_SIZE)
+  const shownCount = Math.min(visibleCount, allRows.length)
+  const sampleRows = allRows.slice(0, shownCount)
+  const remaining = allRows.length - shownCount
 
   const columnSet = new Set<string>()
   for (const r of sampleRows) {
@@ -419,7 +463,10 @@ export function AccessibleDataTable({ scene, chartType, tableId, chartTitle }: A
   const dismiss = () => {
     if (visible && dataSummary) dataSummary.setVisible(false)
     setSrExpanded(false)
+    setVisibleCount(SAMPLE_SIZE)
   }
+
+  const showMore = () => setVisibleCount((c) => c + PAGE_SIZE)
 
   return (
     <div ref={containerRef} id={tableId} className={DATA_TABLE_VISIBLE_CLASS} tabIndex={-1} onBlur={handleBlur} style={VISIBLE_PANEL_STYLE} role="region" aria-label={regionLabel}>
@@ -427,7 +474,7 @@ export function AccessibleDataTable({ scene, chartType, tableId, chartTitle }: A
       <div className="semiotic-accessible-data-table-summary" role="note" style={SUMMARY_NOTE_STYLE}>{summary}</div>
       <table className="semiotic-accessible-data-table-table" role="table" aria-label={`Sample data for ${chartType}`} style={VISIBLE_TABLE_STYLE}>
         <caption className="semiotic-accessible-data-table-caption" style={CAPTION_STYLE}>
-          First {sampleRows.length} of {allRows.length} data points
+          {remaining > 0 ? `First ${shownCount} of ${allRows.length} data points` : `All ${allRows.length} data points`}
         </caption>
         <thead>
           <tr>
@@ -448,6 +495,11 @@ export function AccessibleDataTable({ scene, chartType, tableId, chartTitle }: A
           ))}
         </tbody>
       </table>
+      {remaining > 0 && (
+        <button type="button" className="semiotic-accessible-data-table-show-more" onClick={showMore} style={SHOW_MORE_BUTTON_STYLE}>
+          Show {Math.min(PAGE_SIZE, remaining)} more {remaining === 1 ? "row" : "rows"} ({remaining} remaining)
+        </button>
+      )}
     </div>
   )
 }
@@ -467,13 +519,18 @@ interface NetworkAccessibleDataTableProps {
  */
 export function NetworkAccessibleDataTable({ nodes, edges, chartType, tableId, chartTitle }: NetworkAccessibleDataTableProps) {
   const [srExpanded, setSrExpanded] = React.useState(false)
+  const [visibleCount, setVisibleCount] = React.useState(SAMPLE_SIZE)
   const dataSummary = useDataSummary()
   const visible = dataSummary?.visible ?? false
   const isExpanded = srExpanded || visible
   const regionLabel = chartTitle ? `Data summary for ${chartTitle}` : tableId ? `Data summary for ${chartType} ${tableId}` : `Data summary for ${chartType}`
   const containerRef = React.useRef<HTMLDivElement>(null)
 
-  const handleFocus = React.useCallback(() => {
+  // Only the skip-link path (which focuses the region container itself) auto-
+  // expands; focus bubbling from the inner trigger button must not. See the
+  // matching note in AccessibleDataTable.
+  const handleFocus = React.useCallback((e: React.FocusEvent) => {
+    if (e.target !== e.currentTarget) return
     if (!srExpanded && !visible) setSrExpanded(true)
   }, [srExpanded, visible])
 
@@ -565,12 +622,17 @@ export function NetworkAccessibleDataTable({ nodes, edges, chartType, tableId, c
     summaryParts.push(`Mean degree: ${fmt(avgDegree)}, max degree: ${maxDegree}.`)
   }
 
-  const sampleNodes = nodeRows.slice(0, SAMPLE_SIZE)
+  const shownCount = Math.min(visibleCount, nodeRows.length)
+  const sampleNodes = nodeRows.slice(0, shownCount)
+  const remaining = nodeRows.length - shownCount
 
   const dismiss = () => {
     if (visible && dataSummary) dataSummary.setVisible(false)
     setSrExpanded(false)
+    setVisibleCount(SAMPLE_SIZE)
   }
+
+  const showMore = () => setVisibleCount((c) => c + PAGE_SIZE)
 
   return (
     <div ref={containerRef} id={tableId} className={DATA_TABLE_NETWORK_CLASS} tabIndex={-1} onBlur={handleBlur} style={VISIBLE_PANEL_STYLE} role="region" aria-label={regionLabel}>
@@ -578,7 +640,7 @@ export function NetworkAccessibleDataTable({ nodes, edges, chartType, tableId, c
       <div className="semiotic-accessible-data-table-summary" role="note" style={SUMMARY_NOTE_STYLE}>{summaryParts.join(" ")}</div>
       <table className="semiotic-accessible-data-table-table" role="table" aria-label={`Node degree summary for ${chartType}`} style={VISIBLE_TABLE_STYLE}>
         <caption className="semiotic-accessible-data-table-caption" style={CAPTION_STYLE}>
-          Top {sampleNodes.length} of {nodeRows.length} nodes by degree
+          {remaining > 0 ? `Top ${shownCount} of ${nodeRows.length} nodes by degree` : `All ${nodeRows.length} nodes by degree`}
         </caption>
         <thead>
           <tr>
@@ -605,6 +667,11 @@ export function NetworkAccessibleDataTable({ nodes, edges, chartType, tableId, c
           ))}
         </tbody>
       </table>
+      {remaining > 0 && (
+        <button type="button" className="semiotic-accessible-data-table-show-more" onClick={showMore} style={SHOW_MORE_BUTTON_STYLE}>
+          Show {Math.min(PAGE_SIZE, remaining)} more {remaining === 1 ? "node" : "nodes"} ({remaining} remaining)
+        </button>
+      )}
     </div>
   )
 }

--- a/src/components/stream/AccessibleDataTable.tsx
+++ b/src/components/stream/AccessibleDataTable.tsx
@@ -12,7 +12,7 @@ const SR_ONLY_STYLE: React.CSSProperties = {
   overflow: "hidden",
   clip: "rect(0,0,0,0)",
   whiteSpace: "nowrap",
-  border: 0,
+  border: 0
 }
 
 // ── Aria-label helpers ──────────────────────────────────────────────────
@@ -45,11 +45,22 @@ export function computeCanvasAriaLabel(
     candlestick: "candlesticks",
     wedge: "wedges",
     arc: "arcs",
-    geoarea: "regions",
+    geoarea: "regions"
   }
 
   // Sort by a fixed type order for stable aria-label output
-  const typeOrder = ["point", "line", "area", "rect", "heatcell", "circle", "candlestick", "wedge", "arc", "geoarea"]
+  const typeOrder = [
+    "point",
+    "line",
+    "area",
+    "rect",
+    "heatcell",
+    "circle",
+    "candlestick",
+    "wedge",
+    "arc",
+    "geoarea"
+  ]
   const sortedTypes = Object.keys(typeCounts).sort((a, b) => {
     const ai = typeOrder.indexOf(a)
     const bi = typeOrder.indexOf(b)
@@ -90,7 +101,10 @@ const fmt = (v: number | undefined | null): string => {
 
 // ── Data extraction from scene nodes ────────────────────────────────────
 
-interface DataRow { label: string; values: Record<string, string | number> }
+interface DataRow {
+  label: string
+  values: Record<string, string | number>
+}
 
 /** Pull primitive, user-facing fields from a raw datum into a display row.
  *  Skips synthetic/internal keys (leading underscore) and non-primitive
@@ -152,16 +166,26 @@ export function extractAllRows(scene: AnySceneNode[]): DataRow[] {
           break
         }
         case "rect": {
-          const datum = (node.datum != null && typeof node.datum === "object") ? node.datum : {}
+          const datum =
+            node.datum != null && typeof node.datum === "object"
+              ? node.datum
+              : {}
           const category = datum.category ?? node.group ?? ""
           const rawValue = datum.value ?? datum.__aggregateValue ?? datum.total
-          rows.push({ label: "Bar", values: { category, value: rawValue ?? "" } })
+          rows.push({
+            label: "Bar",
+            values: { category, value: rawValue ?? "" }
+          })
           break
         }
         case "heatcell": {
           const values = datumToValues(node.datum)
           // Fall back to the rendered cell value when datum omits it
-          if (values.value == null && typeof node.value === "number" && Number.isFinite(node.value)) {
+          if (
+            values.value == null &&
+            typeof node.value === "number" &&
+            Number.isFinite(node.value)
+          ) {
             values.value = node.value
           }
           rows.push({ label: "Cell", values })
@@ -172,8 +196,8 @@ export function extractAllRows(scene: AnySceneNode[]): DataRow[] {
             label: "Wedge",
             values: {
               category: node.datum?.category ?? node.datum?.label ?? "",
-              value: node.datum?.value ?? "",
-            },
+              value: node.datum?.value ?? ""
+            }
           })
           break
         case "circle":
@@ -190,8 +214,8 @@ export function extractAllRows(scene: AnySceneNode[]): DataRow[] {
             label: "Region",
             values: {
               name: node.datum?.properties?.name ?? node.datum?.name ?? "",
-              value: node.datum?.value ?? "",
-            },
+              value: node.datum?.value ?? ""
+            }
           })
           break
         // Unknown types are silently skipped
@@ -246,16 +270,30 @@ function computeFieldStats(rows: DataRow[]): FieldStats[] {
     }
 
     if (nums.length > 0) {
-      let min = nums[0], max = nums[0], sum = 0
+      let min = nums[0],
+        max = nums[0],
+        sum = 0
       for (const n of nums) {
         if (n < min) min = n
         if (n > max) max = n
         sum += n
       }
-      stats.push({ name, count: nums.length, numeric: true, min, max, mean: sum / nums.length })
+      stats.push({
+        name,
+        count: nums.length,
+        numeric: true,
+        min,
+        max,
+        mean: sum / nums.length
+      })
     } else if (strs.size > 0) {
       const unique = Array.from(strs)
-      stats.push({ name, count: unique.length, numeric: false, uniqueValues: unique.slice(0, 5) })
+      stats.push({
+        name,
+        count: unique.length,
+        numeric: false,
+        uniqueValues: unique.slice(0, 5)
+      })
     }
   }
 
@@ -268,10 +306,15 @@ function formatSummary(totalRows: number, fieldStats: FieldStats[]): string {
 
   for (const fs of fieldStats) {
     if (fs.numeric) {
-      parts.push(`${fs.name}: ${fmt(fs.min)} to ${fmt(fs.max)}, mean ${fmt(fs.mean)}.`)
+      parts.push(
+        `${fs.name}: ${fmt(fs.min)} to ${fmt(fs.max)}, mean ${fmt(fs.mean)}.`
+      )
     } else {
       const vals = fs.uniqueValues!
-      const label = vals.length <= 3 ? vals.join(", ") : `${vals.slice(0, 3).join(", ")}… (${fs.count} unique)`
+      const label =
+        vals.length <= 3
+          ? vals.join(", ")
+          : `${vals.slice(0, 3).join(", ")}… (${fs.count} unique)`
       parts.push(`${fs.name}: ${label}.`)
     }
   }
@@ -305,23 +348,29 @@ const VISIBLE_PANEL_STYLE: React.CSSProperties = {
   top: 0,
   left: 0,
   right: 0,
-  zIndex: "var(--semiotic-data-table-z-index, var(--semiotic-overlay-z-index, 20))",
+  zIndex:
+    "var(--semiotic-data-table-z-index, var(--semiotic-overlay-z-index, 20))",
   padding: "14px 16px 12px",
-  borderBottom: "1px solid var(--semiotic-data-table-border, var(--semiotic-border, #e0e0e0))",
-  fontFamily: "var(--semiotic-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif)",
+  borderBottom:
+    "1px solid var(--semiotic-data-table-border, var(--semiotic-border, #e0e0e0))",
+  fontFamily:
+    "var(--semiotic-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif)",
   fontSize: 13,
   lineHeight: 1.5,
   color: "var(--semiotic-data-table-text, var(--semiotic-text, #333))",
-  background: "var(--semiotic-data-table-bg, var(--semiotic-surface, var(--semiotic-bg, #fff)))",
-  borderRadius: "var(--semiotic-border-radius, 0px) var(--semiotic-border-radius, 0px) 0 0",
+  background:
+    "var(--semiotic-data-table-bg, var(--semiotic-surface, var(--semiotic-bg, #fff)))",
+  borderRadius:
+    "var(--semiotic-border-radius, 0px) var(--semiotic-border-radius, 0px) 0 0"
 }
 
 const SUMMARY_NOTE_STYLE: React.CSSProperties = {
   marginBottom: 8,
   paddingRight: 28,
-  color: "var(--semiotic-data-table-muted-text, var(--semiotic-text-secondary, #666))",
+  color:
+    "var(--semiotic-data-table-muted-text, var(--semiotic-text-secondary, #666))",
   fontSize: 12,
-  letterSpacing: "0.01em",
+  letterSpacing: "0.01em"
 }
 
 const CLOSE_BUTTON_STYLE: React.CSSProperties = {
@@ -333,14 +382,17 @@ const CLOSE_BUTTON_STYLE: React.CSSProperties = {
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
-  border: "1px solid var(--semiotic-data-table-border, var(--semiotic-border, #e0e0e0))",
-  background: "var(--semiotic-data-table-bg, var(--semiotic-surface, var(--semiotic-bg, #fff)))",
+  border:
+    "1px solid var(--semiotic-data-table-border, var(--semiotic-border, #e0e0e0))",
+  background:
+    "var(--semiotic-data-table-bg, var(--semiotic-surface, var(--semiotic-bg, #fff)))",
   cursor: "pointer",
-  color: "var(--semiotic-data-table-muted-text, var(--semiotic-text-secondary, #666))",
+  color:
+    "var(--semiotic-data-table-muted-text, var(--semiotic-text-secondary, #666))",
   fontSize: 13,
   lineHeight: 1,
   padding: 0,
-  borderRadius: "var(--semiotic-border-radius, 4px)",
+  borderRadius: "var(--semiotic-border-radius, 4px)"
 }
 
 const VISIBLE_TABLE_STYLE: React.CSSProperties = {
@@ -348,31 +400,35 @@ const VISIBLE_TABLE_STYLE: React.CSSProperties = {
   borderCollapse: "collapse",
   fontSize: 12,
   marginTop: 4,
-  fontVariantNumeric: "tabular-nums",
+  fontVariantNumeric: "tabular-nums"
 }
 
 const VISIBLE_TH_STYLE: React.CSSProperties = {
   textAlign: "left",
   padding: "5px 10px",
-  borderBottom: "2px solid var(--semiotic-data-table-border, var(--semiotic-border, #e0e0e0))",
+  borderBottom:
+    "2px solid var(--semiotic-data-table-border, var(--semiotic-border, #e0e0e0))",
   fontWeight: 600,
   fontSize: 11,
   textTransform: "uppercase" as const,
   letterSpacing: "0.04em",
-  color: "var(--semiotic-data-table-muted-text, var(--semiotic-text-secondary, #666))",
+  color:
+    "var(--semiotic-data-table-muted-text, var(--semiotic-text-secondary, #666))"
 }
 
 const VISIBLE_TD_STYLE: React.CSSProperties = {
   padding: "4px 10px",
-  borderBottom: "1px solid var(--semiotic-data-table-border, var(--semiotic-border, #e0e0e0))",
+  borderBottom:
+    "1px solid var(--semiotic-data-table-border, var(--semiotic-border, #e0e0e0))"
 }
 
 const CAPTION_STYLE: React.CSSProperties = {
   textAlign: "left",
   fontSize: 11,
-  color: "var(--semiotic-data-table-muted-text, var(--semiotic-text-secondary, #999))",
+  color:
+    "var(--semiotic-data-table-muted-text, var(--semiotic-text-secondary, #999))",
   marginBottom: 4,
-  fontStyle: "italic",
+  fontStyle: "italic"
 }
 
 const SHOW_MORE_BUTTON_STYLE: React.CSSProperties = {
@@ -380,11 +436,13 @@ const SHOW_MORE_BUTTON_STYLE: React.CSSProperties = {
   padding: "4px 10px",
   fontSize: 12,
   cursor: "pointer",
-  border: "1px solid var(--semiotic-data-table-border, var(--semiotic-border, #e0e0e0))",
+  border:
+    "1px solid var(--semiotic-data-table-border, var(--semiotic-border, #e0e0e0))",
   borderRadius: "var(--semiotic-border-radius, 4px)",
-  background: "var(--semiotic-data-table-bg, var(--semiotic-surface, var(--semiotic-bg, #fff)))",
+  background:
+    "var(--semiotic-data-table-bg, var(--semiotic-surface, var(--semiotic-bg, #fff)))",
   color: "var(--semiotic-data-table-text, var(--semiotic-text, #333))",
-  fontFamily: "inherit",
+  fontFamily: "inherit"
 }
 
 function fmtCell(v: unknown): string {
@@ -404,14 +462,23 @@ function fmtCell(v: unknown): string {
  * computes a statistical summary (.describe()-style) and shows a sample of rows
  * (5 to start), pageable to the full dataset via "Show more".
  */
-export function AccessibleDataTable({ scene, chartType, tableId, chartTitle }: AccessibleDataTableProps) {
+export function AccessibleDataTable({
+  scene,
+  chartType,
+  tableId,
+  chartTitle
+}: AccessibleDataTableProps) {
   const [srExpanded, setSrExpanded] = React.useState(false)
   const [visibleCount, setVisibleCount] = React.useState(SAMPLE_SIZE)
   const dataSummary = useDataSummary()
   const visible = dataSummary?.visible ?? false
   const isExpanded = srExpanded || visible
   const containerRef = React.useRef<HTMLDivElement>(null)
-  const regionLabel = chartTitle ? `Data summary for ${chartTitle}` : tableId ? `Data summary for ${chartType} ${tableId}` : `Data summary for ${chartType}`
+  const regionLabel = chartTitle
+    ? `Data summary for ${chartTitle}`
+    : tableId
+      ? `Data summary for ${chartType} ${tableId}`
+      : `Data summary for ${chartType}`
 
   // Reset paging whenever the panel collapses — via the close button, a blur in
   // sr-only mode, or ChartContainer toggling visibility off — so reopening never
@@ -424,28 +491,44 @@ export function AccessibleDataTable({ scene, chartType, tableId, chartTitle }: A
   // path programmatically focuses it). Focus bubbling up from the inner trigger
   // button must NOT auto-expand — otherwise merely tabbing onto the button
   // forces the screen reader through the entire table without the user opting in.
-  const handleFocus = React.useCallback((e: React.FocusEvent) => {
-    if (e.target !== e.currentTarget) return
-    if (!srExpanded && !visible) setSrExpanded(true)
-  }, [srExpanded, visible])
+  const handleFocus = React.useCallback(
+    (e: React.FocusEvent) => {
+      if (e.target !== e.currentTarget) return
+      if (!srExpanded && !visible) setSrExpanded(true)
+    },
+    [srExpanded, visible]
+  )
 
   // Collapse when focus leaves the panel entirely (not for context-controlled mode).
-  const handleBlur = React.useCallback((e: React.FocusEvent) => {
-    if (visible) return // ChartContainer controls visibility
-    // Check if focus moved to another element inside this container
-    if (containerRef.current?.contains(e.relatedTarget as Node)) return
-    setSrExpanded(false)
-  }, [visible])
+  const handleBlur = React.useCallback(
+    (e: React.FocusEvent) => {
+      if (visible) return // ChartContainer controls visibility
+      // Check if focus moved to another element inside this container
+      if (containerRef.current?.contains(e.relatedTarget as Node)) return
+      setSrExpanded(false)
+    },
+    [visible]
+  )
 
   if (!scene || scene.length === 0) {
-    return tableId ? <span id={tableId} tabIndex={-1} style={SR_ONLY_STYLE} /> : null
+    return tableId ? (
+      <span id={tableId} tabIndex={-1} style={SR_ONLY_STYLE} />
+    ) : null
   }
 
   const totalCount = scene.length
 
   if (!isExpanded) {
     return (
-      <div id={tableId} className={DATA_TABLE_HIDDEN_CLASS} tabIndex={-1} onFocus={handleFocus} style={SR_ONLY_STYLE} role="region" aria-label={regionLabel}>
+      <div
+        id={tableId}
+        className={DATA_TABLE_HIDDEN_CLASS}
+        tabIndex={-1}
+        onFocus={handleFocus}
+        style={SR_ONLY_STYLE}
+        role="region"
+        aria-label={regionLabel}
+      >
         <button type="button" onClick={() => setSrExpanded(true)}>
           View data summary ({totalCount} elements)
         </button>
@@ -476,18 +559,53 @@ export function AccessibleDataTable({ scene, chartType, tableId, chartTitle }: A
   const showMore = () => setVisibleCount((c) => c + PAGE_SIZE)
 
   return (
-    <div ref={containerRef} id={tableId} className={DATA_TABLE_VISIBLE_CLASS} tabIndex={-1} onBlur={handleBlur} style={VISIBLE_PANEL_STYLE} role="region" aria-label={regionLabel}>
-      <button type="button" className="semiotic-accessible-data-table-close" onClick={dismiss} aria-label="Close data summary" style={CLOSE_BUTTON_STYLE}>&times;</button>
-      <div className="semiotic-accessible-data-table-summary" role="note" style={SUMMARY_NOTE_STYLE}>{summary}</div>
-      <table className="semiotic-accessible-data-table-table" role="table" aria-label={`Sample data for ${chartType}`} style={VISIBLE_TABLE_STYLE}>
-        <caption className="semiotic-accessible-data-table-caption" style={CAPTION_STYLE}>
-          {remaining > 0 ? `First ${shownCount} of ${allRows.length} data points` : `All ${allRows.length} data points`}
+    <div
+      ref={containerRef}
+      id={tableId}
+      className={DATA_TABLE_VISIBLE_CLASS}
+      tabIndex={-1}
+      onBlur={handleBlur}
+      style={VISIBLE_PANEL_STYLE}
+      role="region"
+      aria-label={regionLabel}
+    >
+      <button
+        type="button"
+        className="semiotic-accessible-data-table-close"
+        onClick={dismiss}
+        aria-label="Close data summary"
+        style={CLOSE_BUTTON_STYLE}
+      >
+        &times;
+      </button>
+      <div
+        className="semiotic-accessible-data-table-summary"
+        role="note"
+        style={SUMMARY_NOTE_STYLE}
+      >
+        {summary}
+      </div>
+      <table
+        className="semiotic-accessible-data-table-table"
+        role="table"
+        aria-label={`Sample data for ${chartType}`}
+        style={VISIBLE_TABLE_STYLE}
+      >
+        <caption
+          className="semiotic-accessible-data-table-caption"
+          style={CAPTION_STYLE}
+        >
+          {remaining > 0
+            ? `First ${shownCount} of ${allRows.length} data points`
+            : `All ${allRows.length} data points`}
         </caption>
         <thead>
           <tr>
             <th style={VISIBLE_TH_STYLE}>type</th>
             {columns.map((c) => (
-              <th key={c} style={VISIBLE_TH_STYLE}>{c}</th>
+              <th key={c} style={VISIBLE_TH_STYLE}>
+                {c}
+              </th>
             ))}
           </tr>
         </thead>
@@ -496,15 +614,23 @@ export function AccessibleDataTable({ scene, chartType, tableId, chartTitle }: A
             <tr key={i}>
               <td style={VISIBLE_TD_STYLE}>{r.label}</td>
               {columns.map((c) => (
-                <td key={c} style={VISIBLE_TD_STYLE}>{fmtCell(r.values[c])}</td>
+                <td key={c} style={VISIBLE_TD_STYLE}>
+                  {fmtCell(r.values[c])}
+                </td>
               ))}
             </tr>
           ))}
         </tbody>
       </table>
       {remaining > 0 && (
-        <button type="button" className="semiotic-accessible-data-table-show-more" onClick={showMore} style={SHOW_MORE_BUTTON_STYLE}>
-          Show {Math.min(PAGE_SIZE, remaining)} more {remaining === 1 ? "row" : "rows"} ({remaining} remaining)
+        <button
+          type="button"
+          className="semiotic-accessible-data-table-show-more"
+          onClick={showMore}
+          style={SHOW_MORE_BUTTON_STYLE}
+        >
+          Show {Math.min(PAGE_SIZE, remaining)} more{" "}
+          {remaining === 1 ? "row" : "rows"} ({remaining} remaining)
         </button>
       )}
     </div>
@@ -514,7 +640,14 @@ export function AccessibleDataTable({ scene, chartType, tableId, chartTitle }: A
 // ── NetworkAccessibleDataTable ──────────────────────────────────────────
 
 interface NetworkAccessibleDataTableProps {
-  nodes: Array<{ datum?: any; id?: string; cx?: number; cy?: number; x?: number; y?: number }>
+  nodes: Array<{
+    datum?: any
+    id?: string
+    cx?: number
+    cy?: number
+    x?: number
+    y?: number
+  }>
   edges: Array<{ datum?: any; source?: string; target?: string }>
   chartType: string
   tableId?: string
@@ -524,13 +657,23 @@ interface NetworkAccessibleDataTableProps {
 /**
  * JIT accessible data summary for network charts.
  */
-export function NetworkAccessibleDataTable({ nodes, edges, chartType, tableId, chartTitle }: NetworkAccessibleDataTableProps) {
+export function NetworkAccessibleDataTable({
+  nodes,
+  edges,
+  chartType,
+  tableId,
+  chartTitle
+}: NetworkAccessibleDataTableProps) {
   const [srExpanded, setSrExpanded] = React.useState(false)
   const [visibleCount, setVisibleCount] = React.useState(SAMPLE_SIZE)
   const dataSummary = useDataSummary()
   const visible = dataSummary?.visible ?? false
   const isExpanded = srExpanded || visible
-  const regionLabel = chartTitle ? `Data summary for ${chartTitle}` : tableId ? `Data summary for ${chartType} ${tableId}` : `Data summary for ${chartType}`
+  const regionLabel = chartTitle
+    ? `Data summary for ${chartTitle}`
+    : tableId
+      ? `Data summary for ${chartType} ${tableId}`
+      : `Data summary for ${chartType}`
   const containerRef = React.useRef<HTMLDivElement>(null)
 
   // Reset paging on any collapse path (close button, blur, ChartContainer
@@ -542,24 +685,40 @@ export function NetworkAccessibleDataTable({ nodes, edges, chartType, tableId, c
   // Only the skip-link path (which focuses the region container itself) auto-
   // expands; focus bubbling from the inner trigger button must not. See the
   // matching note in AccessibleDataTable.
-  const handleFocus = React.useCallback((e: React.FocusEvent) => {
-    if (e.target !== e.currentTarget) return
-    if (!srExpanded && !visible) setSrExpanded(true)
-  }, [srExpanded, visible])
+  const handleFocus = React.useCallback(
+    (e: React.FocusEvent) => {
+      if (e.target !== e.currentTarget) return
+      if (!srExpanded && !visible) setSrExpanded(true)
+    },
+    [srExpanded, visible]
+  )
 
-  const handleBlur = React.useCallback((e: React.FocusEvent) => {
-    if (visible) return
-    if (containerRef.current?.contains(e.relatedTarget as Node)) return
-    setSrExpanded(false)
-  }, [visible])
+  const handleBlur = React.useCallback(
+    (e: React.FocusEvent) => {
+      if (visible) return
+      if (containerRef.current?.contains(e.relatedTarget as Node)) return
+      setSrExpanded(false)
+    },
+    [visible]
+  )
 
   if (!nodes || nodes.length === 0) {
-    return tableId ? <span id={tableId} tabIndex={-1} style={SR_ONLY_STYLE} /> : null
+    return tableId ? (
+      <span id={tableId} tabIndex={-1} style={SR_ONLY_STYLE} />
+    ) : null
   }
 
   if (!isExpanded) {
     return (
-      <div id={tableId} className={DATA_TABLE_HIDDEN_CLASS} tabIndex={-1} onFocus={handleFocus} style={SR_ONLY_STYLE} role="region" aria-label={regionLabel}>
+      <div
+        id={tableId}
+        className={DATA_TABLE_HIDDEN_CLASS}
+        tabIndex={-1}
+        onFocus={handleFocus}
+        style={SR_ONLY_STYLE}
+        role="region"
+        aria-label={regionLabel}
+      >
         <button type="button" onClick={() => setSrExpanded(true)}>
           View data summary ({nodes.length} nodes, {edges.length} edges)
         </button>
@@ -596,7 +755,15 @@ export function NetworkAccessibleDataTable({ nodes, edges, chartType, tableId, c
     }
   }
 
-  type NodeDegreeRow = { id: string; degree: number; inDeg: number; outDeg: number; wDegree: number; wInDeg: number; wOutDeg: number }
+  type NodeDegreeRow = {
+    id: string
+    degree: number
+    inDeg: number
+    outDeg: number
+    wDegree: number
+    wInDeg: number
+    wOutDeg: number
+  }
   const nodeRows: NodeDegreeRow[] = []
   for (let ni = 0; ni < safeNodes.length; ni++) {
     const n = safeNodes[ni]
@@ -607,7 +774,15 @@ export function NetworkAccessibleDataTable({ nodes, edges, chartType, tableId, c
     const outd = outDeg.get(id) ?? 0
     const wind = wInDeg.get(id) ?? 0
     const woutd = wOutDeg.get(id) ?? 0
-    nodeRows.push({ id, degree: ind + outd, inDeg: ind, outDeg: outd, wDegree: wind + woutd, wInDeg: wind, wOutDeg: woutd })
+    nodeRows.push({
+      id,
+      degree: ind + outd,
+      inDeg: ind,
+      outDeg: outd,
+      wDegree: wind + woutd,
+      wInDeg: wind,
+      wOutDeg: woutd
+    })
   }
 
   // Sort by degree descending for most useful summary
@@ -625,14 +800,16 @@ export function NetworkAccessibleDataTable({ nodes, edges, chartType, tableId, c
   }
 
   // Show weighted columns when any edge carries a numeric value
-  const hasWeights = safeEdges.some(e => {
+  const hasWeights = safeEdges.some((e) => {
     const raw = e?.datum ?? e
     return typeof raw?.value === "number" && Number.isFinite(raw.value)
   })
 
   const summaryParts = [`${nodeRows.length} nodes, ${safeEdges.length} edges.`]
   if (nodeRows.length > 0) {
-    summaryParts.push(`Mean degree: ${fmt(avgDegree)}, max degree: ${maxDegree}.`)
+    summaryParts.push(
+      `Mean degree: ${fmt(avgDegree)}, max degree: ${maxDegree}.`
+    )
   }
 
   const shownCount = Math.min(visibleCount, nodeRows.length)
@@ -648,12 +825,45 @@ export function NetworkAccessibleDataTable({ nodes, edges, chartType, tableId, c
   const showMore = () => setVisibleCount((c) => c + PAGE_SIZE)
 
   return (
-    <div ref={containerRef} id={tableId} className={DATA_TABLE_NETWORK_CLASS} tabIndex={-1} onBlur={handleBlur} style={VISIBLE_PANEL_STYLE} role="region" aria-label={regionLabel}>
-      <button type="button" className="semiotic-accessible-data-table-close" onClick={dismiss} aria-label="Close data summary" style={CLOSE_BUTTON_STYLE}>&times;</button>
-      <div className="semiotic-accessible-data-table-summary" role="note" style={SUMMARY_NOTE_STYLE}>{summaryParts.join(" ")}</div>
-      <table className="semiotic-accessible-data-table-table" role="table" aria-label={`Node degree summary for ${chartType}`} style={VISIBLE_TABLE_STYLE}>
-        <caption className="semiotic-accessible-data-table-caption" style={CAPTION_STYLE}>
-          {remaining > 0 ? `Top ${shownCount} of ${nodeRows.length} nodes by degree` : `All ${nodeRows.length} nodes by degree`}
+    <div
+      ref={containerRef}
+      id={tableId}
+      className={DATA_TABLE_NETWORK_CLASS}
+      tabIndex={-1}
+      onBlur={handleBlur}
+      style={VISIBLE_PANEL_STYLE}
+      role="region"
+      aria-label={regionLabel}
+    >
+      <button
+        type="button"
+        className="semiotic-accessible-data-table-close"
+        onClick={dismiss}
+        aria-label="Close data summary"
+        style={CLOSE_BUTTON_STYLE}
+      >
+        &times;
+      </button>
+      <div
+        className="semiotic-accessible-data-table-summary"
+        role="note"
+        style={SUMMARY_NOTE_STYLE}
+      >
+        {summaryParts.join(" ")}
+      </div>
+      <table
+        className="semiotic-accessible-data-table-table"
+        role="table"
+        aria-label={`Node degree summary for ${chartType}`}
+        style={VISIBLE_TABLE_STYLE}
+      >
+        <caption
+          className="semiotic-accessible-data-table-caption"
+          style={CAPTION_STYLE}
+        >
+          {remaining > 0
+            ? `Top ${shownCount} of ${nodeRows.length} nodes by degree`
+            : `All ${nodeRows.length} nodes by degree`}
         </caption>
         <thead>
           <tr>
@@ -673,16 +883,28 @@ export function NetworkAccessibleDataTable({ nodes, edges, chartType, tableId, c
               <td style={VISIBLE_TD_STYLE}>{row.degree}</td>
               <td style={VISIBLE_TD_STYLE}>{row.inDeg}</td>
               <td style={VISIBLE_TD_STYLE}>{row.outDeg}</td>
-              {hasWeights && <td style={VISIBLE_TD_STYLE}>{fmt(row.wDegree)}</td>}
-              {hasWeights && <td style={VISIBLE_TD_STYLE}>{fmt(row.wInDeg)}</td>}
-              {hasWeights && <td style={VISIBLE_TD_STYLE}>{fmt(row.wOutDeg)}</td>}
+              {hasWeights && (
+                <td style={VISIBLE_TD_STYLE}>{fmt(row.wDegree)}</td>
+              )}
+              {hasWeights && (
+                <td style={VISIBLE_TD_STYLE}>{fmt(row.wInDeg)}</td>
+              )}
+              {hasWeights && (
+                <td style={VISIBLE_TD_STYLE}>{fmt(row.wOutDeg)}</td>
+              )}
             </tr>
           ))}
         </tbody>
       </table>
       {remaining > 0 && (
-        <button type="button" className="semiotic-accessible-data-table-show-more" onClick={showMore} style={SHOW_MORE_BUTTON_STYLE}>
-          Show {Math.min(PAGE_SIZE, remaining)} more {remaining === 1 ? "node" : "nodes"} ({remaining} remaining)
+        <button
+          type="button"
+          className="semiotic-accessible-data-table-show-more"
+          onClick={showMore}
+          style={SHOW_MORE_BUTTON_STYLE}
+        >
+          Show {Math.min(PAGE_SIZE, remaining)} more{" "}
+          {remaining === 1 ? "node" : "nodes"} ({remaining} remaining)
         </button>
       )}
     </div>
@@ -741,7 +963,7 @@ export function SkipToTableLink({ tableId }: { tableId: string }) {
           zIndex: "10",
           fontSize: "12px",
           top: "4px",
-          left: "4px",
+          left: "4px"
         })
       }}
       onBlur={(e) => {
@@ -768,18 +990,14 @@ export function AriaLiveTooltip({ hoverPoint }: { hoverPoint: any }) {
       const entries = Object.entries(data).filter(
         ([, v]) => typeof v !== "object" && typeof v !== "function"
       )
-      text = `Focused on data point: ${entries.map(([k, v]) => `${k}: ${v}`).join(", ")}`
+      text = `Data point: ${entries.map(([k, v]) => `${k}: ${v}`).join(", ")}`
     } else {
-      text = `Focused on data point: ${String(data)}`
+      text = `Data point: ${String(data)}`
     }
   }
 
   return (
-    <div
-      aria-live="polite"
-      aria-atomic="true"
-      style={SR_ONLY_STYLE}
-    >
+    <div aria-live="polite" aria-atomic="true" style={SR_ONLY_STYLE}>
       {text}
     </div>
   )

--- a/src/components/stream/AccessibleDataTable.tsx
+++ b/src/components/stream/AccessibleDataTable.tsx
@@ -413,6 +413,13 @@ export function AccessibleDataTable({ scene, chartType, tableId, chartTitle }: A
   const containerRef = React.useRef<HTMLDivElement>(null)
   const regionLabel = chartTitle ? `Data summary for ${chartTitle}` : tableId ? `Data summary for ${chartType} ${tableId}` : `Data summary for ${chartType}`
 
+  // Reset paging whenever the panel collapses — via the close button, a blur in
+  // sr-only mode, or ChartContainer toggling visibility off — so reopening never
+  // re-renders the full (potentially huge) row set at once.
+  React.useEffect(() => {
+    if (!isExpanded) setVisibleCount(SAMPLE_SIZE)
+  }, [isExpanded])
+
   // Expand only when focus lands on the region container itself (the skip-link
   // path programmatically focuses it). Focus bubbling up from the inner trigger
   // button must NOT auto-expand — otherwise merely tabbing onto the button
@@ -463,7 +470,7 @@ export function AccessibleDataTable({ scene, chartType, tableId, chartTitle }: A
   const dismiss = () => {
     if (visible && dataSummary) dataSummary.setVisible(false)
     setSrExpanded(false)
-    setVisibleCount(SAMPLE_SIZE)
+    // visibleCount resets via the collapse effect above.
   }
 
   const showMore = () => setVisibleCount((c) => c + PAGE_SIZE)
@@ -525,6 +532,12 @@ export function NetworkAccessibleDataTable({ nodes, edges, chartType, tableId, c
   const isExpanded = srExpanded || visible
   const regionLabel = chartTitle ? `Data summary for ${chartTitle}` : tableId ? `Data summary for ${chartType} ${tableId}` : `Data summary for ${chartType}`
   const containerRef = React.useRef<HTMLDivElement>(null)
+
+  // Reset paging on any collapse path (close button, blur, ChartContainer
+  // toggle) so reopening never re-renders the full node set at once.
+  React.useEffect(() => {
+    if (!isExpanded) setVisibleCount(SAMPLE_SIZE)
+  }, [isExpanded])
 
   // Only the skip-link path (which focuses the region container itself) auto-
   // expands; focus bubbling from the inner trigger button must not. See the
@@ -629,7 +642,7 @@ export function NetworkAccessibleDataTable({ nodes, edges, chartType, tableId, c
   const dismiss = () => {
     if (visible && dataSummary) dataSummary.setVisible(false)
     setSrExpanded(false)
-    setVisibleCount(SAMPLE_SIZE)
+    // visibleCount resets via the collapse effect above.
   }
 
   const showMore = () => setVisibleCount((c) => c + PAGE_SIZE)

--- a/src/components/stream/StreamGeoFrame.tsx
+++ b/src/components/stream/StreamGeoFrame.tsx
@@ -1322,6 +1322,9 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
         {accessibleTable && <SkipToTableLink tableId={tableId} />}
         {accessibleTable && <AccessibleDataTable scene={storeRef.current?.scene ?? []} chartType="Geographic chart" tableId={tableId} chartTitle={typeof title === "string" ? title : undefined} />}
         <ScreenReaderSummary summary={summary} />
+        {/* Live region MUST live outside the role="img" wrapper — AT treats the
+            image as atomic and never announces content nested inside it. */}
+        <AriaLiveTooltip hoverPoint={hoverPoint} />
         <div
           role="img"
           aria-label={description || (typeof title === "string" ? title : "Geographic chart")}
@@ -1359,7 +1362,6 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
           ref={interactionCanvasRef}
           style={{ position: "absolute", left: 0, top: 0, pointerEvents: "none" }}
         />
-        <AriaLiveTooltip hoverPoint={hoverPoint} />
         <SVGOverlay
           width={adjustedWidth}
           height={adjustedHeight}

--- a/src/components/stream/StreamNetworkFrame.tsx
+++ b/src/components/stream/StreamNetworkFrame.tsx
@@ -1498,6 +1498,9 @@ const StreamNetworkFrame = forwardRef<
       {accessibleTable && <SkipToTableLink tableId={tableId} />}
       {accessibleTable && <NetworkAccessibleDataTable nodes={store?.sceneNodes ?? []} edges={store?.sceneEdges ?? []} chartType="Network chart" tableId={tableId} chartTitle={typeof title === "string" ? title : undefined} />}
       <ScreenReaderSummary summary={summary} />
+      {/* Live region MUST live outside the role="img" wrapper — AT treats the
+          image as atomic and never announces content nested inside it. */}
+      <AriaLiveTooltip hoverPoint={hoverData} />
       <div
         role="img"
         aria-label={description || (typeof title === "string" ? title : "Network chart")}
@@ -1534,7 +1537,6 @@ const StreamNetworkFrame = forwardRef<
           left: 0
         }}
       />
-      <AriaLiveTooltip hoverPoint={hoverData} />
 
       <NetworkSVGOverlay
         width={adjustedWidth}

--- a/src/components/stream/StreamOrdinalFrame.tsx
+++ b/src/components/stream/StreamOrdinalFrame.tsx
@@ -1113,6 +1113,9 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
         {accessibleTable && <SkipToTableLink tableId={tableId} />}
         {accessibleTable && <AccessibleDataTable scene={storeRef.current?.scene ?? []} chartType={chartType + " chart"} tableId={tableId} chartTitle={typeof title === "string" ? title : undefined} />}
         <ScreenReaderSummary summary={summary} />
+        {/* Live region MUST live outside the role="img" wrapper — AT treats the
+            image as atomic and never announces content nested inside it. */}
+        <AriaLiveTooltip hoverPoint={hoverPoint} />
         <div
           role="img"
           aria-label={description || (typeof title === "string" ? title : "Ordinal chart")}
@@ -1162,7 +1165,6 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
             height: size[1]
           }}
         />
-        <AriaLiveTooltip hoverPoint={hoverPoint} />
 
         <OrdinalSVGOverlay
           width={adjustedWidth}

--- a/src/components/stream/StreamXYFrame.tsx
+++ b/src/components/stream/StreamXYFrame.tsx
@@ -1549,6 +1549,9 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
         {accessibleTable && <SkipToTableLink tableId={tableId} />}
         {accessibleTable && <AccessibleDataTable scene={storeRef.current?.scene ?? []} chartType={chartType + " chart"} tableId={tableId} chartTitle={typeof title === "string" ? title : undefined} />}
         <ScreenReaderSummary summary={summary} />
+        {/* Live region MUST live outside the role="img" wrapper — AT treats the
+            image as atomic and never announces content nested inside it. */}
+        <AriaLiveTooltip hoverPoint={hoverPoint} />
         {/* Inner graphic wrapper — role="img" so AT treats canvas as a single image */}
         <div
           role="img"
@@ -1606,7 +1609,6 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
             pointerEvents: "none"
           }}
         />
-        <AriaLiveTooltip hoverPoint={hoverPoint} />
         <SVGOverlay
           width={adjustedWidth}
           height={adjustedHeight}


### PR DESCRIPTION
  1. Tooltip not announced by screen readers — the AriaLiveTooltip live region was nested inside the `<div role="img">` wrapper in all four Stream Frames. Content inside `role="img"` is treated as an atomic image and never exposed to assistive tech, so the aria-live updates were silently dropped (hence Chrome announcing nothing, Firefox just re-reading "XY Chart").
  - Moved the live region out to sit beside ScreenReaderSummary, as a direct child of the outer `role="group"` container, in StreamXYFrame, StreamOrdinalFrame, StreamNetworkFrame, and StreamGeoFrame. It's still rendered unconditionally at a stable position, so it persists across re-renders (addressing the reporter's "re-created on mousemove" concern). Keyboard nav already feeds hoverPoint, so arrow navigation now announces too. 
  
  2. Data table read through without activating the trigger. `handleFocus` auto-expanded on any focus, and focus events bubble, so merely tabbing onto the "View data summary" button (without clicking) fired the region's onFocus and expanded the whole table.
  - `handleFocus` now only expands when `e.target === e.currentTarget` (focus landed on the region container itself — the skip-link path). Focus bubbling up from the inner button no longer auto-expands. Fixed in both AccessibleDataTable and NetworkAccessibleDataTable. 
  
  3. Table showed pixels, capped at 5 rows — point/line/area emitted scene pixel coordinates, and candlestick read node.open (which doesn't exist — only openY pixels did).
  - New datumToValues() helper surfaces the raw datum fields (your accessor names like month/sales), skipping synthetic prefixed keys and non-primitives. Applied to

  3. Table showed pixels, capped at 5 rows — point/line/area emitted scene pixel coordinates, and candlestick read `node.open` (which doesn't exist — only openY pixels did).
  - New datumToValues() helper surfaces the raw datum fields (your accessor names like month/sales), skipping synthetic prefixed keys and non-primitives. Applied to point/line/area/heatcell/candlestick/circle/arc; rect/wedge/geoarea keep their existing semantic extraction. Redundant point nodes are de-duped when a series node already carries the data (avoids double-counting with showPoints).
  - Added bounded pagination: a "Show N more rows" button reveals PAGE_SIZE (25) more per click, up to the full dataset but preventing a 50k-row table from instantiating at once. Caption switches from "First X of N" to "All N data points" when fully shown.

  Tests & docs

  - Rewrote the extractAllRows test block (which previously tested a stale copy of the old logic) to exercise the now-exported real function with the new datum-based semantics, plus added render tests for the no-auto-expand-on-button-focus and pagination flows.
  - All 71 AccessibleDataTable tests and 1401 stream tests pass; tsc --noEmit clean.
  - Updated AccessibilityPage.js to describe real-data values + pagination.

This pull request enhances the accessibility data summary feature for charts, ensuring that the data table surfaces actual user data fields (not pixel coordinates), supports paging through large datasets, and improves both documentation and testing for these behaviors. The most significant changes are grouped below.

**Accessibility Data Table Improvements:**

* The `extractAllRows` function now surfaces only the original, user-facing data fields (like `month`, `sales`) from scene nodes, skipping synthetic/internal keys and pixel coordinates. This ensures the accessible data table shows the real dataset, not rendering details. [[1]](diffhunk://#diff-128db4d47afdadd1b696ac72ca26b41c3e94a7e8c2dcd85ac056db6404c407efL95-R150) [[2]](diffhunk://#diff-128db4d47afdadd1b696ac72ca26b41c3e94a7e8c2dcd85ac056db6404c407efL138-R169) [[3]](diffhunk://#diff-128db4d47afdadd1b696ac72ca26b41c3e94a7e8c2dcd85ac056db6404c407efL151-R186)
* Added paging support to the data summary table via a "Show more rows" button, revealing additional rows in bounded chunks (initial sample of 5, then 25 per page), making large datasets navigable without performance issues. [[1]](diffhunk://#diff-128db4d47afdadd1b696ac72ca26b41c3e94a7e8c2dcd85ac056db6404c407efR294-R297) [[2]](diffhunk://#diff-128db4d47afdadd1b696ac72ca26b41c3e94a7e8c2dcd85ac056db6404c407efR378-R389)

**Documentation Updates:**

* Updated documentation in `AccessibilityPage.js` to clarify that the data summary displays actual data values, not pixel coordinates, and that users can page through the entire dataset in chunks. [[1]](diffhunk://#diff-e8123b06d284a68c658fa1e91c995ef88ce615e8a39e703333ffa4a47c9fd24cL221-R232) [[2]](diffhunk://#diff-e8123b06d284a68c658fa1e91c995ef88ce615e8a39e703333ffa4a47c9fd24cL249-R255) [[3]](diffhunk://#diff-e8123b06d284a68c658fa1e91c995ef88ce615e8a39e703333ffa4a47c9fd24cL475-R480)

**Testing Enhancements:**

* Reworked and expanded tests in `AccessibleDataTable.test.tsx` to verify that the accessible data table surfaces raw data (not pixels), handles paging, and is resilient to malformed or missing data. Also, tests now directly cover the exported `extractAllRows` logic for various chart node types and edge cases. [[1]](diffhunk://#diff-ab8334a42212399cd0f22c429599e26d69c993dd85aaf4793acbf65925163082R8) [[2]](diffhunk://#diff-ab8334a42212399cd0f22c429599e26d69c993dd85aaf4793acbf65925163082L171-R329)

These changes collectively ensure that the accessible data summary is accurate, performant, and user-friendly for both screen reader and sighted users.