### PR TITLE
Serve OpenAI Apps verification token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.3] - 2026-06-13
+
+### Added
+
+- **OpenAI Apps domain verification for hosted MCP.** HTTP mode now serves the raw
+  `OPENAI_APPS_CHALLENGE_TOKEN` from `/.well-known/openai-apps-challenge`, allowing
+  ChatGPT Apps domain verification against Cloud Run and other HTTPS-hosted MCP origins without
+  committing the token.
+- **Cloud Run verification playbook.** `deploy/cloud-run` documents the Challenge Base URL shape,
+  token environment variable, and `curl` check for ChatGPT Apps verification, and the wrapper now
+  tracks the `semiotic@^3.7.3` release line.
+
+### Tests
+
+- Added MCP HTTP regression coverage for the OpenAI Apps challenge route while confirming the
+  unauthenticated OAuth protected-resource probe continues to return 404.
+
 ## [3.7.2] - 2026-06-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,17 +12,16 @@ Simple charts in 5 lines. Network graphs, streaming data, and coordinated
 dashboards when you need them. Structured schemas and an MCP server so
 AI coding assistants generate correct chart code on the first try.
 
-## What's New in 3.7.2
+## What's New in 3.7.3
 
-3.7.2 is a deployment and docs-polish patch release:
+3.7.3 is a hosted ChatGPT Apps patch release:
 
-- `semiotic-mcp --http` now runs in stateless Streamable HTTP mode, with JSON responses,
-  health endpoints, optional `MCP_ALLOWED_HOSTS` host-header protection, and serverless-friendly
-  request teardown.
-- `deploy/cloud-run` contains a minimal Google Cloud Run wrapper for publishing the MCP server as a
-  public read-only connector for ChatGPT, Claude, and other MCP clients.
-- The Accessibility docs' visible navigation tree and bidirectional BarChart examples now honor
-  dark mode, and the contested-annotations blog demo renders its editorial-status callouts reliably.
+- `semiotic-mcp --http` can now serve the OpenAI Apps domain verification challenge from
+  `/.well-known/openai-apps-challenge` when `OPENAI_APPS_CHALLENGE_TOKEN` is configured.
+- The Cloud Run wrapper docs now include the exact Challenge Base URL, token environment variable,
+  and `curl` check for ChatGPT Apps verification.
+- MCP HTTP tests now cover the Apps challenge route while preserving the unauthenticated OAuth
+  discovery 404 behavior.
 
 ```jsx
 import { LineChart } from "semiotic/xy"
@@ -423,13 +422,15 @@ Add to your MCP client config (e.g. `claude_desktop_config.json` for Claude Desk
 }
 ```
 
-No API keys or authentication required. The server runs locally via stdio. HTTP mode is also available for inspectors, web clients, and ChatGPT Apps SDK experiments: `npx semiotic-mcp --http --port 3001`. In 3.7.2 HTTP mode is stateless: each request gets a fresh read-only MCP server + transport, so it can autoscale on serverless hosts without sticky sessions.
+No API keys or authentication required. The server runs locally via stdio. HTTP mode is also available for inspectors, web clients, and ChatGPT Apps SDK experiments: `npx semiotic-mcp --http --port 3001`. Since 3.7.2, HTTP mode is stateless: each request gets a fresh read-only MCP server + transport, so it can autoscale on serverless hosts without sticky sessions.
 
 For ChatGPT developer mode, expose the HTTP endpoint over HTTPS with a tunnel and create a connector that points at `https://<your-tunnel>/mcp`. The experimental Apps SDK surface is `renderInteractiveChart`, which returns a `text/html;profile=mcp-app` widget template plus a hidden SVG payload rendered by Semiotic on the MCP server.
 
 For a hosted deployment, see `deploy/cloud-run`. The wrapper runs the published `semiotic-mcp`
 binary, exposes `/mcp` plus health endpoints, and supports `MCP_ALLOWED_HOSTS` for production
-host-header allowlisting.
+host-header allowlisting. For ChatGPT Apps domain verification, set
+`OPENAI_APPS_CHALLENGE_TOKEN` so HTTP mode serves the raw token from
+`/.well-known/openai-apps-challenge`.
 
 ### Tools
 

