### PR TITLE
Add annotation hierarchy and inferred emphasis

### DIFF
--- a/docs/src/pages/features/AnnotationsPage.js
+++ b/docs/src/pages/features/AnnotationsPage.js
@@ -490,8 +490,11 @@ export default function AnnotationsPage() {
         annotation accepts <code>emphasis: "primary" | "secondary"</code> — the
         same token charts use for dashboard hierarchy. A <code>secondary</code>{" "}
         annotation dims and yields z-order; a <code>primary</code> one paints at
-        full weight and on top. Annotations with no <code>emphasis</code> render
-        exactly as before, so it is purely additive. The wrapper carries class
+        full weight and on top. If <code>emphasis</code> is omitted but
+        annotations carry <code>provenance.confidence</code>, Semiotic infers a
+        reading order from confidence descending, then authored array order, and
+        applies a subtle opacity gradient. Annotations with neither signal
+        render exactly as before, so it is purely additive. The wrapper carries class
         hooks <code>annotation-emphasis--primary</code> /{" "}
         <code>annotation-emphasis--secondary</code> for further styling, and the
         dim composes with the freshness treatment from{" "}

--- a/src/components/charts/shared/annotationEmphasis.test.tsx
+++ b/src/components/charts/shared/annotationEmphasis.test.tsx
@@ -7,8 +7,10 @@ import type { AnnotationContext } from "../../realtime/types"
 // Minimal element-prop accessor so the assertions don't sprinkle `any`.
 type ElProps = {
   "data-id"?: string
+  "data-annotation-reading-order"?: number
   className?: string
   opacity?: number
+  fontSize?: string
   children?: React.ReactNode
 }
 const propsOf = (n: React.ReactNode): ElProps =>
@@ -23,9 +25,13 @@ function innerId(n: React.ReactNode): string | undefined {
   return undefined
 }
 
-const pair = (id: string, emphasis?: string): AnnotationRenderPair => ({
+const pair = (id: string, emphasis?: string, confidence?: number): AnnotationRenderPair => ({
   node: <g key={id} data-id={id} />,
-  annotation: { type: "label", ...(emphasis ? { emphasis } : {}) } as Datum,
+  annotation: {
+    type: "label",
+    ...(emphasis ? { emphasis } : {}),
+    ...(confidence != null ? { provenance: { confidence } } : {}),
+  } as Datum,
 })
 
 describe("applyAnnotationEmphasis", () => {
@@ -54,6 +60,7 @@ describe("applyAnnotationEmphasis", () => {
     const sec = out.find((n) => propsOf(n).className?.includes("secondary"))
     const pri = out.find((n) => propsOf(n).className?.includes("primary"))
     expect(propsOf(sec).opacity).toBe(0.6)
+    expect(propsOf(sec).fontSize).toBe("0.88em")
     expect(propsOf(sec).className).toContain("annotation-emphasis--secondary")
     // Primary paints at full weight — class for styling hooks, but no dim.
     expect(propsOf(pri).opacity).toBeUndefined()
@@ -66,6 +73,39 @@ describe("applyAnnotationEmphasis", () => {
     // The unspecified node passes through as its original element — no wrapper.
     expect(plain).toBeDefined()
     expect(propsOf(plain).className).toBeUndefined()
+  })
+
+  it("infers reading order from provenance confidence, then array order", () => {
+    const out = applyAnnotationEmphasis([
+      pair("low", undefined, 0.2),
+      pair("high", undefined, 0.9),
+      pair("tie-a", undefined, 0.7),
+      pair("tie-b", undefined, 0.7),
+      pair("none"),
+    ])
+
+    // SVG paint order is low priority first, so the highest-confidence
+    // annotation is last/on top while its reading order remains first.
+    expect(out.map(innerId)).toEqual(["none", "low", "tie-b", "tie-a", "high"])
+
+    const byId = new Map(out.map((n) => [innerId(n), propsOf(n)]))
+    expect(byId.get("high")?.["data-annotation-reading-order"]).toBe(0)
+    expect(byId.get("tie-a")?.["data-annotation-reading-order"]).toBe(1)
+    expect(byId.get("tie-b")?.["data-annotation-reading-order"]).toBe(2)
+    expect(byId.get("low")?.["data-annotation-reading-order"]).toBe(3)
+    expect(byId.get("high")?.opacity).toBeGreaterThan(byId.get("low")?.opacity ?? 0)
+    expect(byId.get("none")?.className).toBeUndefined()
+  })
+
+  it("lets explicit emphasis override inferred confidence", () => {
+    const out = applyAnnotationEmphasis([
+      pair("confident-secondary", "secondary", 1),
+      pair("low-primary", "primary", 0.1),
+      pair("inferred", undefined, 0.8),
+    ])
+    expect(out.map(innerId)).toEqual(["confident-secondary", "inferred", "low-primary"])
+    expect(propsOf(out[0]).className).toContain("annotation-emphasis--secondary")
+    expect(propsOf(out[2]).className).toContain("annotation-emphasis--primary")
   })
 })
 
@@ -117,5 +157,15 @@ describe("renderAnnotationPass", () => {
     const out = renderAnnotationPass(anns, (a) => el(String(a.id)), undefined, ctx)
     // secondary → unspecified → primary (innerId reads through the wrapper).
     expect(out.map(innerId)).toEqual(["s", "d", "p"])
+  })
+
+  it("applies inferred hierarchy across the rendered nodes", () => {
+    const anns: Datum[] = [
+      { type: "x", id: "low", provenance: { confidence: 0.3 } },
+      { type: "x", id: "high", provenance: { confidence: 0.9 } },
+    ]
+    const out = renderAnnotationPass(anns, (a) => el(String(a.id)), undefined, ctx)
+    expect(out.map(innerId)).toEqual(["low", "high"])
+    expect(propsOf(out[1])["data-annotation-reading-order"]).toBe(0)
   })
 })

--- a/src/components/charts/shared/annotationHierarchy.tsx
+++ b/src/components/charts/shared/annotationHierarchy.tsx
@@ -1,0 +1,137 @@
+import * as React from "react"
+import type { Datum } from "./datumTypes"
+
+export type AnnotationEmphasis = "primary" | "secondary"
+
+/** A rendered annotation node paired with the source annotation it came
+ *  from, so hierarchy treatment can read metadata after the per-type rule has
+ *  produced the node. */
+export interface AnnotationRenderPair {
+  node: React.ReactNode
+  annotation: Datum
+}
+
+const EMPHASIS_RANK: Record<AnnotationEmphasis, number> = {
+  secondary: 0,
+  primary: 3,
+}
+const DEFAULT_EMPHASIS_RANK = 1
+const INFERRED_EMPHASIS_RANK = 2
+
+/** Opacity applied to a `secondary` annotation so primary notes read as
+ *  the dominant layer (Rahman et al.'s "Hierarchy" consideration). */
+const SECONDARY_EMPHASIS_OPACITY = 0.6
+const SECONDARY_EMPHASIS_FONT_SIZE = "0.88em"
+
+const INFERRED_MAX_OPACITY = 0.95
+const INFERRED_MIN_OPACITY = 0.72
+const INFERRED_OPACITY_STEP = 0.06
+
+function explicitEmphasis(annotation: Datum): AnnotationEmphasis | null {
+  return annotation?.emphasis === "primary" || annotation?.emphasis === "secondary"
+    ? annotation.emphasis
+    : null
+}
+
+function provenanceConfidence(annotation: Datum): number | null {
+  const c = annotation?.provenance?.confidence
+  return typeof c === "number" && Number.isFinite(c)
+    ? Math.max(0, Math.min(1, c))
+    : null
+}
+
+function inferredOpacity(readingOrder: number): number {
+  return Math.max(
+    INFERRED_MIN_OPACITY,
+    INFERRED_MAX_OPACITY - readingOrder * INFERRED_OPACITY_STEP
+  )
+}
+
+/**
+ * Apply annotation hierarchy — Rahman et al.'s "Hierarchy" consideration,
+ * reusing the same `emphasis` token charts already accept (`"primary"` /
+ * `"secondary"`). A `secondary` annotation dims, shrinks note text through
+ * inherited SVG font-size, and yields z-order; a `primary` one paints at full
+ * weight and on top.
+ *
+ * If no explicit emphasis is declared, annotations with
+ * `provenance.confidence` get an inferred reading order: confidence
+ * descending, then authored array order. The visual output uses that order as
+ * a subtle opacity gradient, with higher-confidence notes painted later.
+ *
+ * Type-agnostic: it wraps whatever the per-type rule produced, so all
+ * annotation types get hierarchy without each rule knowing about it.
+ *
+ * Zero-overhead and structure-preserving when no annotation declares an
+ * explicit emphasis or provenance confidence: the original nodes are returned
+ * untouched (same keys, same order), so existing charts render identically.
+ * Opacity composes multiplicatively with lifecycle freshness opacity.
+ */
+export function applyAnnotationEmphasis(
+  pairs: ReadonlyArray<AnnotationRenderPair>
+): React.ReactNode[] {
+  const ranked = pairs.map((p, i) => ({
+    p,
+    i,
+    emphasis: explicitEmphasis(p.annotation),
+    confidence: provenanceConfidence(p.annotation),
+    readingOrder: null as number | null,
+    rank: DEFAULT_EMPHASIS_RANK,
+  }))
+
+  const anyHierarchySignal = ranked.some(
+    (r) => r.emphasis != null || r.confidence != null
+  )
+  if (!anyHierarchySignal) return pairs.map((p) => p.node)
+
+  const inferredReading = ranked
+    .filter((r) => r.emphasis == null && r.confidence != null)
+    .slice()
+    .sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0) || a.i - b.i)
+
+  inferredReading.forEach((r, readingOrder) => {
+    r.readingOrder = readingOrder
+    // SVG paints later nodes on top. Reading order is high confidence first,
+    // so invert it for paint order: low-confidence notes yield z-order.
+    r.rank = INFERRED_EMPHASIS_RANK - readingOrder / Math.max(1, inferredReading.length)
+  })
+
+  for (const r of ranked) {
+    if (r.emphasis) r.rank = EMPHASIS_RANK[r.emphasis]
+  }
+
+  return ranked
+    .sort((a, b) => a.rank - b.rank || a.i - b.i)
+    .map((r) => {
+      const { p, i, emphasis, readingOrder } = r
+      if (emphasis !== "primary" && emphasis !== "secondary" && readingOrder == null) {
+        return p.node
+      }
+
+      const isInferred = emphasis == null && readingOrder != null
+      const className = isInferred
+        ? "annotation-emphasis annotation-emphasis--inferred"
+        : `annotation-emphasis annotation-emphasis--${emphasis}`
+
+      return (
+        <g
+          key={`annotation-emphasis-${i}`}
+          className={className}
+          {...(emphasis === "secondary"
+            ? {
+                opacity: SECONDARY_EMPHASIS_OPACITY,
+                fontSize: SECONDARY_EMPHASIS_FONT_SIZE,
+              }
+            : {})}
+          {...(isInferred
+            ? {
+                opacity: inferredOpacity(readingOrder),
+                "data-annotation-reading-order": readingOrder,
+              }
+            : {})}
+        >
+          {p.node}
+        </g>
+      )
+    })
+}

--- a/src/components/charts/shared/annotationRules.tsx
+++ b/src/components/charts/shared/annotationRules.tsx
@@ -9,6 +9,9 @@ import { loess } from "./loess"
 import regression from "regression"
 import { resolveX, resolveY, resolveAnchoredPosition, isInBounds } from "./annotationResolvers"
 import type { Datum } from "./datumTypes"
+import { applyAnnotationEmphasis, type AnnotationRenderPair } from "./annotationHierarchy"
+
+export { applyAnnotationEmphasis, type AnnotationRenderPair } from "./annotationHierarchy"
 
 const CURVE_FACTORIES: Record<string, CurveFactory> = {
   linear: curveLinear,
@@ -20,69 +23,6 @@ const CURVE_FACTORIES: Record<string, CurveFactory> = {
   basis: curveBasis,
   cardinal: curveCardinal,
   catmullRom: curveCatmullRom,
-}
-
-// ── Annotation hierarchy / emphasis ───────────────────────────────────
-
-/** A rendered annotation node paired with the source annotation it came
- *  from, so emphasis treatment can read `annotation.emphasis` after the
- *  per-type rule has produced the node. */
-export interface AnnotationRenderPair {
-  node: React.ReactNode
-  annotation: Datum
-}
-
-const EMPHASIS_RANK: Record<string, number> = { secondary: 0, primary: 2 }
-const DEFAULT_EMPHASIS_RANK = 1
-/** Opacity applied to a `secondary` annotation so primary notes read as
- *  the dominant layer (Rahman et al.'s "Hierarchy" consideration). */
-const SECONDARY_EMPHASIS_OPACITY = 0.6
-
-/**
- * Apply annotation hierarchy — Rahman et al.'s "Hierarchy" consideration,
- * reusing the same `emphasis` token charts already accept (`"primary"` /
- * `"secondary"`). A `secondary` annotation dims and yields z-order; a
- * `primary` one paints at full weight and on top.
- *
- * Type-agnostic: it wraps whatever the per-type rule produced, so all
- * annotation types get hierarchy without each rule knowing about it.
- * Document order encodes z-order in SVG, so the return is stably sorted
- * `secondary → unspecified → primary`, with the original index breaking
- * ties to preserve authored order within a band.
- *
- * Zero-overhead and structure-preserving when no annotation declares an
- * emphasis: the original nodes are returned untouched (same keys, same
- * order), so existing charts render identically. The dim composes
- * multiplicatively with any lifecycle opacity already on the node.
- */
-export function applyAnnotationEmphasis(
-  pairs: ReadonlyArray<AnnotationRenderPair>
-): React.ReactNode[] {
-  const anyEmphasis = pairs.some(
-    (p) => p.annotation?.emphasis === "primary" || p.annotation?.emphasis === "secondary"
-  )
-  if (!anyEmphasis) return pairs.map((p) => p.node)
-
-  return pairs
-    .map((p, i) => ({
-      p,
-      i,
-      rank: EMPHASIS_RANK[p.annotation?.emphasis as string] ?? DEFAULT_EMPHASIS_RANK,
-    }))
-    .sort((a, b) => a.rank - b.rank || a.i - b.i)
-    .map(({ p, i }) => {
-      const emphasis = p.annotation?.emphasis
-      if (emphasis !== "primary" && emphasis !== "secondary") return p.node
-      return (
-        <g
-          key={`annotation-emphasis-${i}`}
-          className={`annotation-emphasis annotation-emphasis--${emphasis}`}
-          {...(emphasis === "secondary" ? { opacity: SECONDARY_EMPHASIS_OPACITY } : {})}
-        >
-          {p.node}
-        </g>
-      )
-    })
 }
 
 type AnnotationRule = (

--- a/src/components/charts/shared/auditAccessibility.test.ts
+++ b/src/components/charts/shared/auditAccessibility.test.ts
@@ -176,6 +176,43 @@ describe("auditAccessibility — annotation→target association (correspondence
   })
 })
 
