### PR TITLE
Polish accessibility posts and improve formatting

### DIFF
--- a/docs/src/blog/entries-meta.js
+++ b/docs/src/blog/entries-meta.js
@@ -24,8 +24,8 @@ export const allBlogEntriesMeta = [
     title: "Navigating a Chart You Can't See",
     subtitle:
       "Structured navigation exposes a chart as a screen-reader-traversable tree — chart → series → data point — following the Olli / Data Navigator model, uncoupled from the canvas it's drawn on.",
-    author: "Semiotic Team",
-    date: "2026-06-01",
+    author: "Elijah Meeks",
+    date: "2026-06-15",
     tags: ["case-study", "accessibility"],
     excerpt:
       "A flat table of 200 rows is technically accessible and practically unusable. Structured navigation gives a non-visual reader the path a sighted reader takes — overview, then detail — as an ARIA tree built from the chart config and mounted as an opt-in ChartContainer layer, decoupled from how the chart renders.",
@@ -36,12 +36,12 @@ export const allBlogEntriesMeta = [
     slug: "what-a-screen-reader-should-hear",
     title: "What a Screen Reader Should Hear",
     subtitle:
-      "describeChart() turns a chart config into a layered natural-language description — encoding, statistics, and trend — the content research says blind and low-vision readers actually want.",
-    author: "Semiotic Team",
-    date: "2026-06-01",
+      "describeChart() turns a chart config into a layered natural-language description: encoding, statistics, and trend which research says blind and low-vision readers actually want.",
+    author: "Elijah Meeks",
+    date: "2026-06-15",
     tags: ["case-study", "accessibility"],
     excerpt:
-      "A screen reader announces \"line chart, nine points\" — accurate and useless. Research on accessible visualization says readers want statistics and trends, not chart types. describeChart() generates exactly that, deterministically, from the chart's config, and ChartContainer makes it an opt-in layer.",
+      "A screen reader announces 'line chart, nine points' which is both accurate and useless. Research on accessible visualization says readers want statistics and trends, not chart types. describeChart() generates exactly that, deterministically, from the chart\'s config, and ChartContainer makes it an opt-in layer.",
     ogChart: { component: "LineChart" },
     draft: true,
   },

--- a/docs/src/blog/entries/navigating-a-chart-you-cant-see.js
+++ b/docs/src/blog/entries/navigating-a-chart-you-cant-see.js
@@ -7,20 +7,34 @@ const DEMO = {
   component: "LineChart",
   props: {
     data: [
-      { month: "Jan", sales: 4200, region: "West" }, { month: "Feb", sales: 5100, region: "West" },
-      { month: "Mar", sales: 6800, region: "West" }, { month: "Jan", sales: 2200, region: "East" },
-      { month: "Feb", sales: 3100, region: "East" }, { month: "Mar", sales: 2600, region: "East" },
+      { month: "Jan", sales: 4200, region: "West" },
+      { month: "Feb", sales: 5100, region: "West" },
+      { month: "Mar", sales: 6800, region: "West" },
+      { month: "Jan", sales: 2200, region: "East" },
+      { month: "Feb", sales: 3100, region: "East" },
+      { month: "Mar", sales: 2600, region: "East" },
     ],
-    xAccessor: "month", yAccessor: "sales", lineBy: "region",
+    xAccessor: "month",
+    yAccessor: "sales",
+    lineBy: "region",
   },
 }
 
 function NavDemo() {
   const tree = React.useMemo(() => buildNavigationTree(DEMO.component, DEMO.props), [])
   return (
-    <div style={{ border: "1px solid var(--surface-3)", borderRadius: 8, padding: 10, margin: "20px 0", background: "var(--surface-1)" }}>
+    <div
+      style={{
+        border: "1px solid var(--surface-3)",
+        borderRadius: 8,
+        padding: 10,
+        margin: "20px 0",
+        background: "var(--surface-1)",
+      }}
+    >
       <p style={{ fontSize: 12, color: "var(--text-2)", margin: "2px 6px 8px" }}>
-        Click in, then ↑/↓ to move, → to expand, ← to collapse. (Visible here; screen-reader-only by default.)
+        Click in, then ↑/↓ to move, → to expand, ← to collapse. (Visible here; screen-reader-only by
+        default.)
       </p>
       <AccessibleNavTree tree={tree} label="Sales by region — navigable structure" visible />
     </div>
@@ -31,80 +45,92 @@ function Body() {
   return (
     <>
       <p>
-        Hand a screen-reader user a chart's data as a flat table of two hundred
-        rows and you've technically made it "accessible" and practically made it
-        unusable. A sighted reader doesn't consume a chart row by row — they see
-        the structure (two series, this one higher), then look closer where it
-        matters. Structured navigation gives a non-visual reader that same path:
-        a tree they walk from the whole chart, down through its series, to
-        individual points — hearing where they are at every step.
+        Hand a screen-reader user a chart's data as a flat table of two hundred rows and you've
+        technically made it "accessible" and practically made it unusable. A sighted reader doesn't
+        consume a chart row by row — they see the structure (two series, this one higher), then look
+        closer where it matters. Structured navigation gives a non-visual reader that same path: a
+        tree they walk from the whole chart, down through its series, to individual points — hearing
+        where they are at every step.
       </p>
 
       <h2 id="why-care">Why this matters</h2>
       <p>
         This is the idea behind{" "}
-        <a href="https://mitvis.github.io/olli/" target="_blank" rel="noopener noreferrer">Olli</a>{" "}
+        <a href="https://mitvis.github.io/olli/" target="_blank" rel="noopener noreferrer">
+          Olli
+        </a>{" "}
         and{" "}
-        <a href="https://www.frank.computer/data-navigator/" target="_blank" rel="noopener noreferrer">Data Navigator</a>{" "}
-        (Frank Elavsky et al., IEEE VIS 2023), and its key move is architectural:
-        the navigation structure lives in the <em>accessibility tree</em>,
-        completely decoupled from how the chart is drawn. That decoupling is what
-        makes it work for canvas. A <code>&lt;canvas&gt;</code> exposes nothing to
-        assistive technology — there are no elements to tab through. So you don't
-        try to make the pixels accessible; you build a parallel, real-DOM
-        structure that mirrors the data and let the screen reader walk <em>that</em>.
-        The chart can render however it likes.
+        <a
+          href="https://www.frank.computer/data-navigator/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Data Navigator
+        </a>{" "}
+        (Frank Elavsky et al., IEEE VIS 2023), and its key move is architectural: the navigation
+        structure lives in the <em>accessibility tree</em>, completely decoupled from how the chart
+        is drawn. That decoupling is what makes it work for canvas. A <code>&lt;canvas&gt;</code>{" "}
+        exposes nothing to assistive technology — there are no elements to tab through. So you don't
+        try to make the pixels accessible; you build a parallel, real-DOM structure that mirrors the
+        data and let the screen reader walk <em>that</em>. The chart can render however it likes.
       </p>
       <p>
-        It also answers a specific Chartability failure — "navigation is tedious."
-        A flat list is the tedious case by construction. A tree is the fix:
-        overview first, detail on demand.
+        It also answers a specific Chartability failure — "navigation is tedious." A flat list is
+        the tedious case by construction. A tree is the fix: overview first, detail on demand.
       </p>
 
       <h2 id="the-thing">Walk the tree</h2>
       <p>
-        Here's a two-series line chart rendered <em>only</em> as its navigation
-        tree (normally this is screen-reader-only; it's shown visibly so you can
-        see the structure):
+        Here's a two-series line chart rendered <em>only</em> as its navigation tree (normally this
+        is screen-reader-only; it's shown visibly so you can see the structure):
       </p>
 
       <NavDemo />
 
       <p>
-        Notice the shape of it. The root announces the whole chart. Below it,
-        axis-context rows orient you ("Value axis: sales, 2,200 to 6,800"). Then
-        one branch per series — collapsed, each carrying a generated statistical
-        summary, so you can decide whether to go in before you commit to hearing
-        six data points. Expand "Series West" and its points appear, each a real{" "}
-        <code>treeitem</code> with <code>aria-level</code>,{" "}
-        <code>aria-posinset</code>/<code>aria-setsize</code> ("2 of 3"), and{" "}
-        <code>aria-expanded</code>. It's the WAI-ARIA tree pattern, keyboard and
-        all: ↑/↓ to move, → to descend, ← to ascend, Home/End to jump.
+        Notice the shape of it. The root announces the whole chart. Below it, axis-context rows
+        orient you ("Value axis: sales, 2,200 to 6,800"). Then one branch per series — collapsed,
+        each carrying a generated statistical summary, so you can decide whether to go in before you
+        commit to hearing six data points. Expand "Series West" and its points appear, each a real{" "}
+        <code>treeitem</code> with <code>aria-level</code>, <code>aria-posinset</code>/
+        <code>aria-setsize</code> ("2 of 3"), and <code>aria-expanded</code>. It's the WAI-ARIA tree
+        pattern, keyboard and all: ↑/↓ to move, → to descend, ← to ascend, Home/End to jump.
       </p>
 
       <h2 id="labels">The labels come from describeChart</h2>
       <p>
         The series-level summaries aren't bespoke — they're generated by{" "}
-        <Link to="/accessibility/descriptions"><code>describeChart()</code></Link>,
-        the same engine that writes the chart's prose description. So the tree and
-        the description speak the same language: "Series West: sales ranges from
-        4,200 to 6,800… overall rises." The structure carries the navigation; the
-        descriptions carry the meaning; they compose.
+        <Link to="/accessibility/descriptions">
+          <code>describeChart()</code>
+        </Link>
+        , the same engine that writes the chart's prose description. So the tree and the description
+        speak the same language: "Series West: sales ranges from 4,200 to 6,800… overall rises." The
+        structure carries the navigation; the descriptions carry the meaning; they compose.
       </p>
 
       <h2 id="opt-in">Opt-in at the container</h2>
       <p>
         Like descriptions, structured navigation is an opt-in at the{" "}
-        <Link to="/features/chart-container">ChartContainer</Link> layer — give it
-        a <code>chartConfig</code> and set <code>navigable</code> — rather than
-        something every bare chart carries. The bare chart's baseline is keyboard
-        point-navigation, a focus ring, a live region, and a data table; the
-        container is where the richer, opt-in accessible surfaces live. Turning it
-        on flips the <Link to="/accessibility/audit">audit's</Link>{" "}
-        <code>navigable-structure</code> finding to a pass — including for
-        treemaps and trees, whose built-in keyboard nav is otherwise flat.
+        <Link to="/features/chart-container">ChartContainer</Link> layer — give it a{" "}
+        <code>chartConfig</code> and set <code>navigable</code> — rather than something every bare
+        chart carries. The bare chart's baseline is keyboard point-navigation, a focus ring, a live
+        region, and a data table; the container is where the richer, opt-in accessible surfaces
+        live. Turning it on flips the <Link to="/accessibility/audit">audit's</Link>{" "}
+        <code>navigable-structure</code> finding to a pass — including for treemaps and trees, whose
+        built-in keyboard nav is otherwise flat.
       </p>
-      <pre style={{ background: "var(--surface-1)", border: "1px solid var(--surface-3)", borderRadius: 8, padding: 16, margin: "20px 0", fontFamily: "var(--font-mono)", fontSize: 13, whiteSpace: "pre-wrap" }}>{`<ChartContainer chartConfig={{ component: "LineChart", props }} navigable>
+      <pre
+        style={{
+          background: "var(--surface-1)",
+          border: "1px solid var(--surface-3)",
+          borderRadius: 8,
+          padding: 16,
+          margin: "20px 0",
+          fontFamily: "var(--font-mono)",
+          fontSize: 13,
+          whiteSpace: "pre-wrap",
+        }}
+      >{`<ChartContainer chartConfig={{ component: "LineChart", props }} navigable>
   <LineChart {...props} />
 </ChartContainer>
 
@@ -114,31 +140,54 @@ function Body() {
       <h2 id="bidirectional">Closing the loop: bidirectional sync</h2>
       <p>
         The tree isn't just a reading structure — it's wired both ways.{" "}
-        <code>useNavigationSync</code> ties the tree to the chart: walk the tree
-        and the matching mark highlights; hover or click the chart and the tree's
-        cursor follows, auto-expanding to reveal the node. A screen-reader user
-        and a sighted collaborator stay on the same data point. It rides
-        Semiotic's existing selection and observation stores, so it needs no
-        provider — the chart takes a <code>chartId</code> and a{" "}
-        <code>selection</code>, the tree takes <code>activeId</code> and{" "}
-        <code>onActiveChange</code>, and <code>useNavigationSync</code> keeps them
-        in lockstep. See it live on the{" "}
+        <code>useNavigationSync</code> ties the tree to the chart: walk the tree and the matching
+        mark highlights; hover or click the chart and the tree's cursor follows, auto-expanding to
+        reveal the node. A screen-reader user and a sighted collaborator stay on the same data
+        point. It rides Semiotic's existing selection and observation stores, so it needs no
+        provider — the chart takes a <code>chartId</code> and a <code>selection</code>, the tree
+        takes <code>activeId</code> and <code>onActiveChange</code>, and{" "}
+        <code>useNavigationSync</code> keeps them in lockstep. See it live on the{" "}
         <Link to="/accessibility/navigation">reference page</Link>.
       </p>
 
       <h2 id="other-domains">Where this pattern shows up</h2>
       <ul>
-        <li><strong>Any canvas/WebGL visualization.</strong> Maps, network graphs, game telemetry — the "build a parallel accessible structure" move applies anywhere the render target is opaque to AT.</li>
-        <li><strong>Dashboards.</strong> A tree per chart, or one tree spanning a dashboard, beats tabbing through dozens of flat tables.</li>
-        <li><strong>Multimodal interfaces.</strong> The same tree structure feeds keyboard, screen reader, and — via Data Navigator — speech and gesture input.</li>
-        <li><strong>Document outlines, file trees, org charts.</strong> The overview-then-detail tree is the same affordance that makes any large hierarchy navigable.</li>
+        <li>
+          <strong>Any canvas/WebGL visualization.</strong> Maps, network graphs, game telemetry —
+          the "build a parallel accessible structure" move applies anywhere the render target is
+          opaque to AT.
+        </li>
+        <li>
+          <strong>Dashboards.</strong> A tree per chart, or one tree spanning a dashboard, beats
+          tabbing through dozens of flat tables.
+        </li>
+        <li>
+          <strong>Multimodal interfaces.</strong> The same tree structure feeds keyboard, screen
+          reader, and — via Data Navigator — speech and gesture input.
+        </li>
+        <li>
+          <strong>Document outlines, file trees, org charts.</strong> The overview-then-detail tree
+          is the same affordance that makes any large hierarchy navigable.
+        </li>
       </ul>
 
       <h2 id="related">Related</h2>
       <ul>
-        <li><Link to="/accessibility/navigation">Structured Navigation — reference</Link></li>
-        <li><Link to="/accessibility/descriptions">Chart Descriptions</Link></li>
-        <li><a href="https://www.frank.computer/data-navigator/" target="_blank" rel="noopener noreferrer">Data Navigator (Elavsky et al., IEEE VIS 2023)</a></li>
+        <li>
+          <Link to="/accessibility/navigation">Structured Navigation — reference</Link>
+        </li>
+        <li>
+          <Link to="/accessibility/descriptions">Chart Descriptions</Link>
+        </li>
+        <li>
+          <a
+            href="https://www.frank.computer/data-navigator/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Data Navigator (Elavsky et al., IEEE VIS 2023)
+          </a>
+        </li>
       </ul>
     </>
   )
@@ -149,8 +198,8 @@ export default {
   title: "Navigating a Chart You Can't See",
   subtitle:
     "Structured navigation exposes a chart as a screen-reader-traversable tree — chart → series → data point — following the Olli / Data Navigator model, uncoupled from the canvas it's drawn on.",
-  author: "Semiotic Team",
-  date: "2026-06-01",
+  author: "Elijah Meeks",
+  date: "2026-06-15",
   tags: ["case-study", "accessibility"],
   excerpt:
     "A flat table of 200 rows is technically accessible and practically unusable. Structured navigation gives a non-visual reader the path a sighted reader takes — overview, then detail — as an ARIA tree built from the chart config and mounted as an opt-in ChartContainer layer, decoupled from how the chart renders.",

--- a/docs/src/blog/entries/what-a-screen-reader-should-hear.js
+++ b/docs/src/blog/entries/what-a-screen-reader-should-hear.js
@@ -21,11 +21,14 @@ const DEMO = {
   component: "LineChart",
   props: {
     data: [
-      { month: "Jan", sales: 4200 }, { month: "Feb", sales: 5100 },
-      { month: "Mar", sales: 6800 }, { month: "Apr", sales: 9100 },
+      { month: "Jan", sales: 4200 },
+      { month: "Feb", sales: 5100 },
+      { month: "Mar", sales: 6800 },
+      { month: "Apr", sales: 9100 },
       { month: "May", sales: 2100 },
     ],
-    xAccessor: "month", yAccessor: "sales",
+    xAccessor: "month",
+    yAccessor: "sales",
   },
 }
 
@@ -35,11 +38,24 @@ function LevelBreakdown() {
     <div style={panel}>
       {LEVELS.map(({ key, tag, name, color }) =>
         r.levels[key] ? (
-          <div key={key} style={{ display: "flex", gap: 10, marginBottom: 10, alignItems: "baseline" }}>
-            <span style={{ flex: "0 0 88px", fontSize: 11, fontWeight: 700, color, fontFamily: "var(--font-mono)" }}>{tag} {name}</span>
+          <div
+            key={key}
+            style={{ display: "flex", gap: 10, marginBottom: 10, alignItems: "baseline" }}
+          >
+            <span
+              style={{
+                flex: "0 0 88px",
+                fontSize: 11,
+                fontWeight: 700,
+                color,
+                fontFamily: "var(--font-mono)",
+              }}
+            >
+              {tag} {name}
+            </span>
             <span style={{ fontSize: 14, lineHeight: 1.5 }}>{r.levels[key]}</span>
           </div>
-        ) : null
+        ) : null,
       )}
     </div>
   )
@@ -49,87 +65,95 @@ function Body() {
   return (
     <>
       <p>
-        Point a screen reader at a chart on a <code>&lt;canvas&gt;</code> and, if
-        you've done everything right, it says "line chart, nine points." That's
-        not a description; it's a census. The data — the rise, the peak, the
-        cliff in May — is exactly the part that never makes it to the person who
-        can't see the pixels. <code>describeChart()</code> closes that gap by
-        generating the description the chart should have been narrating all along.
+        Point a screen reader at a chart on a <code>&lt;canvas&gt;</code> and, if you've done
+        everything right, it says "line chart, nine points." That's not a description; it's a
+        census. The pattern of the data is exactly the part that never makes it to the person who
+        can't see the pixels. <code>describeChart()</code> closes that gap by generating the
+        description the chart should have been narrating all along.
       </p>
 
       <h2 id="why-care">Why this matters</h2>
       <p>
-        There's real research behind what a good chart description contains.
-        Alan Lundgard and Arvind Satyanarayan's{" "}
-        <a href="https://vis.csail.mit.edu/pubs/vis-text-model/" target="_blank" rel="noopener noreferrer">
+        There's real research behind what a good chart description contains. Alan Lundgard and
+        Arvind Satyanarayan's{" "}
+        <a
+          href="https://vis.csail.mit.edu/pubs/vis-text-model/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           four-level model of semantic content
         </a>{" "}
-        (IEEE VIS 2021) analyzed thousands of human-written chart descriptions and
-        sorted their content into four levels: <strong>L1</strong> the encoding
-        (what's a line, what's an axis), <strong>L2</strong> the statistics
-        (ranges, extrema, means), <strong>L3</strong> the perceptual trends (it
-        rises, it peaks, it reverses), and <strong>L4</strong> the domain meaning
-        (why any of it matters). Then they asked blind and sighted readers which
-        levels they valued. The punchline that should reorganize how every
-        charting library does alt-text: <strong>blind and low-vision readers rank
-        L2 and L3 as the most useful</strong> — the statistics and the trends —
-        while most automatic captioning stops at L1, the one level that adds the
-        least.
+        (IEEE VIS 2021) analyzed thousands of human-written chart descriptions and sorted their
+        content into four levels: <strong>L1</strong> the encoding (what's a line, what's an axis),{" "}
+        <strong>L2</strong> the statistics (ranges, extrema, means), <strong>L3</strong> the
+        perceptual trends (it rises, it peaks, it reverses), and <strong>L4</strong> the domain
+        meaning (why any of it matters). Then they asked blind and sighted readers which levels they
+        valued. The punchline that should reorganize how every charting library does alt-text:{" "}
+        <strong>blind and low-vision readers rank L2 and L3 as the most useful</strong>: the
+        statistics and the trends. While most automatic captioning stops at L1, the one level that
+        adds the least.
       </p>
       <p>
-        So the bar isn't "label the chart." It's "tell me the numbers and the
-        shape." That's a higher bar, but it's also a <em>computable</em> one: a
-        chart's config already contains the data and the encoding. You can derive
-        L1, L2, and most of L3 without an LLM, deterministically, offline.
+        So the bar isn't "label the chart." It's "tell me the numbers and the shape." That's a
+        higher bar, but it's also a <em>computable</em> one: a chart's config already contains the
+        data and the encoding. You can derive L1, L2, and most of L3 without an LLM,
+        deterministically, offline.
       </p>
 
       <h2 id="the-thing">Three levels from one config</h2>
       <p>
-        Here's <code>describeChart()</code> run live on a five-point line chart —
-        sales that climb for four months and then fall off a cliff. Each line is
-        one semantic level:
+        Here's <code>describeChart()</code> run live on a five-point line chart showing sales that
+        climb for four months and then fall off a cliff. Each line is one semantic level:
       </p>
 
       <LevelBreakdown />
 
       <p>
-        L1 is the encoding. L2 is the statistics, and note it carries the{" "}
-        <em>labels</em> at the extremes — not "max 9,100" but "9,100 (Apr)," which
-        is the version a person can actually use. L3 is the trend, and it's doing
-        the subtle thing: the series ends at its lowest point, so it reports the
-        fall to May rather than pretending the April peak is the headline. Glue
-        the three together and a screen reader finally narrates the chart instead
-        of counting it.
+        L1 is the encoding. L2 is the statistics, and note it carries the <em>labels</em> at the
+        extremes but not "max 9,100" but "9,100 (Apr)," which is the version a person can actually
+        use. L3 is the trend, and it's doing the subtle thing: the series ends at its lowest point,
+        so it reports the fall to May rather than pretending the April peak is the headline. Glue
+        the three together and a screen reader finally narrates the chart instead of counting it.
       </p>
 
       <h2 id="how-it-works">How it works</h2>
       <p>
-        No model, no network. <code>describeChart()</code> reads the chart's
-        accessors to find the measure and the dimension, then:
+        No model, no network. <code>describeChart()</code> reads the chart's accessors to find the
+        measure and the dimension, then:
       </p>
       <ul>
-        <li><strong>L1</strong> maps the component to a chart-type phrase and names the channels — "a line chart of sales by month," "split by region" when there's a series field.</li>
-        <li><strong>L2</strong> walks the data once for min, max, and mean, holding onto the dimension label at each extreme so it can say <em>where</em> the peak was.</li>
-        <li><strong>L3</strong> compares first to last against the overall spread, classifies the net direction, and — the part that keeps it honest — detects reversals, so a series that peaks in the middle reads "rises … after peaking at 400 (Feb)" rather than a flat "rises."</li>
+        <li>
+          <strong>L1</strong> maps the component to a chart-type phrase and names the channels such
+          as "a line chart of sales by month," "split by region" when there's a series field.
+        </li>
+        <li>
+          <strong>L2</strong> walks the data once for min, max, and mean, holding onto the dimension
+          label at each extreme so it can say <em>where</em> the peak was.
+        </li>
+        <li>
+          <strong>L3</strong> compares first to last against the overall spread, classifies the net
+          direction, and detects reversals, so a series that peaks in the middle reads "rises …
+          after peaking at 400 (Feb)" rather than a flat "rises."
+        </li>
       </ul>
       <p>
-        It's richest for the families where a measure over a dimension is the
-        whole point — XY, bar, part-to-whole, distributions. For network,
-        hierarchy, geo, and single-value charts it returns a clean L1 and stops,
-        rather than inventing a trend that isn't there. Honest degradation beats
-        confident nonsense.
+        It's richest for the families where a measure over a dimension is the whole point — XY, bar,
+        part-to-whole, distributions. For network, hierarchy, geo, and single-value charts it
+        returns a clean L1 and stops, rather than inventing a trend that isn't there. Honest
+        degradation beats confident nonsense.
       </p>
 
       <h2 id="opt-in">The description belongs to the container</h2>
       <p>
-        We made one deliberate architectural choice: auto-description is{" "}
-        <strong>not</strong> baked into every chart. It's an opt-in at the{" "}
-        <Link to="/features/chart-container">ChartContainer</Link> layer, which is
-        already where presentation chrome — title, subtitle, toolbar — lives. Give
-        the container a <code>chartConfig</code> (it takes one anyway, for "copy
-        config") and set <code>describe</code>:
+        We made one deliberate architectural choice: auto-description is <strong>not</strong> baked
+        into every chart. It's an opt-in at the{" "}
+        <Link to="/features/chart-container">ChartContainer</Link> layer, which is already where
+        title, subtitle, toolbar live. Give the container a <code>chartConfig</code> (it takes one
+        anyway, for "copy config") and set <code>describe</code>:
       </p>
-      <pre style={{ ...panel, fontFamily: "var(--font-mono)", fontSize: 13, whiteSpace: "pre-wrap" }}>{`<ChartContainer
+      <pre
+        style={{ ...panel, fontFamily: "var(--font-mono)", fontSize: 13, whiteSpace: "pre-wrap" }}
+      >{`<ChartContainer
   title="Sales by month"
   chartConfig={{ component: "LineChart", props }}
   describe                       // screen-reader-only L1–L3 description
@@ -137,45 +161,66 @@ function Body() {
   <LineChart {...props} />
 </ChartContainer>`}</pre>
       <p>
-        Why not just do it automatically on the bare chart? Two reasons. The bare
-        chart space is a deliberate baseline — keyboard navigation, focus ring,
-        live region, a data table — and piling presentation on top of it blurs
-        that line. And a container-level description sits in one place in the
-        reading order instead of fighting the chart's own terse aria-label. Full
-        accessible legibility is something you opt into by reaching for the
-        container, not something every chart has to carry alone. (The{" "}
-        <Link to="/accessibility/audit">accessibility audit</Link> knows the
-        difference: flip <code>describe</code> on and its "features described"
-        finding flips from warning to pass.)
+        Why not just do it automatically on the bare chart? Two reasons. The bare chart space is a
+        deliberate baseline: keyboard navigation, focus ring, live region, a data table. Adding
+        presentation on top of it blurs that line. And a container-level description sits in one
+        place in the reading order instead of fighting the chart's own terse aria-label. Full
+        accessible legibility is something you opt into by reaching for the container, not something
+        every chart has to carry alone. (The{" "}
+        <Link to="/accessibility/audit">accessibility audit</Link> knows the difference: flip{" "}
+        <code>describe</code> on and its "features described" finding flips from warning to pass.)
       </p>
 
       <h2 id="when">When to reach for it (and its limit)</h2>
       <p>
-        Use it as the <strong>default first draft</strong> for any chart's
-        description, and as a <strong>reliable fallback</strong> when no one has
-        written one. What it gives you is the shape — type, numbers, trend. What
-        it can't give you is L4: the <em>meaning</em>. It will tell you sales fell
-        to 2,100 in May; it won't tell you that's because the warehouse flooded.
-        For the "why," write a <code>summary</code>, or — and this is the natural
-        next step — feed the generated L1–L3 text plus the data through an LLM via
-        the <Link to="/intelligence/interrogation">interrogation</Link> layer and
-        let it supply the domain narrative. Deterministic description for the
-        shape, generative for the meaning.
+        Use it as the <strong>default first draft</strong> for any chart's description, and as a{" "}
+        <strong>reliable fallback</strong> when no one has written one. What it gives you is the
+        shape: type, numbers, trend. What it can't give you is L4: the <em>meaning</em>. It will
+        tell you sales fell to 2,100 in May; it won't tell you that's because the warehouse flooded.
+        For the "why," write a <code>summary</code>, or feed the generated L1–L3 text plus the data
+        through an LLM via the <Link to="/intelligence/interrogation">interrogation</Link> layer and
+        let it supply the domain narrative. Deterministic description for the shape, generative for
+        the meaning.
       </p>
 
       <h2 id="other-domains">Where this pattern shows up</h2>
       <ul>
-        <li><strong>Dashboards.</strong> A grid of twenty charts is twenty "line chart, N points" announcements unless each one narrates itself. Auto-description scales where hand-written alt-text doesn't.</li>
-        <li><strong>Automated reporting.</strong> The same L1–L3 text is a serviceable caption for a generated PDF or email, sighted readers included.</li>
-        <li><strong>LLM grounding.</strong> Handing a model the deterministic statistics keeps its narrative honest — it's describing real extrema, not hallucinating a trend.</li>
-        <li><strong>Any raster visualization.</strong> Maps, WebGL scenes, game telemetry — anywhere the visual has no DOM, a config-derived description is the accessible path.</li>
+        <li>
+          <strong>Dashboards.</strong> A grid of twenty charts is twenty "line chart, N points"
+          announcements unless each one narrates itself. Auto-description scales where hand-written
+          alt-text doesn't.
+        </li>
+        <li>
+          <strong>Automated reporting.</strong> The same L1–L3 text is a serviceable caption for a
+          generated PDF or email, sighted readers included.
+        </li>
+        <li>
+          <strong>LLM grounding.</strong> Handing a model the deterministic statistics keeps its
+          narrative honest by describing real extrema, not hallucinating a trend.
+        </li>
+        <li>
+          <strong>Any raster visualization.</strong> Maps, WebGL scenes, game telemetry or anywhere
+          the visual has no DOM to provide a config-derived description is the accessible path.
+        </li>
       </ul>
 
       <h2 id="related">Related</h2>
       <ul>
-        <li><Link to="/accessibility/descriptions">Chart Descriptions — reference</Link></li>
-        <li><Link to="/accessibility/audit">Chartability Audit</Link></li>
-        <li><a href="https://vis.csail.mit.edu/pubs/vis-text-model/" target="_blank" rel="noopener noreferrer">Lundgard &amp; Satyanarayan — A Four-Level Model of Semantic Content</a></li>
+        <li>
+          <Link to="/accessibility/descriptions">Chart Descriptions - reference</Link>
+        </li>
+        <li>
+          <Link to="/accessibility/audit">Chartability Audit</Link>
+        </li>
+        <li>
+          <a
+            href="https://vis.csail.mit.edu/pubs/vis-text-model/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Lundgard &amp; Satyanarayan - A Four-Level Model of Semantic Content
+          </a>
+        </li>
       </ul>
     </>
   )
@@ -185,12 +230,12 @@ export default {
   slug: "what-a-screen-reader-should-hear",
   title: "What a Screen Reader Should Hear",
   subtitle:
-    "describeChart() turns a chart config into a layered natural-language description — encoding, statistics, and trend — the content research says blind and low-vision readers actually want.",
-  author: "Semiotic Team",
-  date: "2026-06-01",
+    "describeChart() turns a chart config into a layered natural-language description: encoding, statistics, and trend which research says blind and low-vision readers actually want.",
+  author: "Elijah Meeks",
+  date: "2026-06-15",
   tags: ["case-study", "accessibility"],
   excerpt:
-    "A screen reader announces \"line chart, nine points\" — accurate and useless. Research on accessible visualization says readers want statistics and trends, not chart types. describeChart() generates exactly that, deterministically, from the chart's config, and ChartContainer makes it an opt-in layer.",
+    'A screen reader announces "line chart, nine points" which is both accurate and useless. Research on accessible visualization says readers want statistics and trends, not chart types. describeChart() generates exactly that, deterministically, from the chart\'s config, and ChartContainer makes it an opt-in layer.',
   component: Body,
   ogChart: { component: "LineChart" },
   draft: true,


### PR DESCRIPTION
This pull request updates the blog entry metadata and content for two accessibility-focused posts, clarifies authorship and publication dates, and improves code readability and formatting in the blog source files. The most significant changes are author and date updates, content and prose clarifications, and code style improvements for better maintainability.

**Blog metadata and authorship:**

* Changed the `author` from "Semiotic Team" to "Elijah Meeks" and updated the `date` from "2026-06-01" to "2026-06-15" for both "Navigating a Chart You Can't See" and "What a Screen Reader Should Hear" in both the metadata (`entries-meta.js`) and the entry files themselves. [[1]](diffhunk://#diff-b29e7c9dae4d0d98a41b08dcc1c22f652d850291523ccac53d1f8c1cb180e3a6L27-R28) [[2]](diffhunk://#diff-b29e7c9dae4d0d98a41b08dcc1c22f652d850291523ccac53d1f8c1cb180e3a6L39-R44) [[3]](diffhunk://#diff-6f9fb22c135024e67ebf2fbcb156a6b22824696855bb8b265c84617907c1a231L152-R202)

**Content and prose improvements:**

* Refined subtitles, excerpts, and several paragraphs for clarity and conciseness in both blog entries, making explanations more readable and consistent. [[1]](diffhunk://#diff-b29e7c9dae4d0d98a41b08dcc1c22f652d850291523ccac53d1f8c1cb180e3a6L39-R44) [[2]](diffhunk://#diff-6f9fb22c135024e67ebf2fbcb156a6b22824696855bb8b265c84617907c1a231L34-R133) [[3]](diffhunk://#diff-6f9fb22c135024e67ebf2fbcb156a6b22824696855bb8b265c84617907c1a231L117-R190)

**Code formatting and style:**

* Reformatted data arrays and props objects in the demo chart definitions for better readability and maintainability in both entries. [[1]](diffhunk://#diff-6f9fb22c135024e67ebf2fbcb156a6b22824696855bb8b265c84617907c1a231L10-R37) [[2]](diffhunk://#diff-762c548a526022ff5b398bbe0a40349c97ea81d16a63b62ab4a21333ae491cc2L24-R31)
* Improved JSX formatting and style for HTML elements, links, and inline styles throughout the blog entry files, resulting in more readable and maintainable code. [[1]](diffhunk://#diff-6f9fb22c135024e67ebf2fbcb156a6b22824696855bb8b265c84617907c1a231L10-R37) [[2]](diffhunk://#diff-6f9fb22c135024e67ebf2fbcb156a6b22824696855bb8b265c84617907c1a231L34-R133) [[3]](diffhunk://#diff-6f9fb22c135024e67ebf2fbcb156a6b22824696855bb8b265c84617907c1a231L117-R190) [[4]](diffhunk://#diff-762c548a526022ff5b398bbe0a40349c97ea81d16a63b62ab4a21333ae491cc2L38-R58)