### PR TITLE
Release 3.7.4: version bump & changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Lineage DAG recipe helpers.** `semiotic/recipes` now exports lineage DAG helpers for
   data-flow and KStreams-style network layouts, with tests covering stable topology layout.
-- **KStreams data-lineage docs demo.** The docs add a KStreams recipe page and example data,
+- **KStreams docs demo.** The docs add a KStreams recipe page and example data,
   plus expanded custom network chart guidance for selection-aware layouts.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.4] - 2026-06-15
+
+### Added
+
+- **Lineage DAG recipe helpers.** `semiotic/recipes` now exports lineage DAG helpers for
+  data-flow and KStreams-style network layouts, with tests covering stable topology layout.
+- **KStreams data-lineage docs demo.** The docs add a KStreams recipe page and example data,
+  plus expanded custom network chart guidance for selection-aware layouts.
+
+### Fixed
+
+- **Network custom layout selection metadata.** Network custom layouts now preserve selection
+  metadata through pipeline layout and render paths, with regression coverage for selection
+  actions and `NetworkCustomChart` behavior.
+
+### Changed
+
+- Refreshed developer/dependency tooling, including Prettier, TypeScript ESLint, Rollup, and Sharp.
+
 ## [3.7.3] - 2026-06-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,16 +12,15 @@ Simple charts in 5 lines. Network graphs, streaming data, and coordinated
 dashboards when you need them. Structured schemas and an MCP server so
 AI coding assistants generate correct chart code on the first try.
 
-## What's New in 3.7.3
+## What's New in 3.7.4
 
-3.7.3 is a hosted ChatGPT Apps patch release:
+3.7.4 is a network-chart and maintenance patch release:
 
-- `semiotic-mcp --http` can now serve the OpenAI Apps domain verification challenge from
-  `/.well-known/openai-apps-challenge` when `OPENAI_APPS_CHALLENGE_TOKEN` is configured.
-- The Cloud Run wrapper docs now include the exact Challenge Base URL, token environment variable,
-  and `curl` check for ChatGPT Apps verification.
-- MCP HTTP tests now cover the Apps challenge route while preserving the unauthenticated OAuth
-  discovery 404 behavior.
+- `semiotic/recipes` adds lineage DAG helpers for laying out data-flow and KStreams-style network
+  diagrams.
+- Network custom layouts now preserve selection metadata through streaming layout and render paths.
+- Docs add the KStreams data-lineage recipe and expand custom network chart guidance, alongside
+  dependency updates for Prettier, TypeScript ESLint, Rollup, and Sharp.
 
 ```jsx
 import { LineChart } from "semiotic/xy"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ AI coding assistants generate correct chart code on the first try.
 - `semiotic/recipes` adds lineage DAG helpers for laying out data-flow and KStreams-style network
   diagrams.
 - Network custom layouts now preserve selection metadata through streaming layout and render paths.
-- Docs add the KStreams data-lineage recipe and expand custom network chart guidance, alongside
+- Docs add the KStreams DAG recipe and expand custom network chart guidance, alongside
   dependency updates for Prettier, TypeScript ESLint, Rollup, and Sharp.
 
 ```jsx

--- a/ai/schema.json
+++ b/ai/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "semiotic",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "description": "React data visualization library for charts, networks, and beyond",
   "tools": [
     {

--- a/deploy/cloud-run/README.md
+++ b/deploy/cloud-run/README.md
@@ -113,4 +113,4 @@ ChatGPT: add it as a connector / app using the `/mcp` URL.
 ## Updating
 
 When a new `semiotic` is published, re-run the same `gcloud run deploy` command — the
-build does a fresh `npm install` and picks up the latest `^3.7.3`-compatible release.
+build does a fresh `npm install` and picks up the latest `^3.7.4`-compatible release.

--- a/deploy/cloud-run/package.json
+++ b/deploy/cloud-run/package.json
@@ -12,6 +12,6 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "semiotic": "^3.7.3"
+    "semiotic": "^3.7.4"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "semiotic",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "semiotic",
-      "version": "3.7.3",
+      "version": "3.7.4",
       "license": "Apache-2.0",
       "dependencies": {
         "d3-array": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semiotic",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "mcpName": "io.github.nteract/semiotic",
   "description": "React data visualization library with built-in MCP server for AI-assisted chart generation",
   "main": "dist/semiotic.min.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/nteract/semiotic",
     "source": "github"
   },
-  "version": "3.7.3",
+  "version": "3.7.4",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "semiotic",
-      "version": "3.7.3",
+      "version": "3.7.4",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Bump project version to 3.7.4 across package.json, ai/schema.json, server.json, and the Cloud Run wrapper; update README and deploy docs to reference the new release and bump the Cloud Run demo dependency to ^3.7.4. Add a CHANGELOG entry describing the 3.7.4 changes: lineage DAG recipe helpers, KStreams docs demo, a fix to preserve network layout selection metadata, and various tooling/dependency refreshes.