+describe("auditAccessibility — annotation hierarchy", () => {
+  const base = { data: LINE_DATA, title: "x" }
+
+  it("warns when multiple annotations have no declared hierarchy", () => {
+    const r = auditAccessibility("LineChart", {
+      ...base,
+      annotations: [
+        { type: "callout", x: 1, y: 4200, label: "First" },
+        { type: "callout", x: 2, y: 5100, label: "Second" },
+      ],
+    })
+    const f = find(r, "understandable.annotation-hierarchy")
+    expect(f?.status).toBe("warn")
+    expect(f?.fix).toContain("emphasis")
+  })
+
+  it("passes when hierarchy is explicit or inferred from provenance confidence", () => {
+    const explicit = auditAccessibility("LineChart", {
+      ...base,
+      annotations: [
+        { type: "callout", x: 1, y: 4200, label: "Context", emphasis: "secondary" },
+        { type: "callout", x: 2, y: 5100, label: "Main", emphasis: "primary" },
+      ],
+    })
+    const inferred = auditAccessibility("LineChart", {
+      ...base,
+      annotations: [
+        { type: "callout", x: 1, y: 4200, label: "Context", provenance: { confidence: 0.6 } },
+        { type: "callout", x: 2, y: 5100, label: "Main", provenance: { confidence: 0.9 } },
+      ],
+    })
+
+    expect(status(explicit, "understandable.annotation-hierarchy")).toBe("pass")
+    expect(status(inferred, "understandable.annotation-hierarchy")).toBe("pass")
+  })
+})
+
 describe("auditAccessibility — operability", () => {
   it("keeps single-input-modality a pass for a recognized HOC (keyboard nav is built in)", () => {
     const withBrush = auditAccessibility("LineChart", { data: LINE_DATA, title: "x", brush: { dimension: "x" } })

--- a/src/components/charts/shared/auditAccessibility.ts
+++ b/src/components/charts/shared/auditAccessibility.ts
@@ -541,18 +541,32 @@ export function auditAccessibility(
       fix: "Confirm the second axis is necessary; consider two aligned charts (small multiples) or indexing both series to a common baseline. Label each axis and its series unambiguously.",
     })
   }
-  if (annotations.length > 1) {
-    const hierarchyCount = annotations.filter(annotationHasHierarchySignal).length
-    f.push({
-      id: "understandable.annotation-hierarchy",
-      principle: "understandable",
-      heuristic: "Information complexity is inappropriate",
-      critical: false,
-      ...(hierarchyCount > 0
-        ? { status: "pass" as A11yStatus, message: `${hierarchyCount} of ${annotations.length} annotation(s) declare hierarchy through emphasis or provenance confidence, so the renderer can resolve reading order and visual priority.` }
-        : { status: "warn" as A11yStatus, message: `${annotations.length} annotations are present with no emphasis or provenance confidence; readers may not know which note is primary.`, fix: "Mark the main annotation with emphasis=\"primary\", set supporting notes to emphasis=\"secondary\", or provide provenance.confidence so Semiotic can infer order." }),
-    })
-  }
+if (annotations.length > 1) {
+  const hierarchyCount = annotations.filter(annotationHasHierarchySignal).length
+  const missing = annotations.length - hierarchyCount
+  f.push({
+    id: "understandable.annotation-hierarchy",
+    principle: "understandable",
+    heuristic: "Information complexity is inappropriate",
+    critical: false,
+    ...(hierarchyCount === annotations.length
+      ? {
+          status: "pass" as A11yStatus,
+          message: `All ${annotations.length} annotation(s) declare hierarchy through emphasis or provenance confidence, so the renderer can resolve reading order and visual priority.`,
+        }
+      : hierarchyCount === 0
+        ? {
+            status: "warn" as A11yStatus,
+            message: `${annotations.length} annotations are present with no emphasis or provenance confidence; readers may not know which note is primary.`,
+            fix: "Mark the main annotation with emphasis=\"primary\", set supporting notes to emphasis=\"secondary\", or provide provenance.confidence so Semiotic can infer order.",
+          }
+        : {
+            status: "warn" as A11yStatus,
+            message: `${missing} of ${annotations.length} annotation(s) have no emphasis or provenance confidence; readers may not know which note is primary among the unordered notes.`,
+            fix: "Set emphasis on each annotation (primary/secondary), or provide provenance.confidence on all annotations so Semiotic can infer order.",
+          }),
+  })
+}
   {
     const hasUncertainty = props.forecast != null || props.anomaly != null || props.band != null || props.regression != null
     if (hasUncertainty) {

--- a/src/components/charts/shared/auditAccessibility.ts
+++ b/src/components/charts/shared/auditAccessibility.ts
@@ -159,6 +159,17 @@ function isNonEmptyString(v: unknown): v is string {
   return typeof v === "string" && v.trim().length > 0
 }
 
+function annotationConfidence(a: Datum): number | null {
+  const c = a?.provenance?.confidence
+  return typeof c === "number" && Number.isFinite(c) ? c : null
+}
+
+function annotationHasHierarchySignal(a: Datum): boolean {
+  return a?.emphasis === "primary" ||
+    a?.emphasis === "secondary" ||
+    annotationConfidence(a) != null
+}
+
 /** Rough Flesch–Kincaid grade level for a blob of description text. */
 function fleschKincaidGrade(text: string): number | null {
   const sentences = text.split(/[.!?]+/).map(s => s.trim()).filter(Boolean)
@@ -261,6 +272,9 @@ export function auditAccessibility(
   const hasSummary = isNonEmptyString(props.summary)
   const hasAnyText = hasTitle || hasDescription || hasSummary
   const interactive = isInteractive(props)
+  const annotations = Array.isArray(props.annotations)
+    ? (props.annotations as Datum[]).filter((a): a is Datum => !!a && typeof a === "object")
+    : []
 
   // Tracks built-in passes that only hold for recognized Semiotic HOCs.
   const builtIn: A11yStatus = known ? "pass" : "manual"
@@ -346,9 +360,7 @@ export function auditAccessibility(
   // connector disabled, ties to its target by color + position alone, which a
   // color-blind or non-visual reader can't follow.
   {
-    const anns = Array.isArray(props.annotations)
-      ? (props.annotations as Datum[]).filter((a): a is Datum => !!a && typeof a === "object")
-      : []
+    const anns = annotations
     if (anns.length > 0) {
       const cueless = anns.filter((a) => {
         if (typeof a.color !== "string") return false // not color-linked → not this problem
@@ -527,6 +539,18 @@ export function auditAccessibility(
       status: "warn",
       message: "Dual-axis chart: two y-scales are hard to read accurately and notoriously easy to misinterpret (the crossover point is arbitrary).",
       fix: "Confirm the second axis is necessary; consider two aligned charts (small multiples) or indexing both series to a common baseline. Label each axis and its series unambiguously.",
+    })
+  }
+  if (annotations.length > 1) {
+    const hierarchyCount = annotations.filter(annotationHasHierarchySignal).length
+    f.push({
+      id: "understandable.annotation-hierarchy",
+      principle: "understandable",
+      heuristic: "Information complexity is inappropriate",
+      critical: false,
+      ...(hierarchyCount > 0
+        ? { status: "pass" as A11yStatus, message: `${hierarchyCount} of ${annotations.length} annotation(s) declare hierarchy through emphasis or provenance confidence, so the renderer can resolve reading order and visual priority.` }
+        : { status: "warn" as A11yStatus, message: `${annotations.length} annotations are present with no emphasis or provenance confidence; readers may not know which note is primary.`, fix: "Mark the main annotation with emphasis=\"primary\", set supporting notes to emphasis=\"secondary\", or provide provenance.confidence so Semiotic can infer order." }),
     })
   }
   {

--- a/src/components/server/staticAnnotations.tsx
+++ b/src/components/server/staticAnnotations.tsx
@@ -8,6 +8,7 @@ import type { Datum } from "../charts/shared/datumTypes"
 
 import * as React from "react"
 import type { SemioticTheme } from "../store/ThemeStore"
+import { applyAnnotationEmphasis, type AnnotationRenderPair } from "../charts/shared/annotationHierarchy"
 
 /** Resolve annotation color: explicit > theme annotation > theme text */
 function resolveAnnotationColor(ann: Datum, theme: SemioticTheme): string {
@@ -102,13 +103,14 @@ export function renderStaticAnnotations(config: StaticAnnotationConfig): React.R
   const { annotations } = config
   if (!annotations || annotations.length === 0) return null
 
-  const elements: React.ReactNode[] = []
+  const pairs: AnnotationRenderPair[] = []
 
   for (let i = 0; i < annotations.length; i++) {
     const node = renderAnnotation(annotations[i], i, config)
-    if (node) elements.push(node)
+    if (node) pairs.push({ node, annotation: annotations[i] })
   }
 
+  const elements = applyAnnotationEmphasis(pairs)
   const pfx = config.idPrefix ? `${config.idPrefix}-` : ""
   return elements.length > 0 ? <g id={`${pfx}annotations`} className="semiotic-annotations">{elements}</g> : null
 }

--- a/src/components/stream/NetworkSVGOverlay.tsx
+++ b/src/components/stream/NetworkSVGOverlay.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react"
 import type { NetworkLabel } from "./networkTypes"
 import type { LegendGroup, GradientLegendConfig, LegendLayout } from "../types/legendTypes"
 import { renderLegendFromConfig } from "./legendRenderer"
+import { applyAnnotationEmphasis, type AnnotationRenderPair } from "../charts/shared/annotationHierarchy"
 
 type AnnotationAnchorNode = {
   type: string
@@ -85,6 +86,24 @@ export function NetworkSVGOverlay(props: NetworkSVGOverlayProps) {
     annotationFrame: _annotationFrame
   } = props
 
+  const renderedSvgAnnotations = annotations
+    ? applyAnnotationEmphasis(
+        annotations.reduce<AnnotationRenderPair[]>((acc, annotation, i) => {
+          if (annotation.type === "widget" || !svgAnnotationRules) return acc
+          const element = svgAnnotationRules(annotation, i, {
+            width, height, sceneNodes
+          })
+          if (element) {
+            acc.push({
+              node: <React.Fragment key={`annotation-${i}`}>{element}</React.Fragment>,
+              annotation,
+            })
+          }
+          return acc
+        }, [])
+      )
+    : null
+
   return (
     <>
     <svg
@@ -122,18 +141,7 @@ export function NetworkSVGOverlay(props: NetworkSVGOverlayProps) {
         ))}
 
         {/* Non-widget annotations (rendered in SVG) */}
-        {annotations &&
-          annotations.filter(a => a.type !== "widget").map((annotation, i) => {
-            if (svgAnnotationRules) {
-              const element = svgAnnotationRules(annotation, i, {
-                width, height, sceneNodes
-              })
-              if (element) return (
-                <React.Fragment key={`annotation-${i}`}>{element}</React.Fragment>
-              )
-            }
-            return null
-          })}
+        {renderedSvgAnnotations}
 
         {/* Foreground graphics */}
         {foregroundGraphics}


### PR DESCRIPTION
Introduce a dedicated annotation hierarchy module and inference for emphasis. Added src/components/charts/shared/annotationHierarchy.tsx which implements applyAnnotationEmphasis: honors explicit emphasis (primary/secondary), infers reading order from provenance.confidence (confidence desc, then array order), wraps nodes with classes/attributes (annotation-emphasis--primary/secondary/inferred, data-annotation-reading-order), applies secondary opacity (0.6) and font-size (0.88em), and a subtle inferred opacity gradient. Refactor annotationRules to import/re-export the new helpers, update server and NetworkSVGOverlay to produce AnnotationRenderPair lists and run them through applyAnnotationEmphasis, and update docs to describe inferred behavior. Audit accessibility now warns when multiple annotations lack hierarchy and treats provenance.confidence as a valid signal; tests updated/added to cover reading-order, inferred emphasis, font sizing and rendering order.

This pull request introduces a more robust and flexible annotation hierarchy system for chart annotations, enhancing both visual clarity and accessibility. The main improvement is the ability to infer annotation importance (hierarchy) not only from an explicit `emphasis` field (`primary`/`secondary`), but also from a `provenance.confidence` value. This allows the renderer to automatically establish a reading order and visual priority among annotations, even when explicit emphasis is not provided. The accessibility audit is updated to warn when multiple annotations lack hierarchy signals, and the new logic is thoroughly tested. The code for annotation emphasis is refactored into its own module and integrated across relevant components.

**Annotation hierarchy and emphasis improvements:**

* Introduced a new `applyAnnotationEmphasis` implementation in `annotationHierarchy.tsx` that supports both explicit `emphasis` and inferred hierarchy from `provenance.confidence`, applying visual cues (opacity gradient, order, font size) accordingly.
* Updated documentation and user-facing descriptions to explain the new inference mechanism for annotation hierarchy.

**Accessibility enhancements:**

* Improved the accessibility audit (`auditAccessibility`) to check for annotation hierarchy: it now passes if any annotation has explicit emphasis or confidence, and warns if multiple annotations lack hierarchy signals. [[1]](diffhunk://#diff-485b39ad970b7c071eb0decc7d528d233327e5f43bea560f8dc6c8ba754aa413R544-R555) [[2]](diffhunk://#diff-485b39ad970b7c071eb0decc7d528d233327e5f43bea560f8dc6c8ba754aa413R162-R172) [[3]](diffhunk://#diff-485b39ad970b7c071eb0decc7d528d233327e5f43bea560f8dc6c8ba754aa413R275-R277) [[4]](diffhunk://#diff-485b39ad970b7c071eb0decc7d528d233327e5f43bea560f8dc6c8ba754aa413L349-R363) [[5]](diffhunk://#diff-e93559c352d2589efcf21ac4054a0e7439fc70a4fdd63ea3c780701307dd8ba8R179-R215)

**Testing and validation:**

* Expanded test coverage to verify inferred reading order, opacity gradient, and correct override behavior between explicit and inferred emphasis. [[1]](diffhunk://#diff-380f8b5652d56d4f49d70b41ddc1aeacb61cab78ba4c99cd6ca70513882e9810R10-R13) [[2]](diffhunk://#diff-380f8b5652d56d4f49d70b41ddc1aeacb61cab78ba4c99cd6ca70513882e9810L26-R34) [[3]](diffhunk://#diff-380f8b5652d56d4f49d70b41ddc1aeacb61cab78ba4c99cd6ca70513882e9810R63) [[4]](diffhunk://#diff-380f8b5652d56d4f49d70b41ddc1aeacb61cab78ba4c99cd6ca70513882e9810R77-R109) [[5]](diffhunk://#diff-380f8b5652d56d4f49d70b41ddc1aeacb61cab78ba4c99cd6ca70513882e9810R161-R170)

**Codebase refactoring and integration:**

* Moved annotation emphasis logic from `annotationRules.tsx` to a new `annotationHierarchy.tsx` module, and updated all relevant imports and usages (`annotationRules.tsx`, `staticAnnotations.tsx`, `NetworkSVGOverlay.tsx`) to use the new implementation. [[1]](diffhunk://#diff-56427b28607e78985a658b22cf0c605da127ecbe5dabf5c671da520a65eaf930R12-R14) [[2]](diffhunk://#diff-56427b28607e78985a658b22cf0c605da127ecbe5dabf5c671da520a65eaf930L25-L87) [[3]](diffhunk://#diff-32c68eec5cea8f105c9392d98ab037f434c913d82eae08d5ce681f93be37aac2R11) [[4]](diffhunk://#diff-32c68eec5cea8f105c9392d98ab037f434c913d82eae08d5ce681f93be37aac2L105-R113) [[5]](diffhunk://#diff-fc20a2248a3cf72c9f6db07f64974067afcdc7454e8e06c7c1796c05580d4d5cR8) [[6]](diffhunk://#diff-fc20a2248a3cf72c9f6db07f64974067afcdc7454e8e06c7c1796c05580d4d5cR89-R106)

These changes make annotation hierarchy more intuitive and accessible, while improving code organization and maintainability.