--- a/ai/dist/mcp-server.js
+++ b/ai/dist/mcp-server.js
@@ -33850,6 +33850,7 @@ var port = Number.isFinite(parsedPort) ? parsedPort : 3001;
 async function main() {
   if (httpMode) {
     const allowedHosts = (process.env.MCP_ALLOWED_HOSTS || "").split(",").map((h) => h.trim().toLowerCase()).filter(Boolean);
+    const openaiAppsChallengeToken = (process.env.OPENAI_APPS_CHALLENGE_TOKEN || "").trim();
     const healthBody = () => JSON.stringify({
       status: "ok",
       name: "semiotic-mcp",
@@ -33889,6 +33890,14 @@ async function main() {
       if (req.method === "GET" && (pathname === "/healthz" || pathname === "/health")) {
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(healthBody());
+        return;
+      }
+      if (req.method === "GET" && pathname === "/.well-known/openai-apps-challenge" && openaiAppsChallengeToken) {
+        res.writeHead(200, {
+          "Content-Type": "text/plain; charset=utf-8",
+          "Cache-Control": "no-store"
+        });
+        res.end(openaiAppsChallengeToken);
         return;
       }
       if (pathname !== "/" && pathname !== "/mcp") {

--- a/ai/mcp-server.ts
+++ b/ai/mcp-server.ts
@@ -1811,6 +1811,7 @@ async function main() {
       .split(",")
       .map((h) => h.trim().toLowerCase())
       .filter(Boolean)
+    const openaiAppsChallengeToken = (process.env.OPENAI_APPS_CHALLENGE_TOKEN || "").trim()
 
     const healthBody = () =>
       JSON.stringify({
@@ -1865,6 +1866,22 @@ async function main() {
       if (req.method === "GET" && (pathname === "/healthz" || pathname === "/health")) {
         res.writeHead(200, { "Content-Type": "application/json" })
         res.end(healthBody())
+        return
+      }
+
+      // ChatGPT Apps domain verification expects the raw challenge token at
+      // the origin-root well-known URL. Keep it env-driven so deployments can
+      // rotate or remove the token without committing it.
+      if (
+        req.method === "GET" &&
+        pathname === "/.well-known/openai-apps-challenge" &&
+        openaiAppsChallengeToken
+      ) {
+        res.writeHead(200, {
+          "Content-Type": "text/plain; charset=utf-8",
+          "Cache-Control": "no-store",
+        })
+        res.end(openaiAppsChallengeToken)
         return
       }
 

--- a/ai/schema.json
+++ b/ai/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "semiotic",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "description": "React data visualization library for charts, networks, and beyond",
   "tools": [
     {

--- a/deploy/cloud-run/README.md
+++ b/deploy/cloud-run/README.md
@@ -52,7 +52,8 @@ add `--max-instances N` as a cost ceiling, or `--min-instances 1` to keep it alw
 | `/` , `/mcp` | POST | MCP Streamable HTTP (JSON-RPC). `/mcp` is the canonical URL to give clients. Returns a JSON response. |
 | `/` , `/mcp` | GET | 200 JSON info blob (for humans/browsers — stateless mode has no session SSE stream). |
 | `/healthz`, `/health` | GET | 200 health JSON (for uptime checks). |
-| anything else (`/favicon.ico`, `/.well-known/*`) | any | 404. The 404 on `/.well-known/oauth-protected-resource` is the correct signal that this is an unauthenticated server. |
+| `/.well-known/openai-apps-challenge` | GET | 200 plain-text OpenAI Apps domain verification token when `OPENAI_APPS_CHALLENGE_TOKEN` is set. |
+| anything else (`/favicon.ico`, other `/.well-known/*` probes) | any | 404. The 404 on `/.well-known/oauth-protected-resource` is the correct signal that this is an unauthenticated server. |
 
 ## Environment variables
 
@@ -60,6 +61,29 @@ add `--max-instances N` as a cost ceiling, or `--min-instances 1` to keep it alw
 |---|---|---|
 | `PORT` | `8080` (Cloud Run sets this) | Listen port. |
 | `MCP_ALLOWED_HOSTS` | unset (disabled) | Comma-separated `Host` allowlist. Unset → no host check (fine for local dev). Set in production. |
+| `OPENAI_APPS_CHALLENGE_TOKEN` | unset | Raw token shown by ChatGPT Apps domain verification. When set, the server serves it from `/.well-known/openai-apps-challenge`. |
+
+## Verify a ChatGPT Apps domain
+
+In the OpenAI domain verification dialog, use the Cloud Run origin as the Challenge Base
+URL, not the MCP path:
+
+```
+https://semiotic-mcp-481507046413.us-central1.run.app
+```
+
+Then put the dialog's token into Cloud Run without committing it:
+
+```sh
+gcloud run services update semiotic-mcp --region us-central1 \
+  --update-env-vars "OPENAI_APPS_CHALLENGE_TOKEN=PASTE_TOKEN_HERE"
+```
+
+Check that Cloud Run is serving the token before clicking Verify:
+
+```sh
+curl https://semiotic-mcp-481507046413.us-central1.run.app/.well-known/openai-apps-challenge
+```
 
 ## Connect a client
 
@@ -73,4 +97,4 @@ ChatGPT: add it as a connector / app using the `/mcp` URL.
 ## Updating
 
 When a new `semiotic` is published, re-run the same `gcloud run deploy` command — the
-build does a fresh `npm install` and picks up the latest `^3.7.2`-compatible release.
+build does a fresh `npm install` and picks up the latest `^3.7.3`-compatible release.

--- a/deploy/cloud-run/README.md
+++ b/deploy/cloud-run/README.md
@@ -82,7 +82,7 @@ gcloud run services update semiotic-mcp --region us-central1 \
 Check that Cloud Run is serving the token before clicking Verify:
 
 ```sh
-curl https://semiotic-mcp-481507046413.us-central1.run.app/.well-known/openai-apps-challenge
+curl https://YOUR-SERVICE-URL.run.app/.well-known/openai-apps-challenge
 ```
 
 ## Connect a client

--- a/deploy/cloud-run/package.json
+++ b/deploy/cloud-run/package.json
@@ -12,6 +12,6 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "semiotic": "^3.7.2"
+    "semiotic": "^3.7.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "semiotic",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "semiotic",
-      "version": "3.7.2",
+      "version": "3.7.3",
       "license": "Apache-2.0",
       "dependencies": {
         "d3-array": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semiotic",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "mcpName": "io.github.nteract/semiotic",
   "description": "React data visualization library with built-in MCP server for AI-assisted chart generation",
   "main": "dist/semiotic.min.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/nteract/semiotic",
     "source": "github"
   },
-  "version": "3.7.2",
+  "version": "3.7.3",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "semiotic",
-      "version": "3.7.2",
+      "version": "3.7.3",
       "transport": {
         "type": "stdio"
       }

--- a/src/__tests__/scenarios/mcp-protocol.test.ts
+++ b/src/__tests__/scenarios/mcp-protocol.test.ts
@@ -1077,6 +1077,27 @@ describe.skipIf(!SERVER_DEPS_READY)("MCP HTTP transport smoke", () => {
     expect(probe.body).toEqual({ error: "Not found" })
   })
 
+  it("serves the OpenAI Apps domain challenge token when configured", async () => {
+    proc?.kill("SIGTERM")
+    if (proc) await waitForProcessExit(proc)
+    proc = undefined
+
+    const token = "test-openai-apps-domain-token"
+    const server = await spawnReadyHTTPServer({ OPENAI_APPS_CHALLENGE_TOKEN: ` ${token} ` })
+    proc = server.proc
+    port = server.port
+
+    const challenge = await requestHTTP(port, "/.well-known/openai-apps-challenge")
+    expect(challenge.status).toBe(200)
+    expect(challenge.headers["content-type"]).toContain("text/plain")
+    expect(challenge.headers["cache-control"]).toBe("no-store")
+    expect(challenge.text).toBe(token)
+
+    const oauthProbe = await requestHTTP(port, "/.well-known/oauth-protected-resource")
+    expect(oauthProbe.status).toBe(404)
+    expect(oauthProbe.body).toEqual({ error: "Not found" })
+  })
+
   it("enforces MCP_ALLOWED_HOSTS against raw and normalized Host headers", async () => {
     proc?.kill("SIGTERM")
     if (proc) await waitForProcessExit(proc)


### PR DESCRIPTION
Add support for ChatGPT Apps domain verification by serving the raw OPENAI_APPS_CHALLENGE_TOKEN at /.well-known/openai-apps-challenge when configured. Update ai/mcp-server (and compiled dist) to return the token as plain text with no-cache headers, add an HTTP regression test for the route while preserving the unauthenticated OAuth probe 404, and document the Cloud Run verification playbook and environment variable in deploy/cloud-run/README. Bump version metadata to 3.7.3 across package.json, schema, server.json and update the Cloud Run wrapper dependency to semiotic ^3.7.3. README and CHANGELOG updated to describe the hosted Apps verification behavior.
