### PR TITLE
Respect animate prop for topology diff

### DIFF
--- a/src/components/stream/StreamNetworkFrame.tsx
+++ b/src/components/stream/StreamNetworkFrame.tsx
@@ -1296,8 +1296,13 @@ const StreamNetworkFrame = forwardRef<
       store.applyThresholds(now)
     }
 
-    // Topology diff highlighting (always active for streaming)
-    store.applyTopologyDiff(now)
+    // Topology diff highlighting (newly-added nodes glow briefly). Active for
+    // streaming, but suppressed when the consumer opts out of animation with
+    // `animate={false}` — a bounded/static chart (e.g. a minimap) shouldn't
+    // pulse every node on its first render.
+    if (animate !== false) {
+      store.applyTopologyDiff(now)
+    }
 
     // Staleness dimming
     const staleThreshold = staleness?.threshold ?? 5000
@@ -1406,7 +1411,7 @@ const StreamNetworkFrame = forwardRef<
     // Schedule next frame for continuous rendering (particles/transitions/pulses/thresholds/diffs/animation),
     // OR to retry a throttled setAnnotationFrame so a one-shot dirty event
     // that landed inside the throttle gate still reconciles the SVG layer.
-    if (isContinuous || isTransitioning || store.transition != null || animationTicked || store.hasActivePulses || store.hasActiveThresholds || store.hasActiveTopologyDiff || pendingAnnotationFrameRef.current) {
+    if (isContinuous || isTransitioning || store.transition != null || animationTicked || store.hasActivePulses || store.hasActiveThresholds || (animate !== false && store.hasActiveTopologyDiff) || pendingAnnotationFrameRef.current) {
       rafRef.current = requestAnimationFrame(() => renderFnRef.current())
     }
   }


### PR DESCRIPTION
Skip topology diff highlighting when the component is rendered with animate={false}. This prevents newly-added nodes from briefly pulsing on bounded/static charts (e.g. minimaps). The change gates both the store.applyTopologyDiff call and the requestAnimationFrame scheduling on animate !== false to avoid unnecessary pulses and frames. Adds an explanatory comment for the behavior.
