### PR TITLE
Add experimental GoFish IR adapter and docs

### DIFF
--- a/docs/src/App.js
+++ b/docs/src/App.js
@@ -104,6 +104,7 @@ import StreamingSystemModelPage from "./pages/features/StreamingSystemModelPage"
 import PerformancePage from "./pages/features/PerformancePage"
 import PushApiPage from "./pages/features/PushApiPage"
 import CustomChartsPage from "./pages/features/CustomChartsPage"
+import GoFishLayoutsPage from "./pages/features/GoFishLayoutsPage"
 import CapabilitiesPage from "./pages/features/CapabilitiesPage"
 import InterrogationPage from "./pages/features/InterrogationPage"
 import SuggestionsPage from "./pages/features/SuggestionsPage"
@@ -434,6 +435,7 @@ export default function DocsApp() {
               <Route path="performance" element={<PerformancePage />} />
               <Route path="push-api" element={<PushApiPage />} />
               <Route path="custom-charts" element={<CustomChartsPage />} />
+              <Route path="gofish-layouts" element={<GoFishLayoutsPage />} />
             </Route>
 
             {/* Accessibility — first-class category (before Intelligence).

--- a/docs/src/blog/entries-meta.js
+++ b/docs/src/blog/entries-meta.js
@@ -20,6 +20,18 @@
 // inspection still work; the build scripts filter at consumption time.
 export const allBlogEntriesMeta = [
   {
+    slug: "making-better-custom-charts",
+    title: "Making Better Custom Charts",
+    subtitle:
+      "The custom-chart escape hatch grew up: a scene-node/overlay contract, a real Kafka Streams lineage view that lets your pipeline own layout, and a GoFish IR interpreter that executes a foreign grammar instead of recognizing it.",
+    author: "Elijah Meeks",
+    date: "2026-06-17",
+    tags: ["case-study", "network", "ai"],
+    excerpt:
+      "Every charting library hits the wall where the catalog runs out. This is about what's on the other side of that wall in Semiotic — a custom-layout surface principled enough to host a domain pipeline's lineage DAG and to interpret another library's serialized grammar, escape hatches and all.",
+    draft: true,
+  },
+  {
     slug: "release-3-7-2",
     title: "Semiotic 3.7.2",
     subtitle:

--- a/docs/src/blog/entries.js
+++ b/docs/src/blog/entries.js
@@ -58,6 +58,7 @@ import ReleaseGatesForFastPrs from "./entries/release-gates-for-fast-prs.js"
 import Release360 from "./entries/release-3-6-0.js"
 import TalkTrackIntelligence from "./entries/talk-track-intelligence.js"
 import FromSpecToRuntime from "./entries/from-spec-to-runtime.js"
+import MakingBetterCustomCharts from "./entries/making-better-custom-charts.js"
 import ScaleAwareSuggestions from "./entries/scale-aware-suggestions.js"
 import AuditingWhatYouCantSee from "./entries/auditing-what-you-cant-see.js"
 import WhatAScreenReaderShouldHear from "./entries/what-a-screen-reader-should-hear.js"
@@ -74,6 +75,7 @@ import AnnotationsThatGetContestedAndHeard from "./entries/annotations-that-get-
  * drafts (index listing, RSS, SEO prerender) read `blogEntries` below.
  */
 export const allBlogEntries = [
+  MakingBetterCustomCharts,
   Release372,
   Release371,
   Release370,

--- a/docs/src/blog/entries/making-better-custom-charts.js
+++ b/docs/src/blog/entries/making-better-custom-charts.js
@@ -2,7 +2,7 @@
 import React, { useMemo } from "react"
 import { Link } from "react-router-dom"
 import { XYCustomChart } from "semiotic/xy"
-import { unstable_fromGofishIR, unstable_gofishFlowerIR } from "semiotic/experimental"
+import { unstable_fromGofishIR, unstable_gofishFlowerIR } from "../../../../src/components/semiotic-experimental"
 
 // Entry metadata first so the sync check reads the canonical strings
 // before any UI-string literals.

--- a/docs/src/blog/entries/making-better-custom-charts.js
+++ b/docs/src/blog/entries/making-better-custom-charts.js
@@ -1,0 +1,333 @@
+/* eslint-disable react/no-unescaped-entities */
+import React, { useMemo } from "react"
+import { Link } from "react-router-dom"
+import { XYCustomChart } from "semiotic/xy"
+import { unstable_fromGofishIR, unstable_gofishFlowerIR } from "semiotic/experimental"
+
+// Entry metadata first so the sync check reads the canonical strings
+// before any UI-string literals.
+const META = {
+  slug: "making-better-custom-charts",
+  title: "Making Better Custom Charts",
+  subtitle:
+    "The custom-chart escape hatch grew up: a scene-node/overlay contract, a real Kafka Streams lineage view that lets your pipeline own layout, and a GoFish IR interpreter that executes a foreign grammar instead of recognizing it.",
+  author: "Elijah Meeks",
+  date: "2026-06-17",
+  tags: ["case-study", "network", "ai"],
+  excerpt:
+    "Every charting library hits the wall where the catalog runs out. This is about what's on the other side of that wall in Semiotic — a custom-layout surface principled enough to host a domain pipeline's lineage DAG and to interpret another library's serialized grammar, escape hatches and all.",
+}
+
+const card = {
+  background: "var(--surface-1)",
+  borderRadius: 10,
+  padding: 18,
+  border: "1px solid var(--surface-3)",
+  margin: "20px 0",
+}
+
+const chartFrame = {
+  background: "#ffffff",
+  borderRadius: 10,
+  padding: 12,
+  border: "1px solid var(--surface-3)",
+  margin: "20px 0",
+}
+
+const inlineCode = {
+  fontFamily: "var(--semiotic-font-family-mono, ui-monospace, monospace)",
+  fontSize: "0.9em",
+}
+
+const pre = {
+  background: "var(--surface-2)",
+  padding: 12,
+  borderRadius: 6,
+  fontSize: 13,
+  overflowX: "auto",
+}
+
+const tag = (color) => ({
+  display: "inline-block",
+  background: color,
+  color: "white",
+  fontSize: 11,
+  fontWeight: 600,
+  padding: "2px 8px",
+  borderRadius: 999,
+  marginRight: 6,
+})
+
+// ─── Live demo: a flower chart INTERPRETED from a GoFish IR document ───────
+//
+// No flower-specific recipe runs here. `unstable_fromGofishIR` walks the spec and
+// executes its operators; XYCustomChart hosts the result.
+const FLOWER_IR_SNIPPET = `{
+  "ir": "gofish-frontend",
+  "root": {
+    "type": "chart",
+    "data": { "type": "inline", "rows": [ /* seafood catch by lake */ ] },
+    "operators": [{ "type": "scatter", "by": "lake", "x": { "type": "field", "name": "x" } }],
+    "mark": { "type": "layer", "__combinator": true, "children": [
+      { "type": "rect", "w": 5, "h": { "type": "field", "name": "count" }, "fill": "#2f8f46" },
+      { "type": "layer", "__combinator": true, "options": { "coord": { "type": "polar" } },
+        "children": [
+          { "type": "stack", "__combinator": true, "options": { "dir": "x", "by": "species" },
+            "children": [{ "type": "petal", "h": { "type": "field", "name": "count" },
+                          "fill": { "type": "field", "name": "species" } }] }
+        ] }
+    ] }
+  }
+}`
+
+function FlowerFromIR() {
+  const cfg = useMemo(() => unstable_fromGofishIR(unstable_gofishFlowerIR), [])
+  return (
+    <div style={chartFrame}>
+      <XYCustomChart
+        data={cfg.data}
+        layout={cfg.layout}
+        width={680}
+        height={360}
+        responsiveWidth
+        margin={{ top: 24, right: 24, bottom: 24, left: 24 }}
+        frameProps={{ background: "#ffffff" }}
+      />
+    </div>
+  )
+}
+
+// ─── Body ─────────────────────────────────────────────────────────────────
+
+function Body() {
+  return (
+    <article style={{ lineHeight: 1.65 }}>
+      <p>
+        <span style={tag("#6a52d9")}>draft</span>
+      </p>
+
+      <p>
+        Every charting library has a catalog, and every catalog has an edge. Past the edge is the
+        chart your data actually needs and the library doesn't have: a Kafka Streams topology, a
+        memory diagram, a bubble-tea cup. Semiotic's answer to the edge is the{" "}
+        <Link to="/features/custom-charts">Custom Charts</Link> surface — a layout function that emits
+        scene primitives and gets the frame's runtime for free. This post is about three rounds of
+        making that surface good enough to trust: a clear contract for what a custom layout owns, a
+        real-world lineage view that hands layout back to the domain, and an interpreter that runs an
+        entirely different library's serialized grammar.
+      </p>
+
+      <h2>Why a custom-chart surface is the interesting part</h2>
+
+      <p>
+        Most "extensibility" in charting libraries is a theming API and a slot for a tooltip. The hard
+        version of the problem is: let someone draw a shape you've never heard of, and still give them
+        hit-testing, transitions, decay, staleness, SSR, and accessibility — the things that take
+        months to build and that nobody wants to reimplement per chart. If the escape hatch makes you
+        give those up, it isn't an escape hatch; it's a second, worse library bolted to the side of
+        the first.
+      </p>
+
+      <p>
+        Semiotic's bet is a <strong>scene-node / overlay split</strong>. A custom layout returns two
+        things: <em>scene nodes</em> (rects, points, areas) that flow through the same canvas pipeline
+        the built-in charts use — so they get hit-testing, transitions, decay, and SSR evidence — and{" "}
+        <em>overlays</em> (arbitrary SVG) for the chrome that doesn't need to be a first-class datum:
+        labels, connectors, decorative glyph detail. The rule that emerged is worth stating plainly:{" "}
+        <strong>never let chrome replace data.</strong> A pretty glyph is fine, but the thing the user
+        hovers, the thing a screen reader announces, the thing SSR can prove rendered — that stays a
+        scene node.
+      </p>
+
+      <h2>Letting the domain own layout: Kafka Streams lineage</h2>
+
+      <p>
+        The first real test was a Kafka Streams topology viewer (
+        <Link to="/recipes/kstreams">/recipes/kstreams</Link>). A streaming topology is a layered DAG
+        with source/sink topics, processors, state stores, repartition bridges, and the occasional
+        reconciliation cycle. The layout for that is a <em>domain</em> problem — your pipeline already
+        knows the layers and rows — so the recipe doesn't compute layout at all. It reads
+        pre-computed logical coordinates (<code style={inlineCode}>x</code> = layer,{" "}
+        <code style={inlineCode}>y</code> = row) and maps them into the plot. Semiotic positions
+        nothing; it <em>renders</em> what the pipeline already decided.
+      </p>
+
+      <p>
+        That inversion is the point. <code style={inlineCode}>lineageDagLayout</code> stays
+        domain-agnostic — the app supplies the glyph vocabulary (a topic gets a log/store glyph, a
+        processor gets a colored chip) through a <code style={inlineCode}>renderIcon</code> callback —
+        and each node is a <strong>composite glyph</strong>: one transparent hit-rect in the scene
+        graph carrying the node's datum, with the icon, label, and store-chips as overlay chrome on
+        top. Level-of-detail collapses the glyph (full → compact → icon → dot) as the graph scales,
+        and back-edges render as distinct dashed curves.
+      </p>
+
+      <p>
+        Because the hit target is a real scene node, the interaction story is the normal one:{" "}
+        <code style={inlineCode}>LinkedCharts</code> drives a shared selection across a detail view{" "}
+        <em>and</em> a level-of-detail minimap, hover computes a downstream-reachability set and dims
+        everything else in both views, and click locks a selection. None of that is custom code — it's
+        the same selection + observation plumbing the catalog charts use, reaching a custom layout
+        because the custom layout plays by the scene-node contract.
+      </p>
+
+      <pre style={pre}>{`// Your pipeline owns layout; the recipe only READS logical x/y.
+<NetworkCustomChart
+  nodes={view.nodes} edges={view.edges}
+  layout={lineageDagLayout}
+  layoutConfig={{ reachableIds, selectedId, renderIcon, partitionColors }}
+  selection={{ name: "kstreams" }}   // shared store → selection ring
+  onObservation={onHover}            // hover → downstream reach preview
+  onClick={onPick}
+/>`}</pre>
+
+      <h2>Interpreting a foreign grammar: GoFish IR</h2>
+
+      <p>
+        The harder test came from the other direction. <a href="https://gofish.graphics/">GoFish</a>{" "}
+        is a research visualization grammar (MIT) that formalizes Gestalt relations — spacing,
+        containment, connection — as composable operators, and reclaims charts that fall outside the
+        classic Grammar of Graphics: mosaics, waffles, ribbons, nested glyphs. It serializes specs to
+        a JSON <strong>intermediate representation</strong> (<code style={inlineCode}>to_ir</code>).
+        The question: can you export <em>anything</em> from GoFish and render it in Semiotic?
+      </p>
+
+      <p>
+        The first attempt was a <em>recognizer</em> — match the IR's shape ("this has a petal mark →
+        run the flower recipe") and dispatch to a hand-written layout. It looked declarative and was a
+        lie: only the handful of archetypes we'd coded would ever render. The honest version is an{" "}
+        <strong>interpreter</strong>. <code style={inlineCode}>unstable_fromGofishIR</code> hands the spec to a
+        small layout engine that walks <code style={inlineCode}>data → operators → mark</code> and{" "}
+        <em>executes</em> the grammar: <code style={inlineCode}>group</code> /{" "}
+        <code style={inlineCode}>spread</code> / <code style={inlineCode}>stack</code> /{" "}
+        <code style={inlineCode}>scatter</code> / <code style={inlineCode}>treemap</code> /{" "}
+        <code style={inlineCode}>layer</code>, the <code style={inlineCode}>polar</code> coordinate
+        transform, mark channels through value scales, and{" "}
+        <code style={inlineCode}>connect</code> / <code style={inlineCode}>ref</code> relations. Any
+        spec built from that grammar renders; it is not limited to known charts.
+      </p>
+
+      <p>
+        The flower below is not produced by a flower recipe. It's the GoFish IR document on the right,
+        run through <code style={inlineCode}>unstable_fromGofishIR</code> and mounted on{" "}
+        <code style={inlineCode}>XYCustomChart</code>. A <code style={inlineCode}>scatter</code> places
+        one stem per lake at its x; each stem is a value-scaled <code style={inlineCode}>rect</code>
+        bar; a <code style={inlineCode}>polar</code> layer stacks one <code style={inlineCode}>petal</code>{" "}
+        per species around the angle axis, anchored to the top of the stem.
+      </p>
+
+      <FlowerFromIR />
+
+      <pre style={pre}>{FLOWER_IR_SNIPPET}</pre>
+
+      <h2>Escape hatches, honored — not assumed</h2>
+
+      <p>
+        A grammar can't express everything, and pretending otherwise is how you get the recognizer
+        back. GoFish has two sanctioned escape hatches — <code style={inlineCode}>derive</code> (a data
+        transform) and <code style={inlineCode}>mark-fn</code> (a bespoke per-datum glyph) — that
+        serialize as a <code style={inlineCode}>lambdaId</code> resolved through a bridge. The
+        interpreter honors that exactly: a lambda registry resolves the id, and an{" "}
+        <em>unregistered</em> id produces a warning, not a crash.
+      </p>
+
+      <p>
+        That's what made the bubble-tea menu (the sixth example, derived from Krist Wongsuphasawat's
+        "Boba Science" notebook) tractable on principle rather than by cheating. It's a row of
+        data-driven drinks: each cup's tea + tapioca + ice volumes (plus its cup-size parameters) add
+        up to a total volume that sets the drink height, so "Extra Boba" grows a taller pearl bed and
+        "Light Ice" reads as mostly tea. The cup, tea, straw, and lid are real{" "}
+        <code style={inlineCode}>polygon</code> / <code style={inlineCode}>line</code> marks; the
+        pearls and ice are real <code style={inlineCode}>circle</code> /{" "}
+        <code style={inlineCode}>rect</code> marks. The one genuinely non-grammar step — the
+        frustum-volume → drink-height solve and the tapioca/ice packing — lives in a single{" "}
+        <code style={inlineCode}>derive</code> lambda, which also emits a shared aspect box so an
+        aspect-preserving <code style={inlineCode}>unit</code> fit lets the cups share one scale and a
+        baseline. The spec follows the grammar as far as it reaches and escape-hatches only the
+        irreducible math.
+      </p>
+
+      <p>
+        Six examples ride this interpreter at{" "}
+        <Link to="/features/gofish-layouts">/features/gofish-layouts</Link>, across three frames:
+        flower / bottle / polar-ribbon / circle-treemap on the XY frame, the boba cups on the ordinal
+        frame (one cup per category), and the Python Tutor memory diagram on the network frame (kept
+        as a chart-level escape hatch — a memory diagram is genuinely beyond the grammar).
+      </p>
+
+      <h2>The honest boundary</h2>
+
+      <p>
+        The interpreter is a real layout engine, but it is <em>not</em> GoFish's. GoFish elaborates{" "}
+        <code style={inlineCode}>spread</code> into a constraint system over a linear-system bounding
+        box; we implement the deterministic allocation/accumulation model that the common, acyclic
+        specs reduce to. That covers every operator the examples use and the large majority of gallery
+        charts — and it is forthright about the rest. Constructs outside the model (
+        <code style={inlineCode}>table</code>, <code style={inlineCode}>cut</code>, free-form{" "}
+        <code style={inlineCode}>.constrain</code>) record a warning and fall back rather than
+        silently mis-rendering. The interpreted charts render the grammar faithfully without being
+        pixel-equal to a bespoke recipe. That's the trade a translator makes, and naming it is part of
+        the contract.
+      </p>
+
+      <h2>When to reach for a custom chart — and when not</h2>
+
+      <ul>
+        <li>
+          <strong>Reach for it</strong> when the catalog genuinely doesn't have the shape: a
+          domain-specific diagram (lineage, memory, state machine), a pictorial glyph, a nested or
+          relational layout, or hosting another tool's output.
+        </li>
+        <li>
+          <strong>Reach for it</strong> when an external system already computes positions and you
+          only need a renderer with interaction — hand the layout back to the domain, as the kstreams
+          recipe does.
+        </li>
+        <li>
+          <strong>Don't reach for it</strong> when a catalog chart fits with props. A custom layout is
+          more surface area to own; the built-ins carry their encodings, legends, and a11y defaults
+          for free.
+        </li>
+        <li>
+          <strong>Don't reach for it</strong> to escape one inconvenient default — that's usually a{" "}
+          <code style={inlineCode}>frameProps</code> or a style function, not a new layout.
+        </li>
+      </ul>
+
+      <h2>Where this same pattern shows up</h2>
+
+      <p>
+        The "domain owns layout, the library renders + interacts" split isn't a streaming-topology
+        quirk. It's the right shape any time positions come from somewhere authoritative: build/CI
+        dependency graphs, supply-chain and logistics routes, org and reporting hierarchies, model and
+        data lineage in ML pipelines, and call graphs in observability tooling. And the "interpret a
+        serialized spec" half generalizes to any design tool or grammar that emits an IR — the work
+        here is a template for hosting one inside a runtime that brings interaction, streaming, and
+        accessibility the source format never had.
+      </p>
+
+      <h2>Related</h2>
+
+      <ul>
+        <li>
+          <Link to="/features/custom-charts">Custom Charts</Link> — the XY / ordinal / network
+          escape-hatch surface and the scene-node/overlay contract.
+        </li>
+        <li>
+          <Link to="/recipes/kstreams">Kafka Streams Topology</Link> — the lineage DAG recipe and the
+          linked detail + minimap views.
+        </li>
+        <li>
+          <Link to="/features/gofish-layouts">Experimental GoFish Adapter</Link> — the six interpreted examples and
+          the live IR for each.
+        </li>
+      </ul>
+    </article>
+  )
+}
+
+export default {
+  ...META,
+  draft: true,
+  component: Body,
+}

--- a/docs/src/components/navData.js
+++ b/docs/src/components/navData.js
@@ -125,6 +125,7 @@ const navData = [
       { title: "Performance", path: "/features/performance" },
       { title: "Push API", path: "/features/push-api" },
       { title: "Custom Charts", path: "/features/custom-charts" },
+      { title: "Experimental GoFish Adapter", path: "/features/gofish-layouts" },
     ],
   },
   {

--- a/docs/src/pages/features/CustomChartsPage.js
+++ b/docs/src/pages/features/CustomChartsPage.js
@@ -767,6 +767,93 @@ export const myLayout: CustomLayout<MyConfig> = (ctx) => {
       </section>
 
       <section>
+        <h2>Recipe authoring contracts</h2>
+        <p>
+          Custom layouts work best when they split semantic marks from decorative chrome. Emit
+          data-bearing scene nodes for anything the reader can hover, click, select, animate, or
+          describe. Render labels, petals, ribbons, arrows, silhouettes, and other visual detail as
+          keyed SVG overlays. If a layout returns overlays without scene nodes, or every scene node
+          has <code>datum: null</code>, Semiotic warns in development because hover callbacks and
+          tooltips have nothing useful to read.
+        </p>
+        <ul>
+          <li>
+            <strong>Stable ids.</strong> Give each emitted node a stable identity such as{" "}
+            <code>_transitionKey</code>, <code>pointId</code>, or a recipe-specific id so transitions
+            can interpolate between solved states.
+          </li>
+          <li>
+            <strong>Transparent hit targets.</strong> Pictorial glyphs often need a simple scene node
+            underneath the visible overlay. Use a transparent rect or point with a useful datum.
+          </li>
+          <li>
+            <strong>Tooltip payloads.</strong> Shape datums with user-facing keys, then use{" "}
+            <code>buildTooltipEntries</code> to unwrap hover payloads consistently across custom
+            chart families.
+          </li>
+        </ul>
+        <CodeBlock language="tsx">{`import { buildTooltipEntries } from "semiotic/recipes"
+
+const hit = {
+  type: "rect",
+  x, y,
+  w: width,
+  h: height,
+  style: { fill: "rgba(0,0,0,0)", stroke: "none" },
+  datum: { category, amount, kind: "bottle" },
+  group: category,
+  _transitionKey: \`bottle-hit-\${category}\`,
+}
+
+function Tooltip(hover) {
+  const rows = buildTooltipEntries(hover)
+  return rows.length ? (
+    <div className="semiotic-tooltip">
+      {rows.map((row) => <div key={row.key}>{row.label}: {row.formatted}</div>)}
+    </div>
+  ) : null
+}`}</CodeBlock>
+      </section>
+
+      <section>
+        <h2>Push semantics</h2>
+        <p>
+          The push API supports two different mental models. Append streams add observations over
+          time: a new event, trade, request, or passenger enters the layout. State updates replace
+          an existing object's current value: a bottle's fill level changes, a node moves, or a KPI
+          updates. Use <code>ref.current.push(datum)</code> for append streams and{" "}
+          <code>ref.current.update(id, updater)</code> when identity should stay fixed.
+        </p>
+        <CodeBlock language="jsx">{`const ref = useRef(null)
+
+// Append semantics: add another observation.
+ref.current.push({ id: "event-42", category: "A", value: 12 })
+
+// State semantics: update an existing object in place.
+ref.current.update("planning", (d) => ({
+  ...d,
+  amount: nextAmount,
+}))`}</CodeBlock>
+        <p>
+          The <Link to="/features/gofish-layouts">experimental GoFish adapter</Link> page uses the bottle-fill
+          example as the canonical state-update pattern: the same five bottles remain in the scene
+          graph while their fill values animate between solved states.
+        </p>
+      </section>
+
+      <section>
+        <h2>Network custom diagrams</h2>
+        <p>
+          <code>NetworkCustomChart</code> is not limited to network science charts. It is the right
+          escape hatch for semantic diagrams with nodes, edges, and stable identity: state machines,
+          dependency diagrams, lineage diagrams, Python Tutor memory diagrams, process maps, and
+          other object-reference systems. Use scene rects/circles for the semantic objects and
+          network edges for relationships; reserve overlays for labels, dividers, arrows, and other
+          detail that should not intercept interaction.
+        </p>
+      </section>
+
+      <section>
         <h2>Sub-path import</h2>
         <p>
           Each frame's escape-hatch HOC ships from its own sub-path: <code>XYCustomChart</code> from{" "}
@@ -784,6 +871,7 @@ import {
   waffleLayout, calendarLayout,
   flextreeLayout, dagreLayout,
   marimekkoLayout, bulletLayout, parallelCoordinatesLayout,
+  buildTooltipEntries,
 } from "semiotic/recipes"`}</CodeBlock>
       </section>
 

--- a/docs/src/pages/features/GoFishLayoutsPage.js
+++ b/docs/src/pages/features/GoFishLayoutsPage.js
@@ -11,7 +11,7 @@ import {
   unstable_gofishPolarRibbonIR as polarRibbonIR,
   unstable_gofishPythonMemoryIR as pythonMemoryIR,
   unstable_gofishTitanicCircleTreemapIR as titanicCircleTreemapIR,
-} from "semiotic/experimental"
+} from "../../../../src/components/semiotic-experimental"
 import {
   buildTooltipEntries,
   extractTooltipDatum,

--- a/docs/src/pages/features/GoFishLayoutsPage.js
+++ b/docs/src/pages/features/GoFishLayoutsPage.js
@@ -1,0 +1,984 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { XYCustomChart } from "../../../../src/components/charts/custom/XYCustomChart"
+import { NetworkCustomChart } from "../../../../src/components/charts/custom/NetworkCustomChart"
+import { OrdinalCustomChart } from "../../../../src/components/charts/custom/OrdinalCustomChart"
+import {
+  EXPERIMENTAL_GOFISH_ADAPTER_NAME,
+  unstable_fromGofishIR,
+  unstable_gofishBobaIR as bobaIR,
+  unstable_gofishBottleIR as bottleIR,
+  unstable_gofishFlowerIR as flowerIR,
+  unstable_gofishPolarRibbonIR as polarRibbonIR,
+  unstable_gofishPythonMemoryIR as pythonMemoryIR,
+  unstable_gofishTitanicCircleTreemapIR as titanicCircleTreemapIR,
+} from "semiotic/experimental"
+import {
+  buildTooltipEntries,
+  extractTooltipDatum,
+  formatTooltipValue,
+} from "semiotic/recipes"
+import PageLayout from "../../components/PageLayout"
+import CodeBlock from "../../components/CodeBlock"
+import { Link } from "react-router-dom"
+
+// Each demo is now driven by a serialized GoFish Frontend IR document. The page
+// runs the IR through `unstable_fromGofishIR` to obtain the layout, accessor config, and
+// inline data — there is no hand-maintained chart data on this page anymore.
+const irByKey = {
+  flower: flowerIR,
+  bottle: bottleIR,
+  polar: polarRibbonIR,
+  titanic: titanicCircleTreemapIR,
+  python: pythonMemoryIR,
+  boba: bobaIR,
+}
+
+// Push seeds for the bottle "update existing object" demo. The ids match the
+// categories in the bottle IR's inline data.
+const bottleData = [
+  { id: "planning", category: "Planning", amount: 64 },
+  { id: "design", category: "Design", amount: 82 },
+  { id: "build", category: "Build", amount: 46 },
+  { id: "review", category: "Review", amount: 71 },
+  { id: "ship", category: "Ship", amount: 55 },
+]
+
+// IR docs can carry large inline datasets (Titanic). Abridge long `rows`
+// arrays so the spec stays readable when shown in the page.
+function irForDisplay(doc) {
+  const clone = JSON.parse(JSON.stringify(doc))
+  const abridge = (node) => {
+    if (!node || typeof node !== "object") return
+    if (Array.isArray(node.charts)) node.charts.forEach(abridge)
+    if (node.data && Array.isArray(node.data.rows) && node.data.rows.length > 6) {
+      const total = node.data.rows.length
+      node.data.rows = [...node.data.rows.slice(0, 3), `…and ${total - 3} more rows`]
+    }
+  }
+  abridge(clone.root)
+  return JSON.stringify(clone, null, 2)
+}
+
+// The memory diagram threads its whole snapshot through `layoutConfig.diagram`;
+// summarise it rather than dumping it when showing the resolved config.
+function stripDataFromConfig(config) {
+  const out = {}
+  for (const [key, value] of Object.entries(config)) {
+    out[key] = value && typeof value === "object" ? "{…}" : value
+  }
+  return out
+}
+
+// Apply an interactive control to the IR itself (the spec), so the interpreter
+// re-renders the edit rather than reading a separate config the interpreter
+// ignores. Flower: the petal-radius slider sets the polar layer's radiusFactor.
+function applyControlsToIR(active, controls) {
+  const base = irByKey[active] ?? flowerIR
+  if (active !== "flower") return base
+  const doc = JSON.parse(JSON.stringify(base))
+  const polarLayer = (doc.root.mark.children || []).find(
+    (c) => c.options && c.options.coord && c.options.coord.type === "polar",
+  )
+  if (polarLayer) {
+    polarLayer.options = { ...polarLayer.options, radiusFactor: controls.flowerRadius / 30 }
+  }
+  return doc
+}
+
+const demoOrder = ["flower", "bottle", "polar", "titanic", "python", "boba"]
+
+function initialDemoKey() {
+  if (typeof window === "undefined") return "flower"
+  const key = window.location.hash.replace(/^#/, "")
+  return demoOrder.includes(key) ? key : "flower"
+}
+
+const demoLabels = {
+  flower: "Flower chart",
+  bottle: "Bottle fill",
+  polar: "Polar ribbon",
+  titanic: "Fare circle treemap",
+  python: "Python memory",
+  boba: "Boba cups",
+}
+
+const gofishLinks = {
+  flower: "https://gofish.graphics/js/examples/flower-chart.html",
+  bottle: "https://gofish.graphics/js/examples/bottle-fill-chart.html",
+  polar: "https://gofish.graphics/js/examples/polar-ribbon-chart.html",
+  titanic: "https://gofish.graphics/js/examples/titanic-fare-circle-treemap.html",
+  python: "https://gofish.graphics/js/examples/python-tutor-memory-diagram.html",
+  boba: "https://observablehq.com/@kristw/boba-science",
+}
+
+const chartColors = ["#4e79a7", "#f28e2c", "#59a14f", "#e15759", "#b07aa1", "#76b7b2"]
+
+function buildPushedDatum(active, tick) {
+  const lakes = ["Erie", "Huron", "Michigan", "Ontario", "Superior"]
+  const species = ["Walleye", "Perch", "Trout"]
+  if (active === "flower" || active === "polar") {
+    const lakeIndex = tick % lakes.length
+    return {
+      id: `${active}-push-${tick}`,
+      lake: lakes[lakeIndex],
+      species: species[(tick + lakeIndex) % species.length],
+      count: 8 + ((tick * 7) % 24),
+      x: lakeIndex,
+    }
+  }
+  if (active === "bottle") {
+    return {
+      id: bottleData[tick % bottleData.length].id,
+      category: bottleData[tick % bottleData.length].category,
+      amount: 35 + ((tick * 17) % 58),
+    }
+  }
+  if (active === "boba") {
+    const cups = ["Classic", "Extra Boba", "Light Ice", "Mega"]
+    return {
+      name: cups[tick % cups.length],
+      bobaVolume: 80 + ((tick * 47) % 220),
+    }
+  }
+  return {
+    id: `passenger-push-${tick}`,
+    name: `pushed-${tick}`,
+    pclass: (tick % 3) + 1,
+    survived: tick % 4 !== 0,
+    fare: 7 + ((tick * 13) % 84),
+  }
+}
+
+// Per-demo presentation metadata. The layout, accessor config, and data all
+// come from `unstable_fromGofishIR`; this only carries chrome and the visual controls
+// the page layers on top of the IR-derived accessors.
+const demoMeta = {
+  flower: {
+    height: 380,
+    margin: { top: 20, right: 24, bottom: 42, left: 24 },
+    visualConfig: (c) => ({ flowerRadius: c.flowerRadius, stemWidth: 5 }),
+    question:
+      "Can a GoFish grouped glyph become a Semiotic custom chart without a one-off renderer?",
+    contract:
+      "The solver groups seafood by lake, keeps stem totals as data-bearing rect hit targets, and renders visible stems and petal glyphs as keyed overlays.",
+  },
+  bottle: {
+    height: 360,
+    margin: { top: 18, right: 50, bottom: 34, left: 18 },
+    visualConfig: (c) => ({ bottleHeight: c.bottleHeight }),
+    question: "Can a custom pictorial mark expose one useful hit target per bottle?",
+    contract:
+      "The bottle silhouette, liquid, label, and fill line are SVG overlay chrome. A transparent rect per bottle stays in the Semiotic scene graph for hover, selection, SSR evidence, and transitions.",
+  },
+  polar: {
+    height: 430,
+    margin: { top: 20, right: 40, bottom: 20, left: 40 },
+    visualConfig: (c) => ({ innerRadius: c.innerRadius, outerRadius: c.outerRadius }),
+    question: "Can grouped polar bars and cross-species ribbons share one stable layout?",
+    contract:
+      "The radial bars and ribbons are glyph overlays generated from a GoFish-style grouping pass. Each bar also emits a data-bearing point node at its polar midpoint.",
+  },
+  titanic: {
+    height: 430,
+    margin: { top: 18, right: 18, bottom: 18, left: 18 },
+    visualConfig: (c) => ({ padding: c.treemapPadding }),
+    question: "Can a treemap tile layout carry non-rectangular passenger marks?",
+    contract:
+      "A treemap of treemaps: an outer squarified treemap sizes one rectangle per passenger class by total fare, and an inner squarified treemap gives each passenger a fare-sized cell rendered as an inscribed circle — each a data-bearing point node coloured by survival.",
+  },
+  python: {
+    height: 330,
+    margin: { top: 16, right: 16, bottom: 16, left: 16 },
+    visualConfig: (c) => ({ heapGap: c.heapGap }),
+    question: "Can custom layout handle semantic diagrams, not only statistical charts?",
+    contract:
+      "Stack bindings and heap cells become NetworkFrame rect nodes. Pointer references become curved network edges with bezier caches, so Semiotic can run particles along them.",
+  },
+  boba: {
+    height: 360,
+    margin: { top: 12, right: 16, bottom: 16, left: 16 },
+    visualConfig: (c) => ({ cupWidthRatio: c.cupWidth }),
+    question: "Can an ordinal frame render a menu of bespoke, data-driven pictorial glyphs as separate categories?",
+    contract:
+      "Each drink is one ordinal item on the band scale. Its tea + tapioca + ice volumes (plus cup-size params) add up to a drink height the derive lambda solves; the cups share one scale and a baseline so they read as a menu on a shelf. A transparent hit rect per cup carries the volumes and pearl/ice counts into the scene graph; the cup outline, tea, tapioca pearls, ice, lid, and straw are keyed SVG overlays. Refilling a cup's boba volume re-solves and re-renders its pearl bed in place.",
+  },
+}
+
+// Merge the IR-derived adapter config with the per-demo chrome and the visual
+// controls. `cfg` is the memoized `unstable_fromGofishIR` output (kept stable per demo
+// so slider drags don't re-parse the IR or regenerate inline data).
+function getDemo(active, controls, cfg) {
+  const meta = demoMeta[active] ?? demoMeta.flower
+  return {
+    ...meta,
+    kind: cfg.family,
+    recipe: cfg.recipe,
+    data: cfg.data,
+    graph: cfg.graph,
+    layout: cfg.layout,
+    networkLayout: cfg.networkLayout,
+    ordinalLayout: cfg.ordinalLayout,
+    categoryAccessor: cfg.categoryAccessor,
+    valueAccessor: cfg.valueAccessor,
+    warnings: cfg.warnings,
+    layoutConfig: { ...cfg.layoutConfig, ...meta.visualConfig(controls) },
+  }
+}
+
+function getControl(active, controls, setControls) {
+  const update = (key) => (event) =>
+    setControls((prev) => ({ ...prev, [key]: Number(event.target.value) }))
+  if (active === "flower") {
+    return {
+      label: "Petal radius",
+      value: controls.flowerRadius,
+      min: 22,
+      max: 48,
+      onChange: update("flowerRadius"),
+      suffix: "px",
+    }
+  }
+  if (active === "bottle") {
+    return {
+      label: "Bottle height",
+      value: controls.bottleHeight,
+      min: 150,
+      max: 260,
+      onChange: update("bottleHeight"),
+      suffix: "px",
+    }
+  }
+  if (active === "polar") {
+    return {
+      label: "Outer radius",
+      value: controls.outerRadius,
+      min: 112,
+      max: 178,
+      onChange: update("outerRadius"),
+      suffix: "px",
+    }
+  }
+  if (active === "titanic") {
+    return {
+      label: "Treemap padding",
+      value: controls.treemapPadding,
+      min: 0,
+      max: 6,
+      step: 0.5,
+      onChange: update("treemapPadding"),
+      suffix: "px",
+    }
+  }
+  if (active === "boba") {
+    return {
+      label: "Cup width",
+      value: controls.cupWidth,
+      min: 0.6,
+      max: 1,
+      step: 0.01,
+      onChange: update("cupWidth"),
+      suffix: "× band",
+    }
+  }
+  return {
+    label: "Heap gap",
+    value: controls.heapGap,
+    min: 4,
+    max: 34,
+    onChange: update("heapGap"),
+    suffix: "px",
+  }
+}
+
+function extractObservedDatum(obs) {
+  return extractTooltipDatum(obs)
+}
+
+function GoFishTooltip(hover) {
+  const entries = buildTooltipEntries(hover, { maxEntries: 8 })
+  if (!entries.length) return null
+  return (
+    <div
+      className="semiotic-tooltip"
+      style={{
+        background: "var(--semiotic-tooltip-bg, var(--surface-1, #fff))",
+        color: "var(--semiotic-tooltip-color, var(--text-primary, #222))",
+        borderWidth: 1,
+        borderStyle: "solid",
+        borderColor: "var(--semiotic-tooltip-border, var(--border-color, #d8dee4))",
+        borderRadius: 6,
+        boxShadow: "var(--semiotic-tooltip-shadow, 0 2px 10px rgba(0,0,0,0.16))",
+        padding: "8px 10px",
+        fontSize: 12,
+        maxWidth: 260,
+      }}
+    >
+      {entries.map((entry) => (
+        <div
+          key={entry.key}
+          style={{
+            display: "grid",
+            gridTemplateColumns: "minmax(62px, auto) 1fr",
+            columnGap: 8,
+            rowGap: 4,
+            overflowWrap: "anywhere",
+          }}
+        >
+          <strong>{entry.label}</strong>
+          <span>{entry.formatted}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function TabButton({ active, children, onClick }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        appearance: "none",
+        borderWidth: 1,
+        borderStyle: "solid",
+        borderColor: active ? "var(--semiotic-primary, #4e79a7)" : "var(--border-color, #d8dee4)",
+        background: active ? "var(--semiotic-primary, #4e79a7)" : "var(--surface-1, #fff)",
+        color: active ? "#fff" : "var(--text-primary, #222)",
+        borderRadius: 8,
+        padding: "8px 11px",
+        fontSize: 13,
+        fontWeight: active ? 700 : 500,
+        cursor: "pointer",
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
+export default function GoFishLayoutsPage() {
+  const chartRef = useRef(null)
+  const [active, setActive] = useState(initialDemoKey)
+  const [observed, setObserved] = useState(null)
+  const [streaming, setStreaming] = useState(false)
+  const [pushCount, setPushCount] = useState(0)
+  const [controls, setControls] = useState({
+    flowerRadius: 34,
+    bottleHeight: 220,
+    innerRadius: 44,
+    outerRadius: 145,
+    treemapPadding: 2,
+    heapGap: 18,
+    cupWidth: 0.92,
+  })
+  const irDoc = useMemo(() => applyControlsToIR(active, controls), [active, controls])
+  const adapterCfg = useMemo(() => unstable_fromGofishIR(irDoc), [irDoc])
+  const demo = useMemo(() => getDemo(active, controls, adapterCfg), [active, controls, adapterCfg])
+  const irText = useMemo(() => irForDisplay(irDoc), [irDoc])
+  const control = getControl(active, controls, setControls)
+  const seedData = demo.data
+
+  // Staleness is a streaming feature: only arm it while the demo is actively
+  // auto-streaming, so a static gallery view never dims to "stale" on idle (and
+  // shows a "LIVE" badge while data is flowing). `pulse` is intentionally not
+  // used here — it targets scene nodes, and the boba hit rects are full-band
+  // transparent targets, so a pulse reads as a panel rather than a flash.
+  const liveStaleness = streaming
+    ? { threshold: 5000, dimOpacity: 0.55, showBadge: true, badgePosition: "top-right" }
+    : undefined
+
+  const resetPushData = useCallback(() => {
+    if (active === "python") return
+    chartRef.current?.clear?.()
+    chartRef.current?.pushMany?.(seedData)
+    setPushCount(0)
+  }, [active, seedData])
+
+  const pushOne = useCallback(() => {
+    if (active === "python") return
+    setPushCount((prev) => {
+      const nextDatum = buildPushedDatum(active, prev)
+      if (active === "bottle") {
+        chartRef.current?.update?.(nextDatum.id, (d) => ({ ...d, amount: nextDatum.amount }))
+      } else if (active === "boba") {
+        chartRef.current?.update?.(nextDatum.name, (d) => ({
+          ...d,
+          bobaVolume: nextDatum.bobaVolume,
+        }))
+      } else {
+        chartRef.current?.push?.(nextDatum)
+      }
+      return prev + 1
+    })
+  }, [active])
+
+  useEffect(() => {
+    setStreaming(false)
+    setObserved(null)
+    resetPushData()
+  }, [resetPushData])
+
+  useEffect(() => {
+    if (!streaming || active === "python") return undefined
+    // Push immediately so the staleness badge starts "LIVE" rather than briefly
+    // flashing "STALE" while the first interval tick is pending.
+    pushOne()
+    const timer = window.setInterval(pushOne, 1100)
+    return () => window.clearInterval(timer)
+  }, [active, pushOne, streaming])
+
+  return (
+    <PageLayout
+      title="Experimental GoFish IR Adapter"
+      subtitle="Temporary PR preview for rendering serialized GoFish Frontend IR through Semiotic custom layouts"
+    >
+      <section>
+        <p>
+          The GoFish examples are a useful stress test for Semiotic custom charts because they are
+          not just new marks. They combine grouping, faceting, coordinate transforms, pictorial
+          glyphs, packed layouts, and semantic diagrams. Each chart below is driven by a serialized{" "}
+          <strong>GoFish Frontend IR</strong> document — the JSON a GoFish <code>to_ir</code> pass
+          emits — run through <code>unstable_fromGofishIR</code>, the GoFish analogue of the{" "}
+          <Link to="/intelligence/vega-lite">Vega-Lite translator</Link>. The adapter does not
+          recognize archetypes — it <em>interprets</em> the spec, walking{" "}
+          <code>data → operators → mark</code> and executing <code>spread</code>/<code>stack</code>/
+          <code>group</code>/<code>scatter</code>/<code>treemap</code>, the <code>polar</code>{" "}
+          transform, channel scales, and <code>connect</code>/<code>ref</code> relations into
+          positioned marks. Any spec built from that grammar renders. The boba cup follows the spec
+          as far as it can (real polygon/circle/rect marks) and escape-hatches only the
+          frustum-volume math to one <code>derive</code>
+          lambda; the Python Tutor memory diagram is a genuinely bespoke diagram, so it stays a
+          chart-level escape hatch with particles on its pointer edges.
+        </p>
+        <p>
+          This adapter is named <code>{EXPERIMENTAL_GOFISH_ADAPTER_NAME}</code>. It is exposed as an{" "}
+          <code>unstable_</code> preview from <code>semiotic/experimental</code> for this PR so the
+          GoFish developer can evaluate the direction. Anything imported from that subpath is
+          unstable: it is not part of the next Semiotic release contract and may be removed or
+          replaced once GoFish exposes a refined bbox-stage static spec and a dynamic equivalent.
+        </p>
+        <p>
+          This is not a runtime dependency on GoFish — it consumes GoFish’s published IR, not its
+          renderer. It is a concrete integration with the{" "}
+          <Link to="/features/custom-charts">Custom Charts</Link> surface: a serialized grammar in,
+          stable mark identity, data-bearing nodes, theme-aware color resolution, transitions, and
+          streaming out.
+        </p>
+      </section>
+
+      <section>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginBottom: 12 }}>
+          {demoOrder.map((key) => (
+            <TabButton
+              key={key}
+              active={key === active}
+              onClick={() => {
+                if (typeof window !== "undefined") window.location.hash = key
+                setActive(key)
+                setObserved(null)
+              }}
+            >
+              {demoLabels[key]}
+            </TabButton>
+          ))}
+        </div>
+
+        <div
+          style={{
+            background: "var(--surface-2, #f8f8f8)",
+            borderWidth: 1,
+            borderStyle: "solid",
+            borderColor: "var(--border-color, #e0e0e0)",
+            borderRadius: 8,
+            padding: 16,
+            overflow: "hidden",
+          }}
+        >
+          {demo.kind === "network" ? (
+            <NetworkCustomChart
+              nodes={demo.graph?.nodes ?? []}
+              edges={demo.graph?.edges ?? []}
+              layout={demo.networkLayout}
+              layoutConfig={demo.layoutConfig}
+              width={880}
+              height={demo.height}
+              responsiveWidth
+              margin={demo.margin}
+              colorScheme={chartColors}
+              enableHover
+              onObservation={(obs) => {
+                if (obs.type === "hover" || obs.type === "click") {
+                  const datum = extractObservedDatum(obs)
+                  if (datum) setObserved(datum)
+                }
+              }}
+              frameProps={{
+                background: "#ffffff",
+                tooltipContent: GoFishTooltip,
+                showParticles: true,
+                particleStyle: {
+                  radius: 2.5,
+                  opacity: 0.75,
+                  spawnRate: 0.4,
+                  maxPerEdge: 10,
+                  color: "#1A5683",
+                },
+                transition: { duration: 600, easing: "ease-out" },
+                pulse: { duration: 700, color: "rgba(26, 86, 131, 0.28)", glowRadius: 7 },
+              }}
+            />
+          ) : demo.kind === "ordinal" ? (
+            <OrdinalCustomChart
+              ref={chartRef}
+              /* push-only: seeded via pushMany in resetPushData, not a data prop */
+              layout={demo.ordinalLayout}
+              layoutConfig={demo.layoutConfig}
+              categoryAccessor={demo.categoryAccessor}
+              valueAccessor={demo.valueAccessor}
+              width={880}
+              height={demo.height}
+              responsiveWidth
+              margin={demo.margin}
+              colorScheme={chartColors}
+              enableHover
+              tooltip={GoFishTooltip}
+              emptyContent={false}
+              onObservation={(obs) => {
+                if (obs.type === "hover" || obs.type === "click") {
+                  const datum = extractObservedDatum(obs)
+                  if (datum) setObserved(datum)
+                }
+              }}
+              frameProps={{
+                background: "#ffffff",
+                dataIdAccessor: "name",
+                transition: { duration: 650, easing: "ease-out" },
+                staleness: liveStaleness,
+              }}
+            />
+          ) : (
+            <XYCustomChart
+              ref={chartRef}
+              /* push-only: seeded via pushMany in resetPushData, not a data prop */
+              layout={demo.layout}
+              layoutConfig={demo.layoutConfig}
+              width={880}
+              height={demo.height}
+              responsiveWidth
+              margin={demo.margin}
+              colorScheme={chartColors}
+              enableHover
+              tooltip={GoFishTooltip}
+              emptyContent={false}
+              onObservation={(obs) => {
+                if (obs.type === "hover" || obs.type === "click") {
+                  const datum = extractObservedDatum(obs)
+                  if (datum) setObserved(datum)
+                }
+              }}
+              frameProps={{
+                ...(active === "titanic" ? { background: "#ffffff" } : {}),
+                pointIdAccessor: "id",
+                transition: { duration: 650, easing: "ease-out" },
+                staleness: liveStaleness,
+              }}
+            />
+          )}
+        </div>
+
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+            gap: 16,
+            marginTop: 16,
+          }}
+        >
+          <div
+            style={{
+              borderWidth: 1,
+              borderStyle: "solid",
+              borderColor: "var(--border-color, #e0e0e0)",
+              borderRadius: 8,
+              padding: 14,
+              minWidth: 0,
+            }}
+          >
+            <h3 style={{ marginTop: 0 }}>Controls</h3>
+            <label style={{ display: "block", fontSize: 13, fontWeight: 700, marginBottom: 8 }}>
+              {control.label}: {control.value}
+              {control.suffix}
+            </label>
+            <input
+              type="range"
+              min={control.min}
+              max={control.max}
+              step={control.step ?? 1}
+              value={control.value}
+              onChange={control.onChange}
+              style={{ width: "100%" }}
+            />
+            {active === "python" ? (
+              <p style={{ marginTop: 12 }}>
+                Pointer edges are rendered by <code>NetworkCustomChart</code> with particles
+                enabled, using bezier caches from the custom layout.
+              </p>
+            ) : (
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: 12 }}>
+                <button type="button" style={smallButtonStyle} onClick={pushOne}>
+                  {active === "bottle"
+                    ? "Update bottle"
+                    : active === "boba"
+                      ? "Refill a cup"
+                      : "Push datum"}
+                </button>
+                <button
+                  type="button"
+                  style={{
+                    ...smallButtonStyle,
+                    background: streaming
+                      ? "var(--semiotic-primary, #4e79a7)"
+                      : "var(--surface-1, #fff)",
+                    color: streaming ? "#fff" : "var(--text-primary, #222)",
+                  }}
+                  onClick={() => setStreaming((value) => !value)}
+                >
+                  {streaming ? "Stop stream" : "Auto stream"}
+                </button>
+                <button type="button" style={smallButtonStyle} onClick={resetPushData}>
+                  Reset
+                </button>
+                <span
+                  style={{
+                    alignSelf: "center",
+                    fontSize: 12,
+                    color: "var(--text-secondary, #666)",
+                  }}
+                >
+                  {pushCount} {active === "bottle" || active === "boba" ? "updates" : "pushed"}
+                </span>
+              </div>
+            )}
+            <p style={{ marginBottom: 0, overflowWrap: "anywhere" }}>
+              <strong>Question:</strong> {demo.question}
+            </p>
+          </div>
+
+          <div
+            style={{
+              borderWidth: 1,
+              borderStyle: "solid",
+              borderColor: "var(--border-color, #e0e0e0)",
+              borderRadius: 8,
+              padding: 14,
+              minWidth: 0,
+            }}
+          >
+            <h3 style={{ marginTop: 0 }}>Selected Mark</h3>
+            {observed ? (
+              <dl
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "minmax(70px, 0.45fr) 1fr",
+                  gap: "6px 10px",
+                  margin: 0,
+                }}
+              >
+                {Object.entries(observed).map(([key, value]) => (
+                  <React.Fragment key={key}>
+                    <dt style={{ fontWeight: 700, overflowWrap: "anywhere" }}>{key}</dt>
+                    <dd style={{ margin: 0, overflowWrap: "anywhere" }}>
+                      {formatTooltipValue(value)}
+                    </dd>
+                  </React.Fragment>
+                ))}
+              </dl>
+            ) : (
+              <p style={{ marginBottom: 0 }}>
+                Hover a stem, bottle, polar bar, passenger, or memory cell.
+              </p>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2>The GoFish IR driving this chart</h2>
+        <p>
+          This chart is not hand-wired. The JSON below is a GoFish Frontend IR document — the
+          serialized form a GoFish <code>to_ir</code> pass emits (
+          <code>data → operators → mark</code>, lowercase <code>type</code> tags, the{" "}
+          <code>__combinator</code> flag, tagged <code>{'{type:"field"}'}</code> accessors). The
+          page runs it through <code>unstable_fromGofishIR</code>, which interprets the operators and mark
+          channels directly and mounts the result on the <code>{demo.kind}</code> frame —{" "}
+          <code>
+            {demo.kind === "network"
+              ? "NetworkCustomChart"
+              : demo.kind === "ordinal"
+                ? "OrdinalCustomChart"
+                : "XYCustomChart"}
+          </code>
+          .
+        </p>
+        {demo.warnings && demo.warnings.length > 0 ? (
+          <p style={{ color: "var(--semiotic-warning, #b26a00)" }}>
+            <strong>Adapter warnings:</strong> {demo.warnings.join(" ")}
+          </p>
+        ) : null}
+        <CodeBlock language="json">{irText}</CodeBlock>
+        <p style={{ fontSize: 13, color: "var(--text-secondary, #666)", marginBottom: 0 }}>
+          Resolved <code>layoutConfig</code>:{" "}
+          <code>{JSON.stringify(stripDataFromConfig(demo.layoutConfig))}</code>
+        </p>
+      </section>
+
+      <section>
+        <h2>Why this is not ad hoc</h2>
+        <p>{demo.contract}</p>
+        <ul>
+          <li>
+            <strong>Layout is separate from rendering.</strong> Each recipe computes glyph marks
+            from data and plot dimensions; the adapter compiles supported marks into Semiotic scene
+            nodes.
+          </li>
+          <li>
+            <strong>Identity is explicit.</strong> Every mark has an id, which becomes the
+            transition key for scene nodes and the React key for overlay glyphs.
+          </li>
+          <li>
+            <strong>Glyph chrome is allowed, but bounded.</strong> Petals, bottle silhouettes,
+            ribbons, tuple dividers, labels, and arrows are overlays. Hit targets and measurable
+            values remain in the scene graph.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Targets</h2>
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 14 }}>
+          <thead>
+            <tr>
+              <th style={thStyle}>GoFish example</th>
+              <th style={thStyle}>Frame · interpreted grammar</th>
+              <th style={thStyle}>Scene-node contract</th>
+            </tr>
+          </thead>
+          <tbody>
+            <TargetRow
+              label="Flower chart"
+              href={gofishLinks.flower}
+              recipe="XY · scatter + polar stack of petals"
+              contract="Stem bars are data-bearing rects; petals are polar-remapped paths."
+            />
+            <TargetRow
+              label="Bottle fill chart"
+              href={gofishLinks.bottle}
+              recipe="XY · spread + derive + image/clip marks"
+              contract="A bottle image per category with a green fill clipped to the silhouette, a fill line, a % label, and a transparent hit rect — via the reusable image + clipPath glyph primitives."
+            />
+            <TargetRow
+              label="Polar ribbon chart"
+              href={gofishLinks.polar}
+              recipe="XY · polar nested stacks + connect"
+              contract="Radial stacked bars as annular paths; connect resolves ribbons across named refs."
+            />
+            <TargetRow
+              label="Titanic fare circle treemap"
+              href={gofishLinks.titanic}
+              recipe="XY · nested squarified treemap → circles"
+              contract="Outer treemap sizes a rectangle per class; inner treemap squarifies passengers into fare-sized cells, each an inscribed circle by survival."
+            />
+            <TargetRow
+              label="Python Tutor memory diagram"
+              href={gofishLinks.python}
+              recipe="network · chart-level mark-fn (escape hatch)"
+              contract="A bespoke diagram beyond the grammar: rect nodes + curved particle pointer edges."
+            />
+            <TargetRow
+              label="Boba science cups"
+              href={gofishLinks.boba}
+              recipe="ordinal · spread + derive + polygon/circle/rect/line marks"
+              contract="A menu of data-driven drinks: tea + tapioca + ice volumes add up to a drink height. One hit rect per cup; cup, tea, pearls, ice, lid, and straw are real marks; one derive for the geometry math + the shared aspect box."
+            />
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>How the interpreter executes a spec</h2>
+        <p>
+          <code>unstable_fromGofishIR</code> picks a frame family and hands the IR to{" "}
+          <code>interpretGofishIR</code>, which walks <code>data → operators → mark</code> and{" "}
+          <em>executes</em> the grammar — it does not match archetypes. It is a real (if minimal)
+          layout engine, not GoFish’s full constraint solver: it implements the deterministic
+          allocation/accumulation model the common acyclic specs reduce to.
+        </p>
+        <ul>
+          <li>
+            <strong>Operators allocate space.</strong> <code>spread</code> divides an axis into even
+            slots, <code>stack</code> accumulates value-scaled segments, <code>group</code>{" "}
+            partitions by a field, <code>scatter</code> positions by x/y scales,{" "}
+            <code>treemap</code> slices proportional cells, <code>layer</code> overlays.
+          </li>
+          <li>
+            <strong>Marks bind channels through scales.</strong> A field <code>h</code>/
+            <code>w</code> becomes a value-scaled bar; <code>fill</code> resolves through the theme
+            palette; the <code>polar</code> transform remaps <code>(θ, r)</code> so rects become
+            annular bands.
+          </li>
+          <li>
+            <strong>Escape hatches are honored, not assumed.</strong> <code>derive</code> and{" "}
+            <code>mark-fn</code> resolve through a lambda registry — the boba cup’s geometry is one{" "}
+            <code>derive</code>; an unregistered id warns rather than crashing.
+          </li>
+          <li>
+            <strong>Out-of-scope constructs warn.</strong> <code>table</code>, <code>cut</code>,
+            free-form <code>.constrain</code>, and similar record an adapter warning and fall back
+            instead of silently mis-rendering. Semiotic still owns hit testing, transitions,
+            staleness, tooltips, SSR, and (for the memory diagram) particles.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Streaming relational layouts</h2>
+        <p>
+          Semiotic can animate between solved states, but relational layout grammars need explicit
+          streaming semantics. Append streams introduce new observations; state updates mutate
+          existing objects. For relational charts, the hard cases are insertion order, relation
+          preservation, and whether a transition should preserve a local relationship or re-solve
+          the whole layout. The bottle demo intentionally uses update semantics; the flower, polar,
+          and Titanic demos use append semantics.
+        </p>
+      </section>
+
+      <section>
+        <h2>Using the adapter</h2>
+        <CodeBlock language="jsx">{`import { useEffect, useRef } from "react"
+import { XYCustomChart } from "semiotic/xy"
+import { NetworkCustomChart } from "semiotic/network"
+import { unstable_fromGofishIR } from "semiotic/experimental"
+
+// A GoFish Frontend IR document — the JSON a GoFish to_ir pass emits.
+const flowerIR = {
+  irVersion: 0,
+  ir: "gofish-frontend",
+  root: {
+    type: "layer",
+    charts: [
+      {
+        type: "chart",
+        data: { type: "inline", rows: seafood },
+        operators: [{ type: "scatter", by: "lake", x: { type: "field", name: "x" } }],
+        mark: { type: "rect", origin: { name: "stems" }, w: 4, h: { type: "field", name: "count" } },
+      },
+      {
+        type: "chart",
+        data: { type: "select", layer: "stems" },
+        operators: [{ type: "group", by: "datum.lake" }],
+        mark: {
+          type: "spread", __combinator: true, options: { dir: "y" },
+          children: [{
+            type: "layer", __combinator: true, options: { coord: { type: "polar" } },
+            children: [{
+              type: "stack", __combinator: true, options: { dir: "x", sharedScale: true },
+              children: [{ type: "petal", w: { type: "field", name: "count" }, fill: { type: "field", name: "species" } }],
+            }],
+          }],
+        },
+      },
+    ],
+  },
+}
+
+function LiveFlower() {
+  const ref = useRef(null)
+  // unstable_fromGofishIR selects the custom frame, derives layoutConfig accessors, and
+  // returns the inline data — no per-chart renderer.
+  const cfg = unstable_fromGofishIR(flowerIR)
+
+  useEffect(() => {
+    ref.current?.clear()
+    ref.current?.pushMany(cfg.data)
+  }, [cfg.data])
+
+  if (cfg.family === "network") {
+    return (
+      <NetworkCustomChart
+        nodes={cfg.graph.nodes}
+        edges={cfg.graph.edges}
+        layout={cfg.networkLayout}
+        layoutConfig={cfg.layoutConfig}
+        frameProps={{ showParticles: true }}
+      />
+    )
+  }
+
+  return (
+    <XYCustomChart
+      ref={ref}
+      data={cfg.data}
+      layout={cfg.layout}
+      layoutConfig={{ ...cfg.layoutConfig, flowerRadius: 34 }}
+      frameProps={{
+        transition: { duration: 650 },
+        staleness: { threshold: 5000, showBadge: true },
+      }}
+      width={880}
+      height={380}
+      responsiveWidth
+      enableHover
+      emptyContent={false}
+    />
+  )
+}`}</CodeBlock>
+      </section>
+    </PageLayout>
+  )
+}
+
+function TargetRow({ label, href, recipe, contract }) {
+  return (
+    <tr>
+      <td style={tdStyle}>
+        <a href={href} target="_blank" rel="noreferrer">
+          {label}
+        </a>
+      </td>
+      <td style={tdStyle}>
+        <code>{recipe}</code>
+      </td>
+      <td style={tdStyle}>{contract}</td>
+    </tr>
+  )
+}
+
+const thStyle = {
+  textAlign: "left",
+  padding: "8px 10px",
+  borderBottomWidth: 1,
+  borderBottomStyle: "solid",
+  borderBottomColor: "var(--border-color, #e0e0e0)",
+}
+
+const smallButtonStyle = {
+  appearance: "none",
+  borderWidth: 1,
+  borderStyle: "solid",
+  borderColor: "var(--border-color, #d8dee4)",
+  background: "var(--surface-1, #fff)",
+  color: "var(--text-primary, #222)",
+  borderRadius: 8,
+  padding: "7px 10px",
+  fontSize: 12,
+  fontWeight: 700,
+  cursor: "pointer",
+}
+
+const tdStyle = {
+  padding: "9px 10px",
+  borderBottomWidth: 1,
+  borderBottomStyle: "solid",
+  borderBottomColor: "var(--border-color, #e0e0e0)",
+  verticalAlign: "top",
+}

--- a/etc/api-surface/semiotic-recipes.api.md
+++ b/etc/api-surface/semiotic-recipes.api.md
@@ -8,10 +8,13 @@ const DEFAULT_AREA_PER_ANNOTATION
 function annotationBudget
 function annotationDensity
 function annotationLayout
+function buildTooltipEntries
 function bulletLayout
 function calendarLayout
 function dagreLayout
+function extractTooltipDatum
 function flextreeLayout
+function formatTooltipValue
 function lineageDagLayout
 function marimekkoLayout
 function parallelCoordinatesLayout
@@ -24,6 +27,8 @@ interface AnnotationLayoutConfig
 interface AnnotationLayoutOptions
 interface BulletConfig
 interface CalendarConfig
+interface CustomTooltipEntry
+interface CustomTooltipEntryOptions
 interface DagreConfig
 interface FlextreeConfig
 interface LayoutContext

--- a/integration-tests/custom-layout-examples/index.html
+++ b/integration-tests/custom-layout-examples/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Custom Layout Regression Tests</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      margin: 0;
+      padding: 20px;
+      background: #f5f5f5;
+    }
+    .test-case {
+      background: white;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+      margin: 0 auto;
+      max-width: 780px;
+      padding: 16px;
+    }
+    .test-case h2 {
+      border-bottom: 2px solid #e0e0e0;
+      color: #333;
+      font-size: 16px;
+      margin: 0 0 10px;
+      padding-bottom: 8px;
+    }
+    .controls {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 10px;
+    }
+    .responsive-shell {
+      width: 100%;
+    }
+  </style>
+</head>
+<body>
+  <h1>Custom Layout Regression Tests</h1>
+  <div id="root"></div>
+  <script type="module" src="./index.js"></script>
+</body>
+</html>

--- a/integration-tests/custom-layout-examples/index.js
+++ b/integration-tests/custom-layout-examples/index.js
@@ -1,0 +1,163 @@
+import * as Semiotic from "../../dist/semiotic.module.min.js"
+import React, { useState } from "react"
+import { createRoot } from "react-dom/client"
+
+const { ThemeProvider, XYCustomChart } = Semiotic
+
+const seafoodData = [
+  { lake: "Erie", species: "Walleye", count: 48, x: 0 },
+  { lake: "Erie", species: "Perch", count: 31, x: 0 },
+  { lake: "Erie", species: "Trout", count: 16, x: 0 },
+  { lake: "Huron", species: "Walleye", count: 26, x: 1 },
+  { lake: "Huron", species: "Perch", count: 18, x: 1 },
+  { lake: "Huron", species: "Trout", count: 35, x: 1 },
+  { lake: "Michigan", species: "Walleye", count: 18, x: 2 },
+  { lake: "Michigan", species: "Perch", count: 42, x: 2 },
+  { lake: "Michigan", species: "Trout", count: 27, x: 2 },
+  { lake: "Ontario", species: "Walleye", count: 22, x: 3 },
+  { lake: "Ontario", species: "Perch", count: 21, x: 3 },
+  { lake: "Ontario", species: "Trout", count: 43, x: 3 },
+  { lake: "Superior", species: "Walleye", count: 14, x: 4 },
+  { lake: "Superior", species: "Perch", count: 24, x: 4 },
+  { lake: "Superior", species: "Trout", count: 57, x: 4 },
+]
+
+function stableId(value) {
+  return String(value).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "item"
+}
+
+function responsiveFlowerLayout(ctx) {
+  const plot = ctx.dimensions.plot
+  const radius = ctx.config.flowerRadius || 32
+  const stemWidth = ctx.config.stemWidth || 5
+  const grouped = new Map()
+  for (const row of ctx.data) {
+    const key = String(row.lake)
+    if (!grouped.has(key)) grouped.set(key, [])
+    grouped.get(key).push(row)
+  }
+  const lakes = Array.from(grouped.keys())
+  const maxTotal = Math.max(
+    1,
+    ...lakes.map((lake) => grouped.get(lake).reduce((sum, row) => sum + Number(row.count || 0), 0))
+  )
+  const baseY = plot.y + plot.height - 28
+  const xPad = Math.min(plot.width / 2, Math.max(radius * 1.8, plot.width * 0.12))
+  const xStart = plot.x + xPad
+  const xEnd = plot.x + plot.width - xPad
+  const nodes = []
+  const overlays = []
+
+  lakes.forEach((lake, index) => {
+    const rows = grouped.get(lake)
+    const total = rows.reduce((sum, row) => sum + Number(row.count || 0), 0)
+    const x = lakes.length === 1 ? plot.x + plot.width / 2 : xStart + index * ((xEnd - xStart) / (lakes.length - 1))
+    const stemHeight = (plot.height * 0.2) + (plot.height * 0.32) * (total / maxTotal)
+    const flowerY = baseY - stemHeight
+    const id = stableId(lake)
+
+    nodes.push({
+      type: "rect",
+      x: x - stemWidth,
+      y: flowerY,
+      w: stemWidth * 2,
+      h: stemHeight,
+      style: { fill: "rgba(0,0,0,0)", stroke: "none" },
+      datum: { lake, total },
+      group: lake,
+      _transitionKey: `flower-hit-${id}`,
+    })
+
+    overlays.push(
+      React.createElement("rect", {
+        key: `stem-${id}`,
+        "data-gofish-id": `flower-stem-${id}`,
+        x: x - stemWidth / 2,
+        y: flowerY,
+        width: stemWidth,
+        height: stemHeight,
+        rx: stemWidth / 2,
+        fill: "#2f8f46",
+      }),
+      React.createElement("circle", {
+        key: `center-${id}`,
+        "data-gofish-id": `flower-center-${id}`,
+        cx: x,
+        cy: flowerY,
+        r: Math.max(5, radius * 0.18),
+        fill: "#f6d365",
+        stroke: "rgba(0,0,0,0.25)",
+        strokeWidth: 0.6,
+      })
+    )
+  })
+
+  return {
+    nodes,
+    overlays: React.createElement(
+      "g",
+      { className: "semiotic-custom-flower-layer", style: { pointerEvents: "none" } },
+      overlays
+    ),
+  }
+}
+
+function TestCase({ title, testId, children }) {
+  return React.createElement(
+    "div",
+    { className: "test-case", "data-testid": testId },
+    React.createElement("h2", null, title),
+    children
+  )
+}
+
+function ResponsiveFlowerFixture() {
+  const [radius, setRadius] = useState(32)
+
+  return React.createElement(
+    TestCase,
+    { title: "Flower custom layout — responsive overlays", testId: "gofish-flower-responsive" },
+    React.createElement(
+      "div",
+      { className: "controls" },
+      React.createElement(
+        "button",
+        {
+          type: "button",
+          "data-testid": "radius-plus",
+          onClick: () => setRadius((prev) => prev + 4),
+        },
+        "Increase radius"
+      ),
+      React.createElement("span", { "data-testid": "radius-value" }, `${radius}px`)
+    ),
+    React.createElement(
+      "div",
+      { className: "responsive-shell" },
+      React.createElement(XYCustomChart, {
+        data: seafoodData,
+        layout: responsiveFlowerLayout,
+        layoutConfig: { flowerRadius: radius, stemWidth: 5 },
+        width: 760,
+        height: 360,
+        responsiveWidth: true,
+        margin: { top: 20, right: 24, bottom: 42, left: 24 },
+        colorScheme: ["#4e79a7", "#f28e2c", "#59a14f"],
+        enableHover: true,
+        frameProps: {
+          transition: { duration: 450, easing: "ease-out" },
+        },
+      })
+    )
+  )
+}
+
+function App() {
+  return React.createElement(
+    ThemeProvider,
+    { theme: "light" },
+    React.createElement(ResponsiveFlowerFixture)
+  )
+}
+
+createRoot(document.getElementById("root")).render(React.createElement(App))

--- a/integration-tests/custom-layout.spec.ts
+++ b/integration-tests/custom-layout.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect, type Page } from "@playwright/test"
+import { waitForRafs } from "./helpers"
+
+async function waitForFlowerFixtureReady(page: Page): Promise<void> {
+  const fixture = page.locator('[data-testid="gofish-flower-responsive"]')
+  await expect(fixture).toBeVisible()
+  await page.waitForFunction(() => {
+    const root = document.querySelector('[data-testid="gofish-flower-responsive"]')
+    const hasCanvas = Boolean(root?.querySelector("canvas"))
+    const flowerCenters = root?.querySelectorAll('circle[data-gofish-id^="flower-center-"]').length ?? 0
+    return hasCanvas && flowerCenters >= 5
+  })
+  await waitForRafs(page, 3)
+}
+
+async function expectFlowerCentersAligned(page: Page): Promise<void> {
+  const pairs = await page.locator('[data-testid="gofish-flower-responsive"]').evaluate((root) => {
+    const centers = Array.from(
+      root.querySelectorAll('circle[data-gofish-id^="flower-center-"]')
+    ) as SVGCircleElement[]
+    const stems = Array.from(
+      root.querySelectorAll('rect[data-gofish-id^="flower-stem-"]')
+    ) as SVGRectElement[]
+    const stemCenters = new Map(
+      stems.map((stem) => {
+        const id = stem.getAttribute("data-gofish-id") ?? ""
+        const lake = id.replace(/^flower-stem-/, "")
+        const x = Number(stem.getAttribute("x"))
+        const width = Number(stem.getAttribute("width"))
+        return [lake, x + width / 2]
+      })
+    )
+
+    return centers.map((center) => {
+      const id = center.getAttribute("data-gofish-id") ?? ""
+      const lake = id.replace(/^flower-center-/, "")
+      const flowerX = Number(center.getAttribute("cx"))
+      const stemX = stemCenters.get(lake) ?? Number.NaN
+      return { lake, dx: Math.abs(flowerX - stemX), flowerX, stemX }
+    })
+  })
+
+  expect(pairs.length).toBeGreaterThan(0)
+  for (const pair of pairs) {
+    expect(pair.dx, `${pair.lake}: flower ${pair.flowerX}, stem ${pair.stemX}`).toBeLessThan(0.01)
+  }
+}
+
+test("custom layout overlays stay aligned through responsive resize and transitions", async ({ page }) => {
+  const pageErrors: string[] = []
+  const consoleErrors: string[] = []
+
+  page.on("pageerror", (err) => pageErrors.push(err.message))
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text())
+  })
+
+  await page.goto("/custom-layout-examples/")
+  await waitForFlowerFixtureReady(page)
+  await expectFlowerCentersAligned(page)
+
+  await page.setViewportSize({ width: 620, height: 800 })
+  await waitForRafs(page, 8)
+  await expectFlowerCentersAligned(page)
+
+  await page.getByTestId("radius-plus").click()
+  await waitForRafs(page, 12)
+  await expectFlowerCentersAligned(page)
+
+  expect(pageErrors).toEqual([])
+  expect(consoleErrors).toEqual([])
+})

--- a/integration-tests/index.html
+++ b/integration-tests/index.html
@@ -103,6 +103,12 @@
         Tests streaming push API color, legend, tooltip, and stability regressions (3.1.0 click-testing fixes)
       </div>
     </li>
+    <li>
+      <a href="/custom-layout-examples/">Custom Layout Regression Tests</a>
+      <div class="description">
+        Tests custom layouts with overlays, responsiveWidth, and transitions enabled
+      </div>
+    </li>
   </ul>
 
   <h2>Running the Tests</h2>

--- a/package.json
+++ b/package.json
@@ -84,6 +84,12 @@
       "require": "./dist/semiotic-recipes.min.js",
       "default": "./dist/semiotic-recipes.module.min.js"
     },
+    "./experimental": {
+      "types": "./dist/semiotic-experimental.d.ts",
+      "import": "./dist/semiotic-experimental.module.min.js",
+      "require": "./dist/semiotic-experimental.min.js",
+      "default": "./dist/semiotic-experimental.module.min.js"
+    },
     "./value": {
       "types": "./dist/semiotic-value.d.ts",
       "import": "./dist/semiotic-value.module.min.js",
@@ -123,8 +129,8 @@
     "bench:baseline": "node scripts/save-bench-baseline.mjs",
     "bench:compare": "node scripts/compare-bench-baseline.mjs",
     "bench:pr-vs-main": "node scripts/bench-pr-vs-main.mjs",
-    "serve-examples": "npm run dist && parcel serve integration-tests/index.html integration-tests/xy-examples/index.html integration-tests/ordinal-examples/index.html integration-tests/network-examples/index.html integration-tests/hoc-legend-examples/index.html integration-tests/coordinated-examples/index.html integration-tests/accessibility-examples/index.html integration-tests/geo-examples/index.html integration-tests/realtime-examples/index.html integration-tests/streaming-regression-examples/index.html integration-tests/themed-examples/index.html integration-tests/background-graphics-examples/index.html integration-tests/histogram-theme-stroke-examples/index.html integration-tests/primitive-theme-matrix-examples/index.html integration-tests/status-scale-theme-examples/index.html integration-tests/primitive-props-examples/index.html integration-tests/chart-modes-examples/index.html integration-tests/ssr-parity-examples/index.html integration-tests/process-sankey-examples/index.html --dist-dir .parcel-cache/integration-tests",
-    "serve-examples:ci": "parcel serve integration-tests/index.html integration-tests/xy-examples/index.html integration-tests/ordinal-examples/index.html integration-tests/network-examples/index.html integration-tests/hoc-legend-examples/index.html integration-tests/coordinated-examples/index.html integration-tests/accessibility-examples/index.html integration-tests/geo-examples/index.html integration-tests/realtime-examples/index.html integration-tests/streaming-regression-examples/index.html integration-tests/themed-examples/index.html integration-tests/background-graphics-examples/index.html integration-tests/histogram-theme-stroke-examples/index.html integration-tests/primitive-theme-matrix-examples/index.html integration-tests/status-scale-theme-examples/index.html integration-tests/primitive-props-examples/index.html integration-tests/chart-modes-examples/index.html integration-tests/ssr-parity-examples/index.html integration-tests/process-sankey-examples/index.html --dist-dir .parcel-cache/integration-tests",
+    "serve-examples": "npm run dist && parcel serve integration-tests/index.html integration-tests/xy-examples/index.html integration-tests/ordinal-examples/index.html integration-tests/network-examples/index.html integration-tests/hoc-legend-examples/index.html integration-tests/coordinated-examples/index.html integration-tests/accessibility-examples/index.html integration-tests/geo-examples/index.html integration-tests/realtime-examples/index.html integration-tests/streaming-regression-examples/index.html integration-tests/themed-examples/index.html integration-tests/background-graphics-examples/index.html integration-tests/histogram-theme-stroke-examples/index.html integration-tests/primitive-theme-matrix-examples/index.html integration-tests/status-scale-theme-examples/index.html integration-tests/primitive-props-examples/index.html integration-tests/chart-modes-examples/index.html integration-tests/ssr-parity-examples/index.html integration-tests/process-sankey-examples/index.html integration-tests/custom-layout-examples/index.html --dist-dir .parcel-cache/integration-tests",
+    "serve-examples:ci": "parcel serve integration-tests/index.html integration-tests/xy-examples/index.html integration-tests/ordinal-examples/index.html integration-tests/network-examples/index.html integration-tests/hoc-legend-examples/index.html integration-tests/coordinated-examples/index.html integration-tests/accessibility-examples/index.html integration-tests/geo-examples/index.html integration-tests/realtime-examples/index.html integration-tests/streaming-regression-examples/index.html integration-tests/themed-examples/index.html integration-tests/background-graphics-examples/index.html integration-tests/histogram-theme-stroke-examples/index.html integration-tests/primitive-theme-matrix-examples/index.html integration-tests/status-scale-theme-examples/index.html integration-tests/primitive-props-examples/index.html integration-tests/chart-modes-examples/index.html integration-tests/ssr-parity-examples/index.html integration-tests/process-sankey-examples/index.html integration-tests/custom-layout-examples/index.html --dist-dir .parcel-cache/integration-tests",
     "dist": "node --max-old-space-size=8192 scripts/build.mjs",
     "dist:prod": "node --max-old-space-size=8192 scripts/build.mjs --production",
     "lint": "eslint src",
@@ -197,6 +203,7 @@
     "semiotic": "./src/components/semiotic.ts",
     "semiotic/ai": "./src/components/semiotic-ai.ts",
     "semiotic/data": "./src/components/semiotic-data.ts",
+    "semiotic/experimental": "./src/components/semiotic-experimental.ts",
     "semiotic/geo": "./src/components/semiotic-geo.ts",
     "semiotic/network": "./src/components/semiotic-network.ts",
     "semiotic/ordinal": "./src/components/semiotic-ordinal.ts",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -228,6 +228,18 @@ async function createBundle(options = {}) {
   }
 }
 
+async function createBundlesWithConcurrency(bundles, concurrency) {
+  const workers = Array.from(
+    { length: Math.min(concurrency, bundles.length) },
+    async (_, workerIndex) => {
+      for (let i = workerIndex; i < bundles.length; i += concurrency) {
+        await createBundle(bundles[i])
+      }
+    }
+  )
+  await Promise.all(workers)
+}
+
 function buildDeclarations() {
   try {
     execSync("npx tsc -p tsconfig.declarations.json", { stdio: "inherit" })
@@ -315,6 +327,10 @@ async function build() {
 
   const minify = isProduction
   const analyze = isAnalyze
+  const requestedConcurrency = Number.parseInt(process.env.SEMIOTIC_BUILD_CONCURRENCY ?? "2", 10)
+  const bundleConcurrency = Number.isFinite(requestedConcurrency) && requestedConcurrency > 0
+    ? requestedConcurrency
+    : 2
 
   // Three categories drive the post-build directive-placement gate:
   //   serverOnly: true   — must NOT carry "use client" (semiotic/server)
@@ -362,10 +378,14 @@ async function build() {
     { input: "src/components/semiotic-value.ts", name: "semiotic-value", analyze: false, minify, clientOnly: true }
   ]
 
-  await Promise.all([
-    ...bundles.map(b => createBundle(b)),
-    buildDeclarations()
-  ])
+  buildDeclarations()
+
+  // Rollup keeps a full module graph per active bundle. Starting every entry
+  // point at once can push CI over the 8GB Node heap when a temporary preview
+  // bundle is added, so keep peak memory bounded while still allowing local
+  // callers to opt into more parallelism.
+  console.log(`Bundling ${bundles.length} entry points with concurrency ${bundleConcurrency}`)
+  await createBundlesWithConcurrency(bundles, bundleConcurrency)
 
   createLegacyAliases(bundles)
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -247,7 +247,7 @@ function buildDeclarations() {
     "semiotic", "semiotic-ai", "semiotic-data", "semiotic-xy",
     "semiotic-ordinal", "semiotic-network", "semiotic-realtime", "semiotic-server",
     "semiotic-geo", "semiotic-themes", "semiotic-utils", "semiotic-recipes",
-    "semiotic-value"
+    "semiotic-experimental", "semiotic-value"
   ]
   for (const name of entryPoints) {
     const src = `dist/components/${name}.d.ts`
@@ -352,6 +352,10 @@ async function build() {
     { input: "src/components/semiotic-themes.ts", name: "semiotic-themes", analyze: false, minify },
     { input: "src/components/semiotic-utils.ts", name: "semiotic-utils", analyze: false, minify },
     { input: "src/components/semiotic-recipes.ts", name: "semiotic-recipes", analyze: false, minify },
+    // Unstable preview surface for adapters such as GoFish. It is packaged so
+    // collaborators can test it, but CI/docs gates intentionally ignore it as a
+    // stable API contract.
+    { input: "src/components/semiotic-experimental.ts", name: "semiotic-experimental", analyze: false, minify },
     // `semiotic-value` is a plain-React HOC bundle — single component
     // (BigNumber) plus pure formatting/threshold helpers. Client-only
     // because BigNumber uses useState/useEffect/useImperativeHandle.
@@ -388,9 +392,10 @@ async function build() {
  *   sub-path would crash with browser-API errors at runtime ("window
  *   is not defined", etc.).
  *
- * - **Neither** — agnostic. Pure-function bundles (`semiotic/data`,
- *   `semiotic/recipes`) contain no React component code, so they
- *   neither need nor harm from the directive. Skip them.
+ * - **Neither** — agnostic. Pure-function or preview bundles
+ *   (`semiotic/data`, `semiotic/recipes`, `semiotic/experimental`) contain
+ *   no client-only React component code, so they neither need nor harm from
+ *   the directive. Skip them.
  *
  * Reading the file synchronously is cheap (we just wrote them) and
  * lets the build fail fast with a clear diagnostic.

--- a/scripts/check-context7.mjs
+++ b/scripts/check-context7.mjs
@@ -18,10 +18,12 @@
  *      repo on a missing folder, which surfaces internal docs the
  *      `folders` allowlist was meant to curate out.
  *
- *   3. Sub-path drift — rule 0 enumerates the public sub-path imports
- *      (`semiotic/xy`, `semiotic/ordinal`, etc.). When `package.json`
- *      exports a new sub-path, the rule should mention it; when an
- *      export disappears, the rule must drop the stale name.
+ *   3. Sub-path drift — rule 0 enumerates the stable public sub-path
+ *      imports (`semiotic/xy`, `semiotic/ordinal`, etc.). When
+ *      `package.json` exports a new stable sub-path, the rule should
+ *      mention it; when an export disappears, the rule must drop the
+ *      stale name. Temporary experimental sub-paths are intentionally
+ *      ignored.
  *
  * Run via `npm run check:context7`. Wired into release/prepublish and
  * the CI workflow so a stale manifest can't merge unnoticed.
@@ -103,9 +105,13 @@ if (Array.isArray(manifest.folders)) {
 // every sub-path package.json exports also appears in the rule, and
 // that the rule doesn't name a sub-path that has been removed.
 const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"))
+// Experimental preview subpaths are intentionally omitted from Context7 so
+// agents do not treat temporary collaborator APIs as stable import guidance.
+const IGNORED_SUBPATHS = new Set(["experimental"])
 const exportedSubpaths = Object.keys(pkg.exports || {})
   .filter((k) => k.startsWith("./") && k !== "./package.json")
   .map((k) => k.slice(2))
+  .filter((k) => !IGNORED_SUBPATHS.has(k))
 
 const subpathRule = (manifest.rules || []).find((r) => r.includes("sub-path"))
 if (!subpathRule) {

--- a/scripts/generate-api-surface.mjs
+++ b/scripts/generate-api-surface.mjs
@@ -21,6 +21,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(__dirname, "..")
 
 // Map of entry-point name → its built `.d.ts` file.
+// `semiotic-experimental` is intentionally omitted: that sub-path is packaged
+// for collaborator previews, but is not a stable API contract for CI snapshots.
 const ENTRIES = {
   semiotic: "dist/semiotic.d.ts",
   "semiotic-xy": "dist/semiotic-xy.d.ts",

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -54,6 +54,11 @@ const ROUTE_META = {
     description:
       "Semiotic features: streaming push API, animated transitions, accessibility, annotations, coordinated views, themed CSS variables, SSR, and AI-facing tooling.",
   },
+  "features/gofish-layouts": {
+    title: "Experimental GoFish Adapter — Semiotic",
+    description:
+      "Temporary PR preview for rendering GoFish Frontend IR through Semiotic custom layouts; not a Semiotic release API contract.",
+  },
   annotations: {
     title: "Annotations — Semiotic",
     description:

--- a/scripts/sync-bundle-sizes.mjs
+++ b/scripts/sync-bundle-sizes.mjs
@@ -4,10 +4,10 @@
  * formats two views (table + bullet list), and upserts them into the
  * docs targets that surface bundle sizes to consumers and AI agents.
  *
- * Source of truth: `package.json#exports` → resolves each subpath to
- *   its `*.module.min.js` artifact under `dist/`. The script never
- *   hand-maintains a list of subpaths — adding a new entry-point in
- *   `package.json` makes the new bundle show up here automatically.
+ * Source of truth: stable `package.json#exports` entries → resolves each
+ *   subpath to its `*.module.min.js` artifact under `dist/`. The script
+ *   intentionally ignores unstable preview exports such as
+ *   `semiotic/experimental`.
  *
  * Marker blocks (same pattern as `generate-ai-behavior-contracts.mjs`):
  *   <!-- semiotic-bundle-sizes:start -->
@@ -44,6 +44,9 @@ const printOnly = args.has("--print")
 
 const MARKER_START = "<!-- semiotic-bundle-sizes:start -->"
 const MARKER_END = "<!-- semiotic-bundle-sizes:end -->"
+// Unstable preview bundles are packaged for collaborators but are intentionally
+// omitted from the consumer-facing bundle-size table and CI drift gate.
+const IGNORED_EXPORTS = new Set(["./experimental"])
 
 // Subpath → short "what's inside" blurb shown in the README table.
 // Keep these short and stable; they describe *which charts/utilities*
@@ -146,11 +149,12 @@ function measure() {
     })
   }
 
-  // Cross-check: every package export key should appear in ORDER
-  // (except the metadata-only `./package.json`). Catches a fresh
-  // export landing without an ORDER + BLURBS update.
+  // Cross-check: every stable package export key should appear in ORDER
+  // (except the metadata-only `./package.json` and explicitly ignored
+  // preview exports). Catches a fresh stable export landing without an
+  // ORDER + BLURBS update.
   for (const subpath of Object.keys(exports)) {
-    if (subpath === "./package.json") continue
+    if (subpath === "./package.json" || IGNORED_EXPORTS.has(subpath)) continue
     if (!ORDER.includes(subpath)) {
       errors.push(`Export ${subpath} is not listed in ORDER (sync-bundle-sizes.mjs)`)
     }

--- a/src/components/charts/shared/useChartSetup.ts
+++ b/src/components/charts/shared/useChartSetup.ts
@@ -81,7 +81,7 @@ export interface ChartSetupInput {
   /** Custom content rendered in place of the default skeleton while `loading` is true. */
   loadingContent?: ReactNode | false
   /** Empty content override */
-  emptyContent?: ReactNode
+  emptyContent?: ReactNode | false
   /** Resolved width from useChartMode */
   width: number
   /** Resolved height from useChartMode */

--- a/src/components/charts/shared/useCustomChartSetup.ts
+++ b/src/components/charts/shared/useCustomChartSetup.ts
@@ -119,7 +119,7 @@ interface DataSetupOptions extends ScaffoldOptions {
   chartId?: string
   loading?: boolean
   loadingContent?: ReactNode | false
-  emptyContent?: ReactNode
+  emptyContent?: ReactNode | false
 }
 
 interface DataSetupResult<TFrameHandle> extends ScaffoldResult<TFrameHandle> {

--- a/src/components/recipes/customTooltip.test.ts
+++ b/src/components/recipes/customTooltip.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildTooltipEntries,
+  extractTooltipDatum,
+  formatTooltipValue,
+} from "./customTooltip"
+
+describe("custom tooltip helpers", () => {
+  it("extracts useful datum fields from wrapped hover payloads", () => {
+    const payload = {
+      datum: {
+        data: {
+          category: "Planning",
+          amount: 72,
+          _transitionKey: "internal",
+          onClick: () => null,
+        },
+      },
+    }
+
+    expect(extractTooltipDatum(payload)).toEqual({
+      category: "Planning",
+      amount: 72,
+    })
+  })
+
+  it("builds filtered key/value entries with labels and max row count", () => {
+    const entries = buildTooltipEntries(
+      {
+        data: {
+          category: "Class 1",
+          value: 124.25,
+          rows: 42,
+          survived: true,
+        },
+      },
+      {
+        labels: { category: "Passenger class" },
+        maxEntries: 2,
+      }
+    )
+
+    expect(entries).toEqual([
+      { key: "category", label: "Passenger class", value: "Class 1", formatted: "Class 1" },
+      { key: "value", label: "value", value: 124.25, formatted: "124.25" },
+    ])
+  })
+
+  it("formats common tooltip values", () => {
+    expect(formatTooltipValue(7)).toBe("7")
+    expect(formatTooltipValue(false)).toBe("false")
+    expect(formatTooltipValue(["a", "b"])).toBe("2 items")
+    expect(formatTooltipValue({ id: "x" })).toBe('{"id":"x"}')
+  })
+})

--- a/src/components/recipes/customTooltip.ts
+++ b/src/components/recipes/customTooltip.ts
@@ -1,0 +1,128 @@
+import type { Datum } from "../charts/shared/datumTypes"
+
+export interface CustomTooltipEntry {
+  key: string
+  label: string
+  value: unknown
+  formatted: string
+}
+
+export interface CustomTooltipEntryOptions {
+  /** Maximum number of rows to return. @default 8 */
+  maxEntries?: number
+  /** Extra keys to omit in addition to underscore-prefixed internals. */
+  excludeKeys?: readonly string[] | Set<string>
+  /** Include underscore-prefixed keys. @default false */
+  includeInternal?: boolean
+  /** Include null, undefined, and empty-string values. @default false */
+  includeEmpty?: boolean
+  /** Optional display labels by key. */
+  labels?: Record<string, string> | ((key: string) => string)
+  /** Optional value formatter. */
+  valueFormat?: (value: unknown, key: string, datum: Record<string, unknown>) => string
+}
+
+const DEFAULT_EXCLUDED_KEYS = new Set(["rows"])
+
+/**
+ * Extract the user-facing datum from Semiotic hover/observation payloads.
+ *
+ * Custom charts can surface hover payloads as `hover.datum`,
+ * `hover.datum.data`, `hover.data`, or `hover.data.data` depending on the
+ * frame family and scene node type. This helper normalizes those shapes and
+ * drops internal/function fields so tooltips do not render empty chrome.
+ */
+export function extractTooltipDatum(payload: unknown): Record<string, unknown> | null {
+  const p = payload as Record<string, unknown> | null | undefined
+  const candidates = [
+    getPath(p, ["datum", "data"]),
+    getPath(p, ["datum"]),
+    getPath(p, ["data", "data"]),
+    getPath(p, ["data"]),
+    getPath(p, ["node", "datum", "data"]),
+    getPath(p, ["node", "datum"]),
+    payload,
+  ]
+
+  for (const candidate of candidates) {
+    if (!isRecord(candidate)) continue
+    const out: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(candidate)) {
+      if (key.startsWith("_") || typeof value === "function") continue
+      out[key] = value
+    }
+    if (Object.keys(out).length > 0) return out
+  }
+  return null
+}
+
+export function buildTooltipEntries(
+  payload: unknown,
+  options: CustomTooltipEntryOptions = {}
+): CustomTooltipEntry[] {
+  const datum = extractTooltipDatum(payload)
+  if (!datum) return []
+
+  const exclude = new Set(DEFAULT_EXCLUDED_KEYS)
+  if (options.excludeKeys) {
+    for (const key of options.excludeKeys) exclude.add(key)
+  }
+
+  const entries: CustomTooltipEntry[] = []
+  for (const [key, value] of Object.entries(datum)) {
+    if (!options.includeInternal && key.startsWith("_")) continue
+    if (exclude.has(key)) continue
+    if (!options.includeEmpty && (value == null || value === "")) continue
+    if (typeof value === "function") continue
+
+    entries.push({
+      key,
+      label: tooltipLabel(key, options.labels),
+      value,
+      formatted: options.valueFormat
+        ? options.valueFormat(value, key, datum)
+        : formatTooltipValue(value),
+    })
+    if (entries.length >= (options.maxEntries ?? 8)) break
+  }
+  return entries
+}
+
+export function formatTooltipValue(value: unknown): string {
+  if (value == null) return ""
+  if (value instanceof Date) return value.toISOString()
+  if (typeof value === "number") {
+    return Number.isInteger(value)
+      ? String(value)
+      : value.toLocaleString(undefined, { maximumFractionDigits: 2 })
+  }
+  if (typeof value === "boolean") return value ? "true" : "false"
+  if (Array.isArray(value)) return `${value.length} items`
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+  return String(value)
+}
+
+function tooltipLabel(key: string, labels?: CustomTooltipEntryOptions["labels"]): string {
+  if (typeof labels === "function") return labels(key)
+  if (labels && labels[key]) return labels[key]
+  return key
+}
+
+function getPath(source: Record<string, unknown> | null | undefined, path: string[]): unknown {
+  let current: unknown = source
+  for (const key of path) {
+    if (!isRecord(current)) return undefined
+    current = current[key]
+  }
+  return current
+}
+
+function isRecord(value: unknown): value is Datum {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/src/components/recipes/gofish.test.ts
+++ b/src/components/recipes/gofish.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest"
+import { scaleLinear } from "d3-scale"
+import {
+  buildPythonTutorMemoryGraph,
+  createGofishGlyphLayout,
+  gofishBottleFillLayout,
+  gofishFlowerLayout,
+  gofishPolarRibbonLayout,
+  gofishPythonTutorLayout,
+  gofishPythonTutorNetworkLayout,
+  gofishTitanicCircleTreemapLayout,
+} from "./gofish"
+import type { LayoutContext } from "../stream/customLayout"
+import type { PointSceneNode, RectSceneNode, SceneNode } from "../stream/types"
+import type { NetworkLayoutContext } from "../stream/networkCustomLayout"
+import type { RealtimeEdge, RealtimeNode } from "../stream/networkTypes"
+
+function makeCtx<C extends object>(config: C, overrides?: Partial<LayoutContext<C>>): LayoutContext<C> {
+  const x = scaleLinear().domain([0, 100]).range([0, 500])
+  const y = scaleLinear().domain([0, 100]).range([320, 0])
+  return {
+    data: [],
+    scales: { x, y } as unknown as LayoutContext["scales"],
+    dimensions: {
+      width: 500,
+      height: 320,
+      margin: { top: 0, right: 0, bottom: 0, left: 0 },
+      plot: { x: 0, y: 0, width: 500, height: 320 },
+    },
+    theme: {
+      semantic: { primary: "#4e79a7", success: "#2e7d32", danger: "#c62828", surface: "#eee" },
+      categorical: ["#4e79a7", "#f28e2c", "#e15759", "#76b7b2"],
+    },
+    resolveColor: (group) => {
+      const palette = ["#4e79a7", "#f28e2c", "#e15759", "#76b7b2", "#59a14f"]
+      let hash = 0
+      for (let i = 0; i < group.length; i++) hash = (hash * 31 + group.charCodeAt(i)) | 0
+      return palette[Math.abs(hash) % palette.length]
+    },
+    config,
+    ...overrides,
+  }
+}
+
+function makeNetworkCtx<C extends object>(
+  config: C,
+  overrides?: Partial<NetworkLayoutContext<C>>
+): NetworkLayoutContext<C> {
+  return {
+    nodes: [],
+    edges: [],
+    dimensions: {
+      width: 600,
+      height: 340,
+      plot: { x: 0, y: 0, width: 600, height: 340 },
+    },
+    theme: {
+      semantic: { primary: "#4e79a7", success: "#2e7d32", danger: "#c62828", surface: "#eee" },
+      categorical: ["#4e79a7", "#f28e2c", "#e15759", "#76b7b2"],
+    },
+    resolveColor: (key) => key === "heap" ? "#59a14f" : "#4e79a7",
+    config,
+    selection: null,
+    ...overrides,
+  }
+}
+
+const seafood = [
+  { lake: "Erie", species: "Trout", count: 42, x: 0 },
+  { lake: "Erie", species: "Perch", count: 28, x: 0 },
+  { lake: "Huron", species: "Trout", count: 31, x: 1 },
+  { lake: "Huron", species: "Bass", count: 22, x: 1 },
+  { lake: "Michigan", species: "Perch", count: 35, x: 2 },
+  { lake: "Michigan", species: "Bass", count: 18, x: 2 },
+]
+
+function isRectNode(node: SceneNode): node is RectSceneNode {
+  return node.type === "rect"
+}
+
+function isPointNode(node: SceneNode): node is PointSceneNode {
+  return node.type === "point"
+}
+
+describe("createGofishGlyphLayout", () => {
+  it("compiles interactive glyph marks to Semiotic scene nodes and leaves chrome as overlays", () => {
+    const layout = createGofishGlyphLayout(() => ({
+      marks: [
+        { kind: "rect", id: "r", x: 10, y: 20, width: 30, height: 40, datum: { id: "r" } },
+        { kind: "circle", id: "c", cx: 90, cy: 80, r: 7, datum: { id: "c" } },
+        { kind: "path", id: "p", d: "M0,0L10,10", style: { stroke: "#333" } },
+      ],
+    }))
+
+    const result = layout(makeCtx({}))
+
+    expect(result.nodes?.map((node) => node.type)).toEqual(["rect", "point"])
+    expect(result.nodes?.map((node) => node._transitionKey)).toEqual(["r", "c"])
+    expect(result.overlays).toBeTruthy()
+  })
+})
+
+describe("GoFish-style recipes", () => {
+  it("renders the flower chart as interactive stems plus petal overlays", () => {
+    const result = gofishFlowerLayout(makeCtx({ flowerRadius: 30 }, { data: seafood }))
+    const nodes = result.nodes ?? []
+
+    expect(nodes.filter((node) => node.type === "rect")).toHaveLength(3)
+    expect(nodes.every((node) => node.datum != null)).toBe(true)
+    expect(result.overlays).toBeTruthy()
+  })
+
+  it("renders the bottle fill chart with one hit target per bottle", () => {
+    const data = [
+      { category: "A", amount: 72 },
+      { category: "B", amount: 48 },
+      { category: "C", amount: 91 },
+    ]
+    const result = gofishBottleFillLayout(makeCtx({ bottleHeight: 180 }, { data }))
+    const nodes = result.nodes ?? []
+    const rects = nodes.filter(isRectNode)
+
+    expect(nodes).toHaveLength(data.length)
+    expect(rects).toHaveLength(data.length)
+    expect(rects.map((node) => node.group)).toEqual(["A", "B", "C"])
+  })
+
+  it("renders the polar ribbon chart with data-bearing hit nodes", () => {
+    const result = gofishPolarRibbonLayout(makeCtx({ outerRadius: 120 }, { data: seafood }))
+    const nodes = result.nodes ?? []
+    const points = nodes.filter(isPointNode)
+
+    expect(nodes).toHaveLength(seafood.length)
+    expect(points).toHaveLength(seafood.length)
+    expect(new Set(points.map((node) => node.datum?.species))).toEqual(new Set(["Trout", "Perch", "Bass"]))
+    expect(result.overlays).toBeTruthy()
+  })
+
+  it("renders the Titanic fare circle treemap as packed passenger circles inside class regions", () => {
+    const data = [
+      { name: "p1-a", pclass: 1, survived: true, fare: 71 },
+      { name: "p1-b", pclass: 1, survived: false, fare: 38 },
+      { name: "p2-a", pclass: 2, survived: true, fare: 26 },
+      { name: "p3-a", pclass: 3, survived: false, fare: 8 },
+      { name: "p3-b", pclass: 3, survived: true, fare: 12 },
+    ]
+    const result = gofishTitanicCircleTreemapLayout(makeCtx({ padding: 1.5 }, { data }))
+    const nodes = result.nodes ?? []
+    const points = nodes.filter(isPointNode)
+
+    expect(points).toHaveLength(data.length)
+    expect(nodes.filter(isRectNode)).toHaveLength(0)
+    expect(new Set(points.map((node) => String(node.datum?.survived)))).toEqual(new Set(["true", "false"]))
+  })
+
+  it("renders the Python Tutor memory diagram as stack and heap scene nodes", () => {
+    const diagram = {
+      stack: [
+        { name: "c", value: { pointer: 0 } },
+        { name: "d", value: { pointer: 1 } },
+        { name: "x", value: "5" },
+      ],
+      heap: [
+        { values: ["12", { pointer: 1 }, "1", "0", { pointer: 2 }, { pointer: 3 }] },
+        { values: ["9", "8"] },
+        { values: ["7", "6"] },
+        { values: ["5", "4"] },
+      ],
+      heapArrangement: [[0, 3, null], [null, 1, 2]],
+    }
+    const result = gofishPythonTutorLayout(makeCtx({ diagram }, { data: [] }))
+    const nodes = result.nodes ?? []
+    const rects = nodes.filter(isRectNode)
+
+    expect(rects.length).toBeGreaterThanOrEqual(7)
+    expect(new Set(rects.map((node) => node.group))).toEqual(new Set(["binding", "heap"]))
+    expect(result.overlays).toBeTruthy()
+  })
+
+  it("renders the Python Tutor memory diagram as a network custom layout with particle-ready edges", () => {
+    const diagram = {
+      stack: [
+        { name: "c", value: { pointer: 0 } },
+        { name: "d", value: { pointer: 1 } },
+        { name: "x", value: "5" },
+      ],
+      heap: [
+        { values: ["12", { pointer: 1 }, "1", "0", { pointer: 2 }, { pointer: 3 }] },
+        { values: ["9", "8"] },
+        { values: ["7", "6"] },
+        { values: ["5", "4"] },
+      ],
+      heapArrangement: [[0, 3, null], [null, 1, 2]],
+    }
+    const graph = buildPythonTutorMemoryGraph(diagram)
+    const nodes = graph.nodes.map((node) => ({
+      id: String(node.id),
+      data: node,
+      value: 1,
+      x: 0,
+      y: 0,
+      x0: 0,
+      x1: 0,
+      y0: 0,
+      y1: 0,
+      width: 0,
+      height: 0,
+    })) as RealtimeNode[]
+    const edges = graph.edges.map((edge) => ({
+      source: String(edge.source),
+      target: String(edge.target),
+      value: Number(edge.value ?? 1),
+      y0: 0,
+      y1: 0,
+      sankeyWidth: 1,
+      data: edge,
+    })) as RealtimeEdge[]
+
+    const result = gofishPythonTutorNetworkLayout(makeNetworkCtx({ diagram }, { nodes, edges }))
+
+    expect(result.sceneNodes?.filter((node) => node.type === "rect").length).toBeGreaterThan(8)
+    expect(result.sceneEdges).toHaveLength(graph.edges.length)
+    expect(edges.every((edge) => edge.bezier?.points?.length === 4)).toBe(true)
+    expect(result.overlays).toBeTruthy()
+
+    const compact = gofishPythonTutorNetworkLayout(makeNetworkCtx({ diagram, heapGap: 4 }, { nodes, edges }))
+    const spacious = gofishPythonTutorNetworkLayout(makeNetworkCtx({ diagram, heapGap: 34 }, { nodes, edges }))
+    const compactHeap = compact.sceneNodes?.find((node) => node.type === "rect" && node.id === "cell-1-0")
+    const spaciousHeap = spacious.sceneNodes?.find((node) => node.type === "rect" && node.id === "cell-1-0")
+
+    expect(spaciousHeap?.type).toBe("rect")
+    expect(compactHeap?.type).toBe("rect")
+    if (compactHeap?.type === "rect" && spaciousHeap?.type === "rect") {
+      expect(spaciousHeap.y).toBeGreaterThan(compactHeap.y)
+    }
+  })
+})

--- a/src/components/recipes/gofish.tsx
+++ b/src/components/recipes/gofish.tsx
@@ -1,0 +1,1576 @@
+import * as React from "react"
+import type { ReactNode } from "react"
+import type { CustomLayout, LayoutContext } from "../stream/customLayout"
+import type { NetworkCustomLayout } from "../stream/networkCustomLayout"
+import type { Datum } from "../charts/shared/datumTypes"
+import type {
+  AreaSceneNode,
+  PointSceneNode,
+  RectSceneNode,
+  SceneNode,
+  Style,
+} from "../stream/types"
+import type {
+  BezierCache,
+  BezierPoint,
+  NetworkCurvedEdge,
+  NetworkRectNode,
+  RealtimeEdge,
+  RealtimeNode,
+} from "../stream/networkTypes"
+import { createSafeDatum, resolveAccessor } from "./recipeUtils"
+
+export type GofishGlyphMark =
+  | {
+      kind: "rect"
+      id: string
+      x: number
+      y: number
+      width: number
+      height: number
+      style?: Style
+      datum?: Datum
+      group?: string
+      interactive?: boolean
+      rx?: number
+      /** Clip this mark to an SVG path (pixel coords) — e.g. a fill to a silhouette. */
+      clipPath?: string
+    }
+  | {
+      kind: "image"
+      id: string
+      x: number
+      y: number
+      width: number
+      height: number
+      href: string
+      /** @default "none" — stretch to the box; "xMidYMid meet" to letterbox. */
+      preserveAspectRatio?: string
+      opacity?: number
+      /** Clip the image to an SVG path (pixel coords). */
+      clipPath?: string
+    }
+  | {
+      kind: "circle"
+      id: string
+      cx: number
+      cy: number
+      r: number
+      style?: Style
+      datum?: Datum
+      group?: string
+      interactive?: boolean
+    }
+  | {
+      kind: "area"
+      id: string
+      topPath: [number, number][]
+      bottomPath: [number, number][]
+      style?: Style
+      datum?: Datum[]
+      group?: string
+    }
+  | {
+      kind: "path"
+      id: string
+      d: string
+      style?: Style
+      datum?: Datum
+      group?: string
+      clipPath?: string
+    }
+  | {
+      kind: "line"
+      id: string
+      x1: number
+      y1: number
+      x2: number
+      y2: number
+      style?: Style
+    }
+  | {
+      kind: "text"
+      id: string
+      x: number
+      y: number
+      text: ReactNode
+      style?: Style
+      fontSize?: number
+      fontWeight?: number | string
+      textAnchor?: "start" | "middle" | "end"
+      dominantBaseline?: React.SVGProps<SVGTextElement>["dominantBaseline"]
+      transform?: string
+    }
+
+export interface GofishGlyphLayer {
+  marks: GofishGlyphMark[]
+  overlays?: ReactNode
+}
+
+export interface HitRectForGlyphOptions {
+  id: string
+  x: number
+  y: number
+  width: number
+  height: number
+  datum?: Datum
+  group?: string
+  style?: Style
+  rx?: number
+}
+
+export type GofishGlyphSolver<C extends object> = (
+  ctx: LayoutContext<C>
+) => GofishGlyphLayer
+
+export function hitRectForGlyph(options: HitRectForGlyphOptions): GofishGlyphMark {
+  return {
+    kind: "rect",
+    id: options.id,
+    x: options.x,
+    y: options.y,
+    width: options.width,
+    height: options.height,
+    style: { fill: "rgba(0,0,0,0)", stroke: "none", ...options.style },
+    datum: options.datum,
+    group: options.group,
+    rx: options.rx,
+  }
+}
+
+export function overlayGroup(children: ReactNode, className = "semiotic-gofish-glyph-layer"): ReactNode {
+  return (
+    <g className={className} style={{ pointerEvents: "none" }}>
+      {children}
+    </g>
+  )
+}
+
+/**
+ * Compile a small GoFish-style mark vocabulary to a Semiotic custom layout.
+ *
+ * Rects, circles, and areas become normal scene nodes when interactive is not
+ * false, so Semiotic owns hit testing, transitions, decay, SSR evidence, and
+ * tooltips. Rich glyph chrome such as petal paths, labels, bottle silhouettes,
+ * and arrows is rendered as pointer-events-none SVG overlay content.
+ */
+export function createGofishGlyphLayout<C extends object>(
+  solve: GofishGlyphSolver<C>
+): CustomLayout<C> {
+  return (ctx) => {
+    const layer = solve(ctx)
+    const nodes: SceneNode[] = []
+    const overlayMarks: ReactNode[] = []
+
+    for (const mark of layer.marks) {
+      if (mark.kind === "rect" && mark.interactive !== false) {
+        const node: RectSceneNode = {
+          type: "rect",
+          x: mark.x,
+          y: mark.y,
+          w: mark.width,
+          h: mark.height,
+          cornerRadii: mark.rx ? { tl: mark.rx, tr: mark.rx, br: mark.rx, bl: mark.rx } : undefined,
+          style: mark.style ?? { fill: ctx.theme.semantic.primary ?? "#4e79a7", stroke: "none" },
+          datum: mark.datum ?? null,
+          group: mark.group,
+          _transitionKey: mark.id,
+        }
+        nodes.push(node)
+      } else if (mark.kind === "circle" && mark.interactive !== false) {
+        const node: PointSceneNode = {
+          type: "point",
+          x: mark.cx,
+          y: mark.cy,
+          r: mark.r,
+          style: mark.style ?? { fill: ctx.theme.semantic.primary ?? "#4e79a7", stroke: "none" },
+          datum: mark.datum ?? null,
+          pointId: mark.id,
+          _transitionKey: mark.id,
+        }
+        nodes.push(node)
+      } else if (mark.kind === "area") {
+        const node: AreaSceneNode = {
+          type: "area",
+          topPath: mark.topPath,
+          bottomPath: mark.bottomPath,
+          style: mark.style ?? { fill: ctx.theme.semantic.primary ?? "#4e79a7", stroke: "none" },
+          datum: mark.datum ?? null,
+          group: mark.group,
+          _transitionKey: mark.id,
+        }
+        nodes.push(node)
+      }
+
+      if (mark.kind !== "area") {
+        overlayMarks.push(renderGlyphMark(mark))
+      }
+    }
+
+    const hasOverlays = overlayMarks.some(Boolean) || layer.overlays != null
+    return {
+      nodes,
+      overlays: hasOverlays
+        ? overlayGroup(
+            <>
+              {overlayMarks}
+              {layer.overlays}
+            </>
+          )
+        : null,
+    }
+  }
+}
+
+export interface GofishFlowerConfig {
+  lakeAccessor?: string | ((d: Datum) => string)
+  speciesAccessor?: string | ((d: Datum) => string)
+  countAccessor?: string | ((d: Datum) => number)
+  xAccessor?: string | ((d: Datum) => number)
+  flowerRadius?: number
+  stemWidth?: number
+}
+
+export interface GofishBottleConfig {
+  categoryAccessor?: string | ((d: Datum) => string)
+  amountAccessor?: string | ((d: Datum) => number)
+  bottleWidth?: number
+  bottleHeight?: number
+}
+
+export interface GofishPolarRibbonConfig {
+  lakeAccessor?: string | ((d: Datum) => string)
+  speciesAccessor?: string | ((d: Datum) => string)
+  countAccessor?: string | ((d: Datum) => number)
+  innerRadius?: number
+  outerRadius?: number
+}
+
+export interface GofishTitanicCircleTreemapConfig {
+  classAccessor?: string | ((d: Datum) => string | number)
+  survivedAccessor?: string | ((d: Datum) => string | number | boolean)
+  fareAccessor?: string | ((d: Datum) => number)
+  padding?: number
+}
+
+export interface PythonTutorPointer {
+  pointer: number
+}
+
+export interface PythonTutorBinding {
+  name: string
+  value: string | PythonTutorPointer
+}
+
+export interface PythonTutorTuple {
+  values: Array<string | PythonTutorPointer>
+}
+
+export interface PythonTutorDiagram {
+  stack: PythonTutorBinding[]
+  heap: PythonTutorTuple[]
+  heapArrangement: Array<Array<number | null>>
+}
+
+export interface GofishPythonTutorConfig {
+  diagram?: PythonTutorDiagram
+  cellWidth?: number
+  cellHeight?: number
+  heapGap?: number
+}
+
+export interface PythonTutorMemoryGraph {
+  nodes: Datum[]
+  edges: Datum[]
+}
+
+export function buildPythonTutorMemoryGraph(diagram: PythonTutorDiagram): PythonTutorMemoryGraph {
+  const nodes: Datum[] = []
+  const edges: Datum[] = []
+
+  diagram.stack.forEach((slot, index) => {
+    nodes.push({
+      id: `binding-${slot.name}`,
+      kind: "binding",
+      index,
+      name: slot.name,
+      value: displayValue(slot.value),
+      pointer: isPointer(slot.value) ? slot.value.pointer : undefined,
+    })
+    if (isPointer(slot.value)) {
+      edges.push({
+        source: `binding-${slot.name}`,
+        target: `cell-${slot.value.pointer}-0`,
+        value: 1,
+        kind: "stack pointer",
+        pointer: slot.value.pointer,
+      })
+    }
+  })
+
+  diagram.heap.forEach((tuple, address) => {
+    tuple.values.forEach((value, cellIndex) => {
+      nodes.push({
+        id: `cell-${address}-${cellIndex}`,
+        kind: "heap cell",
+        address,
+        cellIndex,
+        value: displayValue(value),
+        pointer: isPointer(value) ? value.pointer : undefined,
+      })
+      if (isPointer(value)) {
+        edges.push({
+          source: `cell-${address}-${cellIndex}`,
+          target: `cell-${value.pointer}-0`,
+          value: 1,
+          kind: "heap pointer",
+          pointer: value.pointer,
+        })
+      }
+    })
+  })
+
+  return { nodes, edges }
+}
+
+export const gofishFlowerLayout = createGofishGlyphLayout<GofishFlowerConfig>((ctx) => {
+  const cfg = ctx.config
+  const getLake = resolveAccessor<string>(cfg.lakeAccessor ?? "lake")
+  const getSpecies = resolveAccessor<string>(cfg.speciesAccessor ?? "species")
+  const getCount = resolveAccessor<number>(cfg.countAccessor ?? "count")
+  const getX = resolveAccessor<number>(cfg.xAccessor ?? "x")
+  const plot = ctx.dimensions.plot
+  const radius = cfg.flowerRadius ?? 34
+  const stemW = cfg.stemWidth ?? 4
+  const baseY = plot.y + plot.height - 24
+  const groups = groupBy(ctx.data, (d) => String(getLake(d)))
+  const totals = Array.from(groups.values()).map((rows) => sum(rows, (d) => number(getCount(d))))
+  const maxTotal = Math.max(1, ...totals)
+  const xPad = Math.min(plot.width / 2, Math.max(radius * 1.8, plot.width * 0.12))
+  const xStart = plot.x + xPad
+  const xEnd = plot.x + plot.width - xPad
+  const xValues = ctx.data.map((d) => number(getX(d))).filter(Number.isFinite)
+  const minX = xValues.length ? Math.min(...xValues) : 0
+  const maxX = xValues.length ? Math.max(...xValues) : 1
+  const marks: GofishGlyphMark[] = []
+
+  Array.from(groups.entries()).forEach(([lake, rows], lakeIndex) => {
+    const rowX = rows.map((d) => number(getX(d))).find(Number.isFinite)
+    const hasRowX = typeof rowX === "number" && Number.isFinite(rowX)
+    const x = hasRowX
+      ? lerp(xStart, xEnd, normalize(rowX, minX, maxX))
+      : xStart + lakeIndex * ((xEnd - xStart) / Math.max(1, groups.size - 1))
+    const speciesRows = aggregateRows(rows, (d) => String(getSpecies(d)), (d) => number(getCount(d)), { lake })
+    const total = sum(speciesRows, (d) => d.value)
+    const stemH = lerp(plot.height * 0.18, plot.height * 0.52, total / maxTotal)
+    const flowerY = baseY - stemH
+    const hitW = Math.max(10, stemW + 6)
+    const datum = datumOf({
+      lake,
+      total,
+      kind: "stem",
+    })
+
+    marks.push({
+      kind: "rect",
+      id: `flower-stem-hit-${lake}`,
+      x: x - hitW / 2,
+      y: baseY - stemH,
+      width: hitW,
+      height: stemH,
+      style: { fill: "rgba(0,0,0,0)", stroke: "none" },
+      datum,
+      group: lake,
+      rx: hitW / 2,
+    })
+    marks.push({
+      kind: "rect",
+      id: `flower-stem-${lake}`,
+      x: x - stemW / 2,
+      y: baseY - stemH,
+      width: stemW,
+      height: stemH,
+      style: { fill: ctx.theme.semantic.success ?? "#2f8f46", stroke: "none" },
+      datum,
+      group: lake,
+      rx: stemW / 2,
+      interactive: false,
+    })
+
+    const flowerTotal = Math.max(1, total)
+    let angle = -Math.PI / 2
+    for (const row of speciesRows) {
+      const species = row.key
+      const count = Math.max(0, row.value)
+      const sweep = Math.max(0.16, (count / flowerTotal) * Math.PI * 2)
+      marks.push({
+        kind: "path",
+        id: `flower-petal-${lake}-${species}`,
+        d: petalPath(x, flowerY, radius * 0.18, radius, angle, angle + sweep),
+        style: {
+          fill: ctx.resolveColor(species),
+          fillOpacity: 0.78,
+          stroke: "rgba(255,255,255,0.45)",
+          strokeWidth: 0.7,
+        },
+        datum: row.datum,
+        group: species,
+      })
+      angle += sweep
+    }
+
+    marks.push({
+      kind: "circle",
+      id: `flower-center-${lake}`,
+      cx: x,
+      cy: flowerY,
+      r: Math.max(3, radius * 0.12),
+      style: { fill: "#f6d365", stroke: "rgba(0,0,0,0.25)", strokeWidth: 0.6 },
+      datum,
+      group: lake,
+      interactive: false,
+    })
+    marks.push({
+      kind: "text",
+      id: `flower-label-${lake}`,
+      x,
+      y: baseY + 16,
+      text: lake,
+      fontSize: 11,
+      textAnchor: "middle",
+      style: { fill: "var(--semiotic-text-secondary, #667)" },
+    })
+  })
+
+  return { marks }
+})
+
+export const gofishBottleFillLayout = createGofishGlyphLayout<GofishBottleConfig>((ctx) => {
+  const cfg = ctx.config
+  const getCategory = resolveAccessor<string>(cfg.categoryAccessor ?? "category")
+  const getAmount = resolveAccessor<number>(cfg.amountAccessor ?? "amount")
+  const plot = ctx.dimensions.plot
+  const bottleW = Math.min(cfg.bottleWidth ?? 78, plot.width / Math.max(1, ctx.data.length) * 0.68)
+  const bottleH = Math.min(cfg.bottleHeight ?? 220, plot.height - 44)
+  const gap = ctx.data.length > 1 ? (plot.width - bottleW * ctx.data.length) / (ctx.data.length - 1) : 0
+  const top = plot.y + 14
+  const marks: GofishGlyphMark[] = []
+  const bottleOverlays: ReactNode[] = []
+
+  ctx.data.forEach((d, i) => {
+    const category = String(getCategory(d))
+    const amount = Math.max(0, Math.min(100, number(getAmount(d))))
+    const x = plot.x + (ctx.data.length === 1 ? (plot.width - bottleW) / 2 : i * (bottleW + gap))
+    const y = top
+    const fillH = bottleH * (amount / 100)
+    const clipId = `semiotic-bottle-clip-${stableId(category)}-${i}`
+    const outline = bottlePath(x, y, bottleW, bottleH)
+
+    marks.push(hitRectForGlyph({
+      id: `bottle-hit-${category}`,
+      x,
+      y,
+      width: bottleW,
+      height: bottleH,
+      datum: datumOf({ category, amount, kind: "bottle" }),
+      group: category,
+    }))
+
+    bottleOverlays.push(
+      <g key={`bottle-${category}`}>
+        <clipPath id={clipId}>
+          <path d={outline} />
+        </clipPath>
+        <path
+          d={outline}
+          fill="rgba(255,255,255,0.12)"
+          stroke="var(--semiotic-border, #9aa)"
+          strokeWidth={1.2}
+        />
+        <rect
+          x={x}
+          y={y + bottleH - fillH}
+          width={bottleW}
+          height={fillH}
+          fill="#20bf55"
+          opacity={0.76}
+          clipPath={`url(#${clipId})`}
+        />
+        <line
+          x1={x + bottleW * 0.08}
+          x2={x + bottleW * 1.18}
+          y1={y + bottleH - fillH}
+          y2={y + bottleH - fillH}
+          stroke="var(--semiotic-text-secondary, #666)"
+          strokeWidth={1}
+        />
+        <text
+          x={x + bottleW * 1.22}
+          y={y + bottleH - fillH + 4}
+          fontSize={12}
+          fill="var(--semiotic-text-secondary, #666)"
+        >
+          {amount}%
+        </text>
+        <text
+          x={x + bottleW / 2}
+          y={y + bottleH + 18}
+          fontSize={11}
+          textAnchor="middle"
+          fill="var(--semiotic-text-secondary, #666)"
+        >
+          {category}
+        </text>
+      </g>
+    )
+  })
+
+  return { marks, overlays: bottleOverlays }
+})
+
+export const gofishPolarRibbonLayout = createGofishGlyphLayout<GofishPolarRibbonConfig>((ctx) => {
+  const cfg = ctx.config
+  const getLake = resolveAccessor<string>(cfg.lakeAccessor ?? "lake")
+  const getSpecies = resolveAccessor<string>(cfg.speciesAccessor ?? "species")
+  const getCount = resolveAccessor<number>(cfg.countAccessor ?? "count")
+  const plot = ctx.dimensions.plot
+  const cx = plot.x + plot.width / 2
+  const cy = plot.y + plot.height / 2
+  const outer = Math.min(cfg.outerRadius ?? 145, Math.min(plot.width, plot.height) * 0.43)
+  const inner = cfg.innerRadius ?? Math.max(34, outer * 0.28)
+  const lakeGroups = groupBy(ctx.data, (d) => String(getLake(d)))
+  const lakes = Array.from(lakeGroups.keys())
+  const species = Array.from(new Set(ctx.data.map((d) => String(getSpecies(d)))))
+  const totalsByLake = new Map(lakes.map((lake) => [lake, sum(lakeGroups.get(lake) ?? [], (d) => number(getCount(d)))]))
+  const segmentBySpecies = new Map<string, Array<{ angle: number; innerR: number; outerR: number; datum: Datum }>>()
+  const marks: GofishGlyphMark[] = []
+
+  lakes.forEach((lake, lakeIndex) => {
+    const rows = aggregateRows(
+      lakeGroups.get(lake) ?? [],
+      (d) => String(getSpecies(d)),
+      (d) => number(getCount(d)),
+      { lake }
+    ).sort((a, b) => a.value - b.value)
+    const angle = -Math.PI / 2 + (lakeIndex / lakes.length) * Math.PI * 2
+    const total = Math.max(1, totalsByLake.get(lake) ?? 0)
+    let cursor = inner
+    for (const row of rows) {
+      const sp = row.key
+      const count = Math.max(0, row.value)
+      const segment = (count / total) * (outer - inner)
+      const r0 = cursor
+      const r1 = cursor + segment
+      cursor = r1
+      const barWidth = Math.PI / 46
+      const hit = polarPoint(cx, cy, (r0 + r1) / 2, angle)
+      marks.push({
+        kind: "path",
+        id: `polar-bar-${lake}-${sp}`,
+        d: polarBandPath(cx, cy, r0, r1, angle - barWidth, angle + barWidth),
+        style: {
+          fill: ctx.resolveColor(sp),
+          fillOpacity: 0.82,
+          stroke: "rgba(255,255,255,0.35)",
+          strokeWidth: 0.7,
+        },
+        datum: row.datum,
+        group: sp,
+      })
+      marks.push({
+        kind: "circle",
+        id: `polar-hit-${lake}-${sp}`,
+        cx: hit[0],
+        cy: hit[1],
+        r: Math.max(5, barWidth * (r0 + r1) * 0.5),
+        style: { fill: "rgba(0,0,0,0)", stroke: "none" },
+        datum: row.datum,
+        group: sp,
+      })
+      if (!segmentBySpecies.has(sp)) segmentBySpecies.set(sp, [])
+      segmentBySpecies.get(sp)!.push({ angle, innerR: r0, outerR: r1, datum: row.datum })
+    }
+    const labelPoint = polarPoint(cx, cy, outer + 14, angle)
+    marks.push({
+      kind: "text",
+      id: `polar-label-${lake}`,
+      x: labelPoint[0],
+      y: labelPoint[1],
+      text: lake,
+      fontSize: 10,
+      textAnchor: "middle",
+      dominantBaseline: "middle",
+      style: { fill: "var(--semiotic-text-secondary, #667)" },
+    })
+  })
+
+  for (const sp of species) {
+    const segments = segmentBySpecies.get(sp) ?? []
+    if (segments.length < 2) continue
+    const top = segments.map((s) => polarPoint(cx, cy, s.outerR, s.angle))
+    const bottom = [...segments].reverse().map((s) => polarPoint(cx, cy, s.innerR, s.angle))
+    marks.push({
+      kind: "path",
+      id: `polar-ribbon-${sp}`,
+      d: smoothClosedPath([...top, ...bottom]),
+      style: {
+        fill: ctx.resolveColor(sp),
+        fillOpacity: 0.26,
+        stroke: ctx.resolveColor(sp),
+        strokeWidth: 1,
+        opacity: 0.9,
+      },
+      datum: datumOf({ species: sp, kind: "ribbon" }),
+      group: sp,
+    })
+  }
+
+  marks.push({
+    kind: "circle",
+    id: "polar-center",
+    cx,
+    cy,
+    r: inner - 4,
+    style: { fill: "var(--semiotic-bg, #fff)", stroke: "var(--semiotic-border, #ccd)", strokeWidth: 1 },
+    interactive: false,
+  })
+
+  return { marks }
+})
+
+export const gofishTitanicCircleTreemapLayout = createGofishGlyphLayout<GofishTitanicCircleTreemapConfig>((ctx) => {
+  const cfg = ctx.config
+  const getClass = resolveAccessor<string | number>(cfg.classAccessor ?? "pclass")
+  const getSurvived = resolveAccessor<string | number | boolean>(cfg.survivedAccessor ?? "survived")
+  const getFare = resolveAccessor<number>(cfg.fareAccessor ?? "fare")
+  const plot = ctx.dimensions.plot
+  const padding = cfg.padding ?? 2
+  const classes = Array.from(groupBy(ctx.data, (d) => String(getClass(d))).entries())
+    .sort(([a], [b]) => Number(a) - Number(b))
+  const marks: GofishGlyphMark[] = []
+
+  const regions = layoutTreemapStrip(
+    classes.map(([klass, rows]) => ({
+      id: klass,
+      rows,
+      value: sum(rows, (row) => Math.max(1, number(getFare(row)))),
+      heightValue: rows.length
+        ? sum(rows, (row) => Math.max(1, number(getFare(row)))) / rows.length
+        : 0,
+    })),
+    { x: plot.x, y: plot.y, width: plot.width, height: plot.height },
+    Math.max(4, padding * 4)
+  )
+
+  regions.forEach((region) => {
+    const circles = packCirclesInRect(
+      region.rows,
+      region,
+      (row) => Math.max(1, number(getFare(row))),
+      Math.max(1, padding)
+    )
+
+    for (const circle of circles) {
+      const row = circle.row
+      const survived = String(getSurvived(row))
+      const color = survived === "1" || survived === "true" || survived.toLowerCase() === "yes"
+        ? "#4e92c3"
+        : "#f28e2c"
+      const fare = Math.max(1, number(getFare(row)))
+      const datum = datumOf({
+        ...row,
+        fare,
+        pclass: getClass(row),
+        survived: getSurvived(row),
+        value: fare,
+        kind: "passenger",
+      })
+      marks.push({
+        kind: "circle",
+        id: `titanic-${region.id}-${stableId(String(row.name ?? row.id ?? circle.index))}`,
+        cx: circle.x,
+        cy: circle.y,
+        r: circle.r,
+        style: { fill: color, fillOpacity: 0.95, stroke: "#d7d7d7", strokeWidth: 0.8 },
+        datum,
+        group: survived,
+      })
+    }
+  })
+
+  return { marks }
+})
+
+export const gofishPythonTutorLayout = createGofishGlyphLayout<GofishPythonTutorConfig>((ctx) => {
+  const diagram = ctx.config.diagram ?? (ctx.data[0] as unknown as PythonTutorDiagram | undefined)
+  if (!diagram) return { marks: [] }
+  const plot = ctx.dimensions.plot
+  const cellW = ctx.config.cellWidth ?? 54
+  const cellH = ctx.config.cellHeight ?? 28
+  const heapGap = ctx.config.heapGap ?? 18
+  const frameW = 170
+  const stackX = plot.x + 20
+  const stackY = plot.y + 38
+  const heapX = stackX + frameW + 88
+  const heapY = plot.y + 34
+  const marks: GofishGlyphMark[] = []
+  const overlays: ReactNode[] = []
+  const anchors = new Map<string, [number, number]>()
+
+  marks.push({
+    kind: "rect",
+    id: "python-global-frame",
+    x: stackX,
+    y: stackY - 30,
+    width: frameW,
+    height: 30 + diagram.stack.length * cellH,
+    style: { fill: "rgba(58, 142, 255, 0.08)", stroke: "var(--semiotic-border, #9aa)", strokeWidth: 1 },
+    datum: datumOf({ kind: "global frame" }),
+    group: "stack",
+    rx: 6,
+    interactive: false,
+  })
+  marks.push({
+    kind: "text",
+    id: "python-global-label",
+    x: stackX + 10,
+    y: stackY - 10,
+    text: "Global frame",
+    fontSize: 12,
+    fontWeight: 700,
+    style: { fill: "var(--semiotic-text, #333)" },
+  })
+
+  diagram.stack.forEach((slot, i) => {
+    const y = stackY + i * cellH
+    marks.push({
+      kind: "rect",
+      id: `python-binding-${slot.name}`,
+      x: stackX,
+      y,
+      width: frameW,
+      height: cellH,
+      style: { fill: "rgba(255,255,255,0.05)", stroke: "var(--semiotic-border, #9aa)", strokeWidth: 1 },
+      datum: datumOf({ name: slot.name, value: displayValue(slot.value), kind: "binding" }),
+      group: "binding",
+    })
+    marks.push({
+      kind: "text",
+      id: `python-binding-name-${slot.name}`,
+      x: stackX + 10,
+      y: y + cellH / 2 + 4,
+      text: slot.name,
+      fontSize: 12,
+      style: { fill: "var(--semiotic-text, #333)" },
+    })
+    marks.push({
+      kind: "text",
+      id: `python-binding-value-${slot.name}`,
+      x: stackX + frameW - 12,
+      y: y + cellH / 2 + 4,
+      text: displayValue(slot.value),
+      fontSize: 12,
+      textAnchor: "end",
+      style: { fill: isPointer(slot.value) ? "#1A5683" : "var(--semiotic-text-secondary, #666)" },
+    })
+    anchors.set(`stack-${i}`, [stackX + frameW - 8, y + cellH / 2])
+  })
+
+  diagram.heapArrangement.forEach((row, r) => {
+    row.forEach((addr, c) => {
+      if (addr == null) return
+      const obj = diagram.heap[addr]
+      if (!obj) return
+      const tupleW = Math.max(cellW, obj.values.length * cellW)
+      const x = heapX + c * (cellW * 2.55 + heapGap)
+      const y = heapY + r * (cellH * 3.1)
+      marks.push({
+        kind: "rect",
+        id: `python-heap-${addr}`,
+        x,
+        y,
+        width: tupleW,
+        height: cellH,
+        style: { fill: "rgba(45, 138, 74, 0.10)", stroke: "var(--semiotic-border, #9aa)", strokeWidth: 1 },
+        datum: datumOf({ address: addr, kind: "heap tuple" }),
+        group: "heap",
+        rx: 5,
+      })
+      marks.push({
+        kind: "text",
+        id: `python-heap-label-${addr}`,
+        x,
+        y: y - 7,
+        text: `addr ${addr}`,
+        fontSize: 10,
+        style: { fill: "var(--semiotic-text-secondary, #666)" },
+      })
+      obj.values.forEach((value, i) => {
+        const cellX = x + i * cellW
+        marks.push({
+          kind: "line",
+          id: `python-heap-divider-${addr}-${i}`,
+          x1: cellX,
+          y1: y,
+          x2: cellX,
+          y2: y + cellH,
+          style: { stroke: "var(--semiotic-border, #9aa)", strokeWidth: 1 },
+        })
+        marks.push({
+          kind: "text",
+          id: `python-heap-value-${addr}-${i}`,
+          x: cellX + cellW / 2,
+          y: y + cellH / 2 + 4,
+          text: displayValue(value),
+          fontSize: 12,
+          textAnchor: "middle",
+          style: { fill: isPointer(value) ? "#1A5683" : "var(--semiotic-text, #333)" },
+        })
+        anchors.set(`heap-${addr}-${i}`, [cellX + cellW / 2, y + cellH / 2])
+      })
+      anchors.set(`heap-${addr}`, [x + 8, y + cellH / 2])
+    })
+  })
+
+  const addrPosition = new Map<number, [number, number]>()
+  diagram.heapArrangement.forEach((row, r) => {
+    row.forEach((addr, c) => {
+      if (addr != null) addrPosition.set(addr, [r, c])
+    })
+  })
+
+  diagram.stack.forEach((slot, i) => {
+    if (!isPointer(slot.value)) return
+    const start = anchors.get(`stack-${i}`)
+    const target = anchors.get(`heap-${slot.value.pointer}`)
+    if (start && target) overlays.push(<ArrowPath key={`stack-arrow-${i}`} start={start} end={target} />)
+  })
+  diagram.heap.forEach((obj, addr) => {
+    obj.values.forEach((value, i) => {
+      if (!isPointer(value)) return
+      const start = anchors.get(`heap-${addr}-${i}`)
+      const target = anchors.get(`heap-${value.pointer}`)
+      if (start && target) overlays.push(<ArrowPath key={`heap-arrow-${addr}-${i}`} start={start} end={target} />)
+    })
+  })
+
+  return {
+    marks,
+    overlays: (
+      <>
+        <defs>
+          <marker id="semiotic-gofish-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <path d="M0,0 L8,4 L0,8 Z" fill="#1A5683" />
+          </marker>
+        </defs>
+        {overlays}
+      </>
+    ),
+  }
+})
+
+export const gofishPythonTutorNetworkLayout: NetworkCustomLayout<GofishPythonTutorConfig> = (ctx) => {
+  const diagram = ctx.config.diagram
+  if (!diagram) return { sceneNodes: [], sceneEdges: [], labels: [] }
+
+  const plot = ctx.dimensions.plot
+  const fit = Math.max(0.68, Math.min(1, plot.width / 1120))
+  const cellW = ctx.config.cellWidth ?? Math.round(58 * fit)
+  const cellH = ctx.config.cellHeight ?? Math.round(52 * fit)
+  const heapGap = ctx.config.heapGap ?? 18
+  const frameW = Math.round(198 * fit)
+  const titleH = Math.round(42 * fit)
+  const bindingH = Math.round(42 * fit)
+  const frameH = titleH + diagram.stack.length * bindingH + Math.round(18 * fit)
+  const stackX = plot.x + 16
+  const stackY = plot.y + 28
+  const sceneNodes: NetworkRectNode[] = []
+  const overlays: ReactNode[] = []
+  const anchors = new Map<string, [number, number]>()
+  const tupleTargets = new Map<string, [number, number]>()
+  const tuplePositions = pythonTuplePositions(diagram, plot, stackX, frameW, cellW, cellH, heapGap)
+  const pointerColor = "#1A5683"
+  const tupleFill = "#fffcc5"
+  const tupleStroke = "#a8a8a8"
+  const frameFill = "#dce7f4"
+  const labelFill = "#222"
+  const mutedFill = "#777"
+
+  sceneNodes.push({
+    type: "rect",
+    id: "python-global-frame",
+    x: stackX,
+    y: stackY,
+    w: frameW,
+    h: frameH,
+    style: { fill: frameFill, stroke: "none" },
+    datum: datumOf({ kind: "global frame" }),
+    label: "Global frame",
+  })
+  overlays.push(
+    <g key="python-global-overlay">
+      <text
+        x={stackX + 12 * fit}
+        y={stackY + 25 * fit}
+        fontSize={24 * fit}
+        fontFamily="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+        fill={labelFill}
+      >
+        Global Frame
+      </text>
+      <line
+        x1={stackX}
+        y1={stackY}
+        x2={stackX}
+        y2={stackY + frameH}
+        stroke="#9caebf"
+        strokeWidth={4 * fit}
+      />
+    </g>
+  )
+
+  for (const node of ctx.nodes) {
+    const raw = rawNodeDatum(node)
+    const id = String(raw.id ?? node.id)
+    if (raw.kind === "binding") {
+      const index = number(raw.index)
+      const y = stackY + titleH + index * bindingH
+      const value = String(raw.value ?? "")
+      const pointer = number(raw.pointer)
+      const pointerLike = Number.isFinite(pointer) && value.startsWith("->")
+      const textY = y + bindingH / 2 + 6 * fit
+      const valueX = stackX + frameW - 40 * fit
+      const dotX = stackX + frameW - 34 * fit
+      const dotY = y + bindingH / 2
+      sceneNodes.push({
+        type: "rect",
+        id,
+        x: stackX,
+        y,
+        w: frameW,
+        h: bindingH,
+        style: { fill: "rgba(0,0,0,0)", stroke: "none" },
+        datum: raw,
+        label: String(raw.name ?? id),
+      })
+      overlays.push(
+        <g key={`python-binding-label-${id}`}>
+          <text x={stackX + 124 * fit} y={textY} fontSize={25 * fit} fill={labelFill}>
+            {String(raw.name ?? id)}
+          </text>
+          {pointerLike ? (
+            <>
+              <path
+                d={`M${valueX - 12 * fit},${dotY - 18 * fit} L${valueX - 12 * fit},${dotY + 18 * fit} L${valueX + 28 * fit},${dotY + 18 * fit}`}
+                fill="none"
+                stroke="#8d9aa0"
+                strokeWidth={1.2}
+              />
+              <circle cx={dotX} cy={dotY} r={3.6 * fit} fill={pointerColor} />
+            </>
+          ) : (
+            <>
+              <text x={valueX} y={textY} fontSize={25 * fit} fill={labelFill}>
+                {value}
+              </text>
+              <line
+                x1={valueX - 3 * fit}
+                y1={dotY + 18 * fit}
+                x2={valueX + 27 * fit}
+                y2={dotY + 18 * fit}
+                stroke="#8d9aa0"
+                strokeWidth={1.2}
+              />
+            </>
+          )}
+        </g>
+      )
+      if (pointerLike) anchors.set(id, [dotX, dotY])
+    } else if (raw.kind === "heap cell") {
+      const address = number(raw.address)
+      const cellIndex = number(raw.cellIndex)
+      const tuple = tuplePositions.get(address)
+      if (!tuple) continue
+      const pos = { x: tuple.x + cellIndex * cellW, y: tuple.y }
+      const value = String(raw.value ?? "")
+      const pointerLike = value.startsWith("->")
+      sceneNodes.push({
+        type: "rect",
+        id,
+        x: pos.x,
+        y: pos.y,
+        w: cellW,
+        h: cellH,
+        style: { fill: tupleFill, stroke: tupleStroke, strokeWidth: 1 },
+        datum: raw,
+        label: String(raw.value ?? ""),
+      })
+      if (pointerLike) anchors.set(id, [pos.x + cellW / 2, pos.y + cellH / 2])
+    }
+  }
+
+  tuplePositions.forEach((tuple, addr) => {
+    const obj = diagram.heap[addr]
+    if (!obj) return
+    tupleTargets.set(`tuple-${addr}`, [tuple.x - 8 * fit, tuple.y + cellH / 2])
+    overlays.push(
+      <g key={`python-tuple-${addr}`}>
+        <text x={tuple.x} y={tuple.y - 14 * fit} fontSize={16 * fit} fill={mutedFill}>
+          tuple
+        </text>
+        {obj.values.map((value, i) => {
+          const x = tuple.x + i * cellW
+          const pointerLike = isPointer(value)
+          return (
+            <g key={`python-tuple-cell-label-${addr}-${i}`}>
+              <text x={x + 2 * fit} y={tuple.y + 16 * fit} fontSize={15 * fit} fill={mutedFill}>
+                {i}
+              </text>
+              {pointerLike ? (
+                <circle cx={x + cellW / 2} cy={tuple.y + cellH / 2} r={3.6 * fit} fill={pointerColor} />
+              ) : (
+                <text
+                  x={x + cellW / 2}
+                  y={tuple.y + cellH / 2 + 9 * fit}
+                  textAnchor="middle"
+                  fontSize={25 * fit}
+                  fill={labelFill}
+                >
+                  {String(value)}
+                </text>
+              )}
+            </g>
+          )
+        })}
+      </g>
+    )
+  })
+
+  const sceneEdges: NetworkCurvedEdge[] = []
+  const edgeOverlays: ReactNode[] = []
+  for (const edge of ctx.edges) {
+    const sourceId = endpointId(edge.source)
+    const targetId = endpointId(edge.target)
+    const start = anchors.get(sourceId)
+    const end = tupleTargets.get(targetTupleId(targetId)) ?? anchors.get(targetId)
+    if (!start || !end) continue
+    const curve = pointerCurve(start, end)
+    const bezier: BezierCache = {
+      circular: false,
+      points: curve.points,
+      halfWidth: 2,
+    }
+    ;(edge as RealtimeEdge).bezier = bezier
+    sceneEdges.push({
+      type: "curved",
+      pathD: curve.d,
+      style: { stroke: "rgba(26, 86, 131, 0.001)", strokeWidth: 1, fill: "none" },
+      datum: edge.data ?? edge,
+    })
+    edgeOverlays.push(
+      <path
+        key={`python-pointer-${sourceId}-${targetId}`}
+        d={curve.d}
+        fill="none"
+        stroke={pointerColor}
+        strokeWidth={2.4 * fit}
+        markerEnd="url(#semiotic-gofish-memory-arrow)"
+      />
+    )
+  }
+
+  return {
+    sceneNodes,
+    sceneEdges,
+    labels: [],
+    overlays: (
+      <g className="semiotic-gofish-python-memory" style={{ pointerEvents: "none" }}>
+        <defs>
+          <marker
+            id="semiotic-gofish-memory-arrow"
+            markerWidth="9"
+            markerHeight="9"
+            refX="8"
+            refY="4.5"
+            orient="auto"
+          >
+            <path d="M0,0 L9,4.5 L0,9 Z" fill={pointerColor} />
+          </marker>
+        </defs>
+        {edgeOverlays}
+        {overlays}
+      </g>
+    ),
+  }
+}
+
+function rawNodeDatum(node: RealtimeNode): Datum {
+  return (node.data ?? node) as Datum
+}
+
+function endpointId(endpoint: string | RealtimeNode): string {
+  return typeof endpoint === "string" ? endpoint : endpoint.id
+}
+
+function pythonTuplePositions(
+  diagram: PythonTutorDiagram,
+  plot: { x: number; y: number; width: number; height: number },
+  stackX: number,
+  frameW: number,
+  cellW: number,
+  cellH: number,
+  heapGap: number
+): Map<number, { x: number; y: number }> {
+  const out = new Map<number, { x: number; y: number }>()
+  const tupleW = (addr: number) => Math.max(cellW, (diagram.heap[addr]?.values.length ?? 1) * cellW)
+  const heapX = stackX + frameW + Math.max(54, plot.width * 0.07)
+  const gap = Math.max(0, heapGap)
+  const topY = plot.y + Math.max(42, plot.height * 0.18)
+  const bottomY = Math.min(
+    plot.y + plot.height - cellH - 20,
+    topY + Math.max(96, cellH * 2.8) + gap * 1.15
+  )
+
+  diagram.heapArrangement.forEach((row, r) => {
+    row.forEach((addr, c) => {
+      if (addr == null) return
+      out.set(addr, {
+        x: heapX + c * (cellW * 2.55 + heapGap),
+        y: r === 0 ? topY : bottomY,
+      })
+    })
+  })
+
+  if (diagram.heap.length >= 5) {
+    const right = plot.x + plot.width - 16
+    const addr4X = right - tupleW(4)
+    const nearGap = Math.max(24, cellW * 0.55 + gap * 0.75)
+    const midGap = Math.max(54, cellW * 1.15 + gap * 1.35)
+    const farGap = Math.max(120, cellW * 2.55 + gap * 2.1)
+    const addr2X = Math.min(
+      addr4X - tupleW(2) - midGap,
+      heapX + tupleW(0) + nearGap
+    )
+    const addr3X = Math.min(
+      right - tupleW(3) - farGap,
+      heapX + tupleW(0) + midGap
+    )
+    const addr1X = Math.min(
+      Math.max(heapX + cellW * 3.1 + gap, stackX + frameW + Math.max(150, plot.width * 0.19) + gap),
+      addr2X - tupleW(1) - nearGap
+    )
+
+    out.set(0, { x: heapX, y: topY })
+    out.set(1, { x: addr1X, y: bottomY })
+    out.set(2, { x: addr2X, y: bottomY })
+    out.set(3, { x: addr3X, y: topY })
+    out.set(4, { x: addr4X, y: bottomY })
+  }
+
+  return out
+}
+
+function targetTupleId(targetId: string): string {
+  const match = /^cell-(\d+)-0$/.exec(targetId)
+  return match ? `tuple-${match[1]}` : targetId
+}
+
+export function pointerCurve(start: [number, number], end: [number, number]): {
+  d: string
+  points: [BezierPoint, BezierPoint, BezierPoint, BezierPoint]
+} {
+  const dx = end[0] - start[0]
+  const dy = end[1] - start[1]
+  const bend = Math.max(34, Math.min(160, Math.abs(dx) * 0.42))
+  const c1: BezierPoint = { x: start[0] + bend, y: start[1] }
+  const c2: BezierPoint = { x: end[0] - bend, y: end[1] }
+
+  if (Math.abs(dx) < 80 && Math.abs(dy) > 20) {
+    c1.x = start[0]
+    c1.y = start[1] + dy * 0.55
+    c2.x = end[0]
+    c2.y = end[1] - dy * 0.55
+  }
+
+  const p0: BezierPoint = { x: start[0], y: start[1] }
+  const p3: BezierPoint = { x: end[0], y: end[1] }
+  return {
+    d: `M${p0.x},${p0.y} C${c1.x},${c1.y} ${c2.x},${c2.y} ${p3.x},${p3.y}`,
+    points: [p0, c1, c2, p3],
+  }
+}
+
+/**
+ * Clip a glyph element to an SVG path (pixel coords). The `<clipPath>` def
+ * rides inside the same `<g>` so the overlay stays self-contained — a custom
+ * layout can clip a fill (or an image) to a silhouette without wiring shared
+ * `<defs>`.
+ */
+function withClip(id: string, clipPath: string | undefined, element: ReactNode): ReactNode {
+  if (!clipPath) return element
+  const clipId = `${id}-clip`
+  return (
+    <g key={`${id}-clipwrap`}>
+      <defs>
+        <clipPath id={clipId}>
+          <path d={clipPath} />
+        </clipPath>
+      </defs>
+      <g clipPath={`url(#${clipId})`}>{element}</g>
+    </g>
+  )
+}
+
+function renderGlyphMark(mark: GofishGlyphMark): ReactNode {
+  const style = svgStyle("style" in mark ? mark.style : undefined)
+  if (mark.kind === "rect" && mark.interactive === false) {
+    return withClip(
+      mark.id,
+      mark.clipPath,
+      <rect
+        key={mark.id}
+        data-gofish-id={mark.id}
+        x={mark.x}
+        y={mark.y}
+        width={mark.width}
+        height={mark.height}
+        rx={mark.rx}
+        style={style}
+      />
+    )
+  }
+  if (mark.kind === "circle" && mark.interactive === false) {
+    return <circle key={mark.id} data-gofish-id={mark.id} cx={mark.cx} cy={mark.cy} r={mark.r} style={style} />
+  }
+  if (mark.kind === "image") {
+    return withClip(
+      mark.id,
+      mark.clipPath,
+      <image
+        key={mark.id}
+        data-gofish-id={mark.id}
+        href={mark.href}
+        x={mark.x}
+        y={mark.y}
+        width={mark.width}
+        height={mark.height}
+        preserveAspectRatio={mark.preserveAspectRatio ?? "none"}
+        opacity={mark.opacity}
+      />
+    )
+  }
+  if (mark.kind === "path") {
+    return withClip(
+      mark.id,
+      mark.clipPath,
+      <path key={mark.id} data-gofish-id={mark.id} d={mark.d} style={style} />
+    )
+  }
+  if (mark.kind === "line") {
+    return <line key={mark.id} data-gofish-id={mark.id} x1={mark.x1} y1={mark.y1} x2={mark.x2} y2={mark.y2} style={style} />
+  }
+  if (mark.kind === "text") {
+    return (
+      <text
+        key={mark.id}
+        data-gofish-id={mark.id}
+        x={mark.x}
+        y={mark.y}
+        fontSize={mark.fontSize}
+        fontWeight={mark.fontWeight}
+        textAnchor={mark.textAnchor}
+        dominantBaseline={mark.dominantBaseline}
+        transform={mark.transform}
+        style={style}
+      >
+        {mark.text}
+      </text>
+    )
+  }
+  return null
+}
+
+function ArrowPath({ start, end }: { start: [number, number]; end: [number, number] }) {
+  const midX = (start[0] + end[0]) / 2
+  const d = `M${start[0]},${start[1]} C${midX},${start[1]} ${midX},${end[1]} ${end[0]},${end[1]}`
+  return (
+    <path
+      d={d}
+      fill="none"
+      stroke="#1A5683"
+      strokeWidth={1.4}
+      markerEnd="url(#semiotic-gofish-arrow)"
+    />
+  )
+}
+
+function svgStyle(style: Style | undefined): React.CSSProperties {
+  if (!style) return {}
+  const fill = typeof style.fill === "string" ? style.fill : undefined
+  return {
+    fill,
+    fillOpacity: style.fillOpacity,
+    stroke: style.stroke,
+    strokeWidth: style.strokeWidth,
+    strokeDasharray: style.strokeDasharray,
+    strokeLinecap: style.strokeLinecap,
+    opacity: style.opacity,
+  }
+}
+
+interface TreemapStripRegion<T> {
+  id: string
+  rows: T[]
+  value: number
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+interface PackedCircle<T> {
+  row: T
+  index: number
+  x: number
+  y: number
+  r: number
+}
+
+export function layoutTreemapStrip<T>(
+  entries: Array<{ id: string; rows: T[]; value: number; heightValue?: number }>,
+  bounds: { x: number; y: number; width: number; height: number },
+  gap: number
+): Array<TreemapStripRegion<T>> {
+  if (!entries.length) return []
+  const totalValue = sum(entries, (entry) => Math.max(0, entry.value))
+  const maxHeightValue = Math.max(...entries.map((entry) => Math.max(0, entry.heightValue ?? entry.value)), 1)
+  const layoutHeight = Math.max(1, bounds.height * 0.82)
+  const availableWidth = Math.max(1, bounds.width - gap * Math.max(0, entries.length - 1))
+  const targetArea = availableWidth * layoutHeight * 0.82
+  const rawRegions = entries.map((entry) => {
+    const share = totalValue > 0 ? Math.max(0, entry.value) / totalValue : 1 / entries.length
+    const heightShare = Math.max(0, entry.heightValue ?? entry.value) / maxHeightValue
+    const height = lerp(layoutHeight * 0.26, layoutHeight, heightShare)
+    const width = Math.max(1, (targetArea * share) / Math.max(1, height))
+    return { ...entry, width, height }
+  })
+  const rawWidth = sum(rawRegions, (entry) => entry.width)
+  const widthScale = availableWidth / Math.max(1, rawWidth)
+  let x = bounds.x
+
+  return rawRegions.map((entry) => {
+    const width = entry.width * widthScale
+    const height = Math.min(bounds.height, entry.height)
+    const region = {
+      id: entry.id,
+      rows: entry.rows,
+      value: entry.value,
+      x,
+      y: bounds.y + bounds.height - height,
+      width,
+      height,
+    }
+    x += width + gap
+    return region
+  })
+}
+
+export function packCirclesInRect<T>(
+  rows: T[],
+  region: TreemapStripRegion<T>,
+  value: (row: T) => number,
+  gap: number
+): Array<PackedCircle<T>> {
+  const padding = Math.max(2, gap)
+  const left = region.x + padding
+  const right = region.x + region.width - padding
+  const top = region.y + padding
+  const bottom = region.y + region.height - padding
+  const width = Math.max(1, right - left)
+  const height = Math.max(1, bottom - top)
+  const sorted = rows
+    .map((row, index) => ({ row, index, value: Math.max(1, value(row)) }))
+    .sort((a, b) => b.value - a.value || a.index - b.index)
+  const totalValue = sum(sorted, (row) => row.value)
+  let radiusScale = Math.sqrt((width * height * 0.68) / Math.max(1, Math.PI * totalValue))
+  const minRadius = Math.max(1, Math.min(width, height) / 260)
+
+  for (let attempt = 0; attempt < 24; attempt++) {
+    const placed: Array<PackedCircle<T>> = []
+    let cursorX = left
+    let cursorY = top
+    let rowHeight = 0
+    let failed = false
+
+    for (const item of sorted) {
+      const r = Math.max(minRadius, Math.min(Math.min(width, height) / 2, Math.sqrt(item.value) * radiusScale))
+      const diameter = r * 2
+      if (cursorX > left && cursorX + diameter > right) {
+        cursorX = left
+        cursorY += rowHeight + gap
+        rowHeight = 0
+      }
+      if (cursorY + diameter > bottom) {
+        failed = true
+        break
+      }
+      placed.push({ row: item.row, index: item.index, x: cursorX + r, y: cursorY + r, r })
+      cursorX += diameter + gap
+      rowHeight = Math.max(rowHeight, diameter)
+    }
+
+    if (!failed) {
+      const packedBottom = placed.reduce((maxY, circle) => Math.max(maxY, circle.y + circle.r), top)
+      const offsetY = Math.max(0, bottom - packedBottom)
+      return placed.map((circle) => ({ ...circle, y: circle.y + offsetY }))
+    }
+
+    radiusScale *= 0.9
+  }
+
+  return sorted.map((item, index) => {
+    const columns = Math.max(1, Math.floor(width / Math.max(2, gap * 2)))
+    const cellW = width / columns
+    const row = Math.floor(index / columns)
+    const col = index % columns
+    return {
+      row: item.row,
+      index: item.index,
+      x: left + col * cellW + cellW / 2,
+      y: top + row * Math.max(2, gap * 2) + gap,
+      r: Math.max(1, Math.min(cellW, gap * 2) * 0.42),
+    }
+  })
+}
+
+function groupBy<T>(rows: T[], key: (row: T) => string): Map<string, T[]> {
+  const out = new Map<string, T[]>()
+  for (const row of rows) {
+    const k = key(row)
+    if (!out.has(k)) out.set(k, [])
+    out.get(k)!.push(row)
+  }
+  return out
+}
+
+function sum<T>(rows: T[], value: (row: T) => number): number {
+  return rows.reduce((acc, row) => {
+    const v = value(row)
+    return acc + (Number.isFinite(v) ? v : 0)
+  }, 0)
+}
+
+function aggregateRows<T>(
+  rows: T[],
+  key: (row: T) => string,
+  value: (row: T) => number,
+  fields?: Record<string, unknown>
+): Array<{ key: string; value: number; datum: Datum }> {
+  const grouped = new Map<string, { value: number; count: number }>()
+  for (const row of rows) {
+    const k = key(row)
+    const entry = grouped.get(k) ?? { value: 0, count: 0 }
+    entry.value += value(row)
+    entry.count += 1
+    grouped.set(k, entry)
+  }
+  return Array.from(grouped.entries()).map(([k, entry]) => ({
+    key: k,
+    value: entry.value,
+    datum: datumOf({ ...fields, category: k, species: k, value: entry.value, count: entry.value, rows: entry.count }),
+  }))
+}
+
+function number(value: unknown): number {
+  const n = Number(value)
+  return Number.isFinite(n) ? n : 0
+}
+
+function normalize(value: number, min: number, max: number): number {
+  if (max === min) return 0.5
+  return (value - min) / (max - min)
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * Math.max(0, Math.min(1, t))
+}
+
+export function datumFromFields(fields: Record<string, unknown>): Datum {
+  return createSafeDatum((set) => {
+    for (const [key, value] of Object.entries(fields)) set(key, value)
+  })
+}
+
+export function stableGlyphId(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "item"
+}
+
+const datumOf = datumFromFields
+const stableId = stableGlyphId
+
+export function polarPoint(cx: number, cy: number, r: number, angle: number): [number, number] {
+  return [cx + Math.cos(angle) * r, cy + Math.sin(angle) * r]
+}
+
+export function petalPath(cx: number, cy: number, innerR: number, outerR: number, start: number, end: number): string {
+  const mid = (start + end) / 2
+  const a = polarPoint(cx, cy, innerR, start)
+  const b = polarPoint(cx, cy, outerR, mid)
+  const c = polarPoint(cx, cy, innerR, end)
+  return `M${a[0]},${a[1]} Q${b[0]},${b[1]} ${c[0]},${c[1]} Q${cx},${cy} ${a[0]},${a[1]} Z`
+}
+
+export function polarBandPath(cx: number, cy: number, innerR: number, outerR: number, start: number, end: number): string {
+  const p0 = polarPoint(cx, cy, outerR, start)
+  const p1 = polarPoint(cx, cy, outerR, end)
+  const p2 = polarPoint(cx, cy, innerR, end)
+  const p3 = polarPoint(cx, cy, innerR, start)
+  const large = end - start > Math.PI ? 1 : 0
+  return [
+    `M${p0[0]},${p0[1]}`,
+    `A${outerR},${outerR} 0 ${large} 1 ${p1[0]},${p1[1]}`,
+    `L${p2[0]},${p2[1]}`,
+    `A${innerR},${innerR} 0 ${large} 0 ${p3[0]},${p3[1]}`,
+    "Z",
+  ].join(" ")
+}
+
+export function smoothClosedPath(points: [number, number][]): string {
+  if (points.length === 0) return ""
+  if (points.length === 1) return `M${points[0][0]},${points[0][1]}Z`
+  let d = `M${points[0][0]},${points[0][1]}`
+  for (let i = 1; i < points.length; i++) {
+    const prev = points[i - 1]
+    const curr = points[i]
+    const midX = (prev[0] + curr[0]) / 2
+    d += ` Q${midX},${prev[1]} ${curr[0]},${curr[1]}`
+  }
+  d += "Z"
+  return d
+}
+
+export function bottlePath(x: number, y: number, w: number, h: number): string {
+  const neckW = w * 0.34
+  const shoulderY = y + h * 0.22
+  const neckX = x + (w - neckW) / 2
+  const bottomY = y + h
+  return [
+    `M${neckX},${y}`,
+    `L${neckX + neckW},${y}`,
+    `L${neckX + neckW},${shoulderY}`,
+    `C${x + w * 0.88},${shoulderY + h * 0.05} ${x + w * 0.92},${shoulderY + h * 0.16} ${x + w * 0.84},${shoulderY + h * 0.24}`,
+    `L${x + w * 0.78},${bottomY - 8}`,
+    `Q${x + w / 2},${bottomY + 6} ${x + w * 0.22},${bottomY - 8}`,
+    `L${x + w * 0.16},${shoulderY + h * 0.24}`,
+    `C${x + w * 0.08},${shoulderY + h * 0.16} ${x + w * 0.12},${shoulderY + h * 0.05} ${neckX},${shoulderY}`,
+    "Z",
+  ].join(" ")
+}
+
+function isPointer(value: unknown): value is PythonTutorPointer {
+  return typeof value === "object" && value != null && "pointer" in value
+}
+
+function displayValue(value: string | PythonTutorPointer): string {
+  return isPointer(value) ? `-> ${value.pointer}` : String(value)
+}

--- a/src/components/recipes/gofishBoba.tsx
+++ b/src/components/recipes/gofishBoba.tsx
@@ -1,0 +1,379 @@
+import * as React from "react"
+import type { ReactNode } from "react"
+import type { OrdinalCustomLayout } from "../stream/ordinalCustomLayout"
+import type { OrdinalSceneNode } from "../stream/ordinalTypes"
+import type { RectSceneNode } from "../stream/types"
+import type { Datum } from "../charts/shared/datumTypes"
+import { resolveAccessor } from "./recipeUtils"
+import { datumFromFields, stableGlyphId } from "./gofish"
+
+/**
+ * Boba (bubble tea) cup glyphs — an OrdinalCustomLayout, one cup per category.
+ *
+ * Derived from Krist Wongsuphasawat's "Boba Science" Observable notebook
+ * (https://observablehq.com/@kristw/boba-science): each cup is a conical
+ * frustum filled with tea to a drink height computed from total volume, with
+ * tapioca pearls stacked at the bottom, ice cubes floating below the surface,
+ * and a straw. The notebook's frustum-volume / drink-height / pearl-packing
+ * math is ported here (deterministic — no `Math.random`, so SSR and
+ * transitions are stable).
+ *
+ * Scene-node / overlay split, matching the other GoFish recipes: one
+ * transparent hit-rect per cup carries the cup's datum (volumes, pearl/ice
+ * counts) into the Semiotic scene graph for hover, selection, SSR evidence,
+ * and transitions; the cup silhouette, tea, pearls, ice, lid, and straw are
+ * pointer-events-none SVG overlays keyed by cup name.
+ */
+
+const INCH_TO_CM = 2.54
+const ICE_WIDTH = 1.75
+const STRAW_HEIGHT_CM = 8 * INCH_TO_CM
+const STRAW_RADIUS_CM = 0.25 * INCH_TO_CM
+
+const TEA_FILL = "#D2B799"
+const PEARL_FILL = "#222222"
+const ICE_FILL = "#a5f2f3"
+const STRAW_FILL = "#4F91CB"
+const CUP_STROKE = "#222222"
+
+export interface GofishBobaConfig {
+  /** Category — one cup per distinct value. @default "name" */
+  categoryAccessor?: string | ((d: Datum) => string)
+  /** Tea volume (cm³). @default field "teaVolume" → 450 */
+  teaVolumeAccessor?: string | ((d: Datum) => number)
+  /** Tapioca-pearl volume (cm³); pearl count derived from it. @default field "bobaVolume" → 110 */
+  bobaVolumeAccessor?: string | ((d: Datum) => number)
+  /** Ice volume (cm³); cube count derived from it. @default field "iceVolume" → 135 */
+  iceVolumeAccessor?: string | ((d: Datum) => number)
+  /** Cup height (cm). @default field "cupHeight" → 15.5 */
+  cupHeightAccessor?: string | ((d: Datum) => number)
+  /** Cup top radius (cm). @default field "cupTopRadius" → 4.75 */
+  cupTopRadiusAccessor?: string | ((d: Datum) => number)
+  /** Cup bottom radius (cm). @default field "cupBottomRadius" → 3.75 */
+  cupBottomRadiusAccessor?: string | ((d: Datum) => number)
+  /** Pearl radius (cm). @default field "bobaRadius" → 0.6 */
+  bobaRadiusAccessor?: string | ((d: Datum) => number)
+  /** Fraction of each band the cup glyph may occupy. @default 0.82 */
+  cupWidthRatio?: number
+}
+
+interface Cup {
+  height: number
+  topRadius: number
+  bottomRadius: number
+}
+
+// ── Ported geometry from the notebook ───────────────────────────────────────
+
+function frustumVolume(r1: number, r2: number, h: number): number {
+  return (Math.PI * h) / 3 * (r1 * r1 + r1 * r2 + r2 * r2)
+}
+
+function radiusAtDrinkHeight(cup: Cup, h: number): number {
+  return cup.topRadius + ((h - cup.height) / cup.height) * (cup.topRadius - cup.bottomRadius)
+}
+
+function volumeFromDrinkHeight(cup: Cup, h: number): number {
+  return frustumVolume(radiusAtDrinkHeight(cup, h), cup.bottomRadius, h)
+}
+
+function drinkHeightFromVolume(cup: Cup, v: number): number {
+  const r = (cup.topRadius + cup.bottomRadius) / 2
+  const area = Math.PI * r * r
+  let estimate = v / area
+  let diff = v - volumeFromDrinkHeight(cup, estimate)
+  let counter = 0
+  while (counter < 100 && Math.abs(diff) > 0.0001) {
+    estimate += diff / area
+    diff = v - volumeFromDrinkHeight(cup, estimate)
+    counter++
+  }
+  return estimate
+}
+
+/** Deterministic ±amount jitter from an integer index (replaces Math.random). */
+function jitter(i: number, amount: number): number {
+  const f = Math.sin(i * 12.9898 + 78.233) * 43758.5453
+  return ((f - Math.floor(f)) - 0.5) * 2 * amount
+}
+
+/**
+ * Pack `rSmall`-radius circles inside an `rLarge`-radius disk in concentric
+ * rings. Ported from the notebook's `Circle.placeCirclesInside`.
+ */
+function placeCirclesInside(rLarge: number, rSmall: number): Array<{ x: number; y: number }> {
+  if (rSmall > rLarge || rLarge < 2 * rSmall) return [{ x: 0, y: 0 }]
+  const circles: Array<{ x: number; y: number }> = []
+  const make = (rc: number): void => {
+    let no = Math.floor((2 * Math.PI * rc) / (2 * rSmall))
+    if (no < 1) no = 1
+    const x0 = rc * Math.cos(0)
+    const y0 = rc * Math.sin(0)
+    const x1 = rc * Math.cos((2 * Math.PI) / no)
+    const y1 = rc * Math.sin((2 * Math.PI) / no)
+    const dist = Math.hypot(x0 - x1, y0 - y1)
+    if (dist < 2 * rSmall && no > 1) no--
+    for (let i = 0; i < no; i++) {
+      circles.push({ x: rc * Math.cos((i * 2 * Math.PI) / no), y: rc * Math.sin((i * 2 * Math.PI) / no) })
+    }
+    const rcNext = rc - 2 * rSmall
+    if (rcNext >= rSmall) make(rcNext)
+    else if (rc > 2 * rSmall) circles.push({ x: 0, y: 0 })
+  }
+  make(rLarge - rSmall)
+  return circles
+}
+
+interface Pearl {
+  x: number
+  z: number
+}
+
+/** Stack pearls in layers at the bottom of the cup. Returns positions + layer count. */
+function createBobaLayers(cup: Cup, bobaRadius: number, numBobas: number): { pearls: Pearl[]; layers: number } {
+  const pearls: Pearl[] = []
+  let remaining = numBobas
+  let layer = 0
+  while (remaining > 0 && layer < 60) {
+    const h = bobaRadius * (1 + 2 * layer)
+    const drinkRadius = radiusAtDrinkHeight(cup, h)
+    const ring = placeCirclesInside(drinkRadius, bobaRadius)
+    const diff = ring.length - remaining
+    const chosen = diff > 1 ? ring.slice(Math.floor(diff / 2), Math.floor(diff / 2) + remaining) : ring
+    const z = cup.height - h
+    chosen.forEach((p, i) => {
+      pearls.push({ x: p.x + jitter(layer * 97 + i, 0.15), z: z + jitter(layer * 31 + i, 0.05) })
+    })
+    remaining -= chosen.length
+    layer++
+    if (chosen.length === 0) break
+  }
+  return { pearls, layers: layer }
+}
+
+/** Number of stacked ice layers. Ported from `createIceLayers` (squares-per-row ≈ ⌊2r/w⌋). */
+function countIceLayers(cup: Cup, bobaHeight: number, numIce: number): number {
+  let remaining = numIce
+  let layer = 0
+  while (remaining > 0 && layer < 60) {
+    const h = bobaHeight + (ICE_WIDTH / 2) * (1 + 2 * layer)
+    const r = radiusAtDrinkHeight(cup, h)
+    const per = Math.max(1, Math.floor((2 * r) / ICE_WIDTH))
+    remaining -= per
+    layer++
+  }
+  return layer
+}
+
+interface IcePiece {
+  cx: number
+  cy: number
+  rotation: number
+}
+
+function createIcePieces(cup: Cup, bobaHeight: number, teaHeight: number, numIce: number): IcePiece[] {
+  if (numIce <= 0) return []
+  const numLayers = countIceLayers(cup, bobaHeight, numIce)
+  const iceHeight = numLayers * ICE_WIDTH
+  const iceStartY = Math.max(bobaHeight, teaHeight - iceHeight) + ICE_WIDTH / 2
+  const pieces: IcePiece[] = []
+  let placed = 0
+  for (let i = 0; i < numLayers && placed < numIce; i++) {
+    const h = iceStartY + ICE_WIDTH * i
+    const r = radiusAtDrinkHeight(cup, h)
+    const per = Math.max(1, Math.floor((2 * r) / ICE_WIDTH))
+    const gap = (2 * r - per * ICE_WIDTH) / (per + 1)
+    const startX = -r + gap
+    const yTop = cup.height - h - ICE_WIDTH / 2 - 0.1
+    for (let j = 0; j < per && placed < numIce; j++) {
+      const xLeft = startX + (gap + ICE_WIDTH) * j
+      pieces.push({
+        cx: xLeft + ICE_WIDTH / 2,
+        cy: yTop + ICE_WIDTH / 2,
+        rotation: jitter(i * 53 + j, 10),
+      })
+      placed++
+    }
+  }
+  return pieces
+}
+
+// ── Layout ───────────────────────────────────────────────────────────────
+
+function num(value: unknown, fallback: number): number {
+  const n = Number(value)
+  return Number.isFinite(n) ? n : fallback
+}
+
+export const gofishBobaLayout: OrdinalCustomLayout<GofishBobaConfig> = (ctx) => {
+  const cfg = ctx.config
+  const { plot } = ctx.dimensions
+  if (plot.width <= 0 || plot.height <= 0) return { nodes: [] }
+
+  const getCategory = resolveAccessor<string>(cfg.categoryAccessor ?? "name")
+  const getTea = resolveAccessor<number>(cfg.teaVolumeAccessor ?? "teaVolume")
+  const getBoba = resolveAccessor<number>(cfg.bobaVolumeAccessor ?? "bobaVolume")
+  const getIce = resolveAccessor<number>(cfg.iceVolumeAccessor ?? "iceVolume")
+  const getCupH = resolveAccessor<number>(cfg.cupHeightAccessor ?? "cupHeight")
+  const getTopR = resolveAccessor<number>(cfg.cupTopRadiusAccessor ?? "cupTopRadius")
+  const getBotR = resolveAccessor<number>(cfg.cupBottomRadiusAccessor ?? "cupBottomRadius")
+  const getBobaR = resolveAccessor<number>(cfg.bobaRadiusAccessor ?? "bobaRadius")
+  const widthRatio = cfg.cupWidthRatio ?? 0.82
+
+  const o = ctx.scales.o
+  const bandW = o.bandwidth()
+  const labelPad = 26
+  const topPad = 8
+  const availH = Math.max(1, plot.height - labelPad - topPad)
+  const baseTop = plot.y + topPad
+
+  const nodes: RectSceneNode[] = []
+  const overlays: ReactNode[] = []
+
+  for (const d of ctx.data) {
+    const category = String(getCategory(d))
+    const bandX = o(category)
+    if (bandX == null) continue
+
+    const cup: Cup = {
+      height: num(getCupH(d), 15.5),
+      topRadius: num(getTopR(d), 4.75),
+      bottomRadius: num(getBotR(d), 3.75),
+    }
+    const bobaRadius = num(getBobaR(d), 0.6)
+    const teaVolume = Math.max(0, num(getTea(d), 450))
+    const bobaVolume = Math.max(0, num(getBoba(d), 110))
+    const iceVolume = Math.max(0, num(getIce(d), 135))
+
+    // Pearl / ice counts (the notebook's 2D area model for a pearl).
+    const bobaBallVolume = Math.PI * bobaRadius * bobaRadius
+    const numBobas = Math.floor(bobaVolume / bobaBallVolume)
+    const realBobaVolume = numBobas * bobaBallVolume
+    const numIce = Math.floor(iceVolume / (ICE_WIDTH * ICE_WIDTH * ICE_WIDTH))
+    const realIceVolume = numIce * ICE_WIDTH * ICE_WIDTH * ICE_WIDTH
+    const totalVolume = teaVolume + realBobaVolume + realIceVolume
+
+    const rawDrinkHeight = drinkHeightFromVolume(cup, totalVolume)
+    const drinkHeight = Math.min(cup.height, Math.max(0, rawDrinkHeight))
+    const drinkRadius = radiusAtDrinkHeight(cup, drinkHeight)
+    const { pearls, layers } = createBobaLayers(cup, bobaRadius, numBobas)
+    const bobaHeight = layers * bobaRadius * 2
+    const teaHeight = drinkHeight
+    const ices = createIcePieces(cup, bobaHeight, teaHeight, numIce)
+
+    // ── cm → px transform. Origin: cup-top-center. y grows downward; the
+    // straw top (above the cup) sets the drawing's top edge. ──
+    const strawTopCm = cup.height - STRAW_HEIGHT_CM
+    const topCm = Math.min(0, strawTopCm)
+    const spanCm = cup.height - topCm
+    const widthCm = (cup.topRadius + 1) * 2
+    const scale = Math.min((bandW * widthRatio) / widthCm, availH / spanCm)
+    const centerX = bandX + bandW / 2
+    const sx = (xcm: number) => centerX + xcm * scale
+    const sy = (ycm: number) => baseTop + (ycm - topCm) * scale
+
+    // Bounding box of the whole glyph → the data-bearing hit rect.
+    const glyphLeft = sx(-(cup.topRadius + 1))
+    const glyphRight = sx(cup.topRadius + 1)
+    const glyphTop = sy(topCm)
+    const glyphBottom = sy(cup.height)
+    const datum = datumFromFields({
+      name: category,
+      teaVolume,
+      bobaVolume: Math.round(realBobaVolume),
+      iceVolume: Math.round(realIceVolume),
+      totalVolume: Math.round(totalVolume),
+      numBobas,
+      numIce,
+      kind: "boba cup",
+    })
+
+    nodes.push({
+      type: "rect",
+      x: glyphLeft,
+      y: glyphTop,
+      w: Math.max(1, glyphRight - glyphLeft),
+      h: Math.max(1, glyphBottom - glyphTop),
+      style: { fill: "rgba(0,0,0,0)", stroke: "none" },
+      datum,
+      group: category,
+      _transitionKey: `boba-${stableGlyphId(category)}`,
+    })
+
+    const teaY = cup.height - teaHeight
+    const id = stableGlyphId(category)
+    const accent = ctx.resolveColor(category)
+    overlays.push(
+      <g key={`boba-${id}`}>
+        {/* tea */}
+        {teaVolume > 0 ? (
+          <path
+            d={`M${sx(-drinkRadius)},${sy(teaY)} L${sx(-cup.bottomRadius)},${sy(cup.height)} L${sx(cup.bottomRadius)},${sy(cup.height)} L${sx(drinkRadius)},${sy(teaY)} z`}
+            fill={TEA_FILL}
+          />
+        ) : null}
+        {/* pearls */}
+        {pearls.map((p, i) => (
+          <circle key={`p-${i}`} cx={sx(p.x)} cy={sy(p.z)} r={bobaRadius * scale} fill={PEARL_FILL} opacity={0.5} />
+        ))}
+        {/* ice */}
+        {ices.map((ice, i) => (
+          <rect
+            key={`i-${i}`}
+            x={sx(ice.cx) - (ICE_WIDTH * 0.95 * scale) / 2}
+            y={sy(ice.cy) - (ICE_WIDTH * 0.95 * scale) / 2}
+            width={ICE_WIDTH * 0.95 * scale}
+            height={ICE_WIDTH * 0.95 * scale}
+            rx={2}
+            fill={ICE_FILL}
+            opacity={0.85}
+            transform={`rotate(${ice.rotation} ${sx(ice.cx)} ${sy(ice.cy)})`}
+          />
+        ))}
+        {/* cup outline */}
+        <path
+          d={`M${sx(-cup.topRadius)},${sy(0)} L${sx(-cup.bottomRadius)},${sy(cup.height)} L${sx(cup.bottomRadius)},${sy(cup.height)} L${sx(cup.topRadius)},${sy(0)}`}
+          fill="none"
+          stroke={CUP_STROKE}
+          strokeWidth={2.5}
+        />
+        {/* lid */}
+        <line
+          x1={sx(-(cup.topRadius + 1))}
+          y1={sy(0)}
+          x2={sx(cup.topRadius + 1)}
+          y2={sy(0)}
+          stroke={CUP_STROKE}
+          strokeWidth={3}
+          strokeLinecap="round"
+        />
+        {/* straw */}
+        {teaVolume > 0 ? (
+          <path
+            d={`M${sx(-STRAW_RADIUS_CM)},${sy(strawTopCm)} L${sx(-STRAW_RADIUS_CM)},${sy(cup.height - 0.4)} L${sx(STRAW_RADIUS_CM)},${sy(cup.height - STRAW_RADIUS_CM * 2 - 0.4)} L${sx(STRAW_RADIUS_CM)},${sy(strawTopCm)} z`}
+            fill={STRAW_FILL}
+            stroke={CUP_STROKE}
+            strokeWidth={1}
+            opacity={0.78}
+          />
+        ) : null}
+        {/* name + volume */}
+        <text x={centerX} y={glyphBottom + 16} textAnchor="middle" fontSize={12} fontWeight={600} fill="var(--semiotic-text, #333)">
+          {category}
+        </text>
+        <text x={centerX} y={glyphBottom + 30} textAnchor="middle" fontSize={10} fill={accent}>
+          {`${numBobas} pearls · ${Math.round(totalVolume)} cm³`}
+        </text>
+      </g>
+    )
+  }
+
+  return {
+    nodes: nodes as OrdinalSceneNode[],
+    overlays: (
+      <g className="semiotic-gofish-boba" style={{ pointerEvents: "none" }}>
+        {overlays}
+      </g>
+    ),
+  }
+}

--- a/src/components/recipes/gofishIR.test.ts
+++ b/src/components/recipes/gofishIR.test.ts
@@ -1,0 +1,411 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { scaleBand, scaleLinear } from "d3-scale"
+import { fromGofishIR } from "./gofishIR"
+import type { GofishRootIR } from "./gofishIR"
+import { interpretToMarks } from "./gofishInterpreter"
+import { bobaGeometryLambda, registerGofishLambda, unregisterGofishLambda } from "./gofishLambdas"
+import type { BobaCellGeometry } from "./gofishLambdas"
+import {
+  bobaIR,
+  bottleIR,
+  flowerIR,
+  gofishIRExamples,
+  polarRibbonIR,
+  pythonMemoryIR,
+  titanicCircleTreemapIR,
+} from "./gofishIRExamples"
+import type { LayoutContext } from "../stream/customLayout"
+import type { NetworkLayoutContext } from "../stream/networkCustomLayout"
+import type { OrdinalLayoutContext } from "../stream/ordinalCustomLayout"
+import type { Datum } from "../charts/shared/datumTypes"
+
+const FRAME = { x: 0, y: 0, width: 400, height: 200 }
+const colorById = (k: string) => `#${(Math.abs([...k].reduce((a, c) => a * 31 + c.charCodeAt(0), 7)) % 0xffffff).toString(16).padStart(6, "0")}`
+
+// A chart root for the interpreter (interpretToMarks takes a root, not a document).
+function chartRoot(operators: unknown[], mark: unknown, rows: Datum[]): GofishRootIR {
+  return { type: "chart", data: { type: "inline", rows }, operators, mark } as unknown as GofishRootIR
+}
+
+// ── The interpreter executes the grammar (not recognition) ──────────────────
+
+describe("interpretGofishIR — operator execution", () => {
+  const rows = [
+    { c: "A", v: 10 },
+    { c: "B", v: 20 },
+    { c: "C", v: 5 },
+  ]
+
+  it("spread lays one value-scaled bar per group, left → right", () => {
+    const { marks } = interpretToMarks(
+      chartRoot([{ type: "spread", by: "c", dir: "x" }], { type: "rect", h: { type: "field", name: "v" }, fill: { type: "field", name: "c" } }, rows),
+      FRAME,
+      colorById
+    )
+    const rects = marks.filter((m) => m.kind === "rect") as Array<{ x: number; height: number }>
+    expect(rects.length).toBe(3)
+    expect(rects[0].x).toBeLessThan(rects[1].x)
+    expect(rects[1].x).toBeLessThan(rects[2].x)
+    // Heights scale with value: B (20) tallest, C (5) shortest.
+    expect(rects[1].height).toBeGreaterThan(rects[0].height)
+    expect(rects[0].height).toBeGreaterThan(rects[2].height)
+  })
+
+  it("stack accumulates segments along the stack axis", () => {
+    const { marks } = interpretToMarks(
+      chartRoot([{ type: "stack", by: "c", dir: "y" }], { type: "rect", h: { type: "field", name: "v" }, fill: { type: "field", name: "c" } }, rows),
+      FRAME,
+      colorById
+    )
+    const rects = (marks.filter((m) => m.kind === "rect") as Array<{ y: number; height: number }>).slice().sort((a, b) => a.y - b.y)
+    expect(rects.length).toBe(3)
+    expect(rects[1].y).toBeCloseTo(rects[0].y + rects[0].height, 0)
+    expect(rects[2].y).toBeCloseTo(rects[1].y + rects[1].height, 0)
+  })
+
+  it("scatter positions one mark per datum by x", () => {
+    const pts = [
+      { x: 0, y: 1 },
+      { x: 5, y: 2 },
+      { x: 10, y: 3 },
+    ]
+    const { marks } = interpretToMarks(
+      chartRoot([{ type: "scatter", x: { type: "field", name: "x" }, y: { type: "field", name: "y" } }], { type: "circle", r: 4 }, pts),
+      FRAME,
+      colorById
+    )
+    const circles = marks.filter((m) => m.kind === "circle") as Array<{ cx: number }>
+    expect(circles.length).toBe(3)
+    expect(circles[0].cx).toBeLessThan(circles[2].cx)
+  })
+
+  it("treemap allocates one region per group", () => {
+    const { marks } = interpretToMarks(
+      chartRoot([{ type: "treemap", by: "c", valueField: "v" }], { type: "rect", fill: { type: "field", name: "c" } }, rows),
+      FRAME,
+      colorById
+    )
+    expect(marks.filter((m) => m.kind === "rect").length).toBe(3)
+  })
+
+  it("polar coordinate transform remaps rects into annular wedge areas", () => {
+    const mark = {
+      type: "layer",
+      __combinator: true,
+      options: { coord: { type: "polar" } },
+      children: [
+        { type: "stack", __combinator: true, options: { dir: "x", by: "c" }, children: [{ type: "rect", h: { type: "field", name: "v" }, fill: { type: "field", name: "c" } }] },
+      ],
+    }
+    const { marks } = interpretToMarks(chartRoot([], mark, rows), FRAME, colorById)
+    // Wedges are data-bearing area scene nodes (sampled arcs), not path overlays.
+    expect(marks.filter((m) => m.kind === "area").length).toBeGreaterThan(0)
+  })
+
+  it("warns on an unsupported operator instead of mis-rendering", () => {
+    const { warnings } = interpretToMarks(chartRoot([{ type: "table" }], { type: "rect" }, rows), FRAME, colorById)
+    expect(warnings.some((w) => w.toLowerCase().includes("unsupported"))).toBe(true)
+  })
+})
+
+describe("interpretGofishIR — escape hatches are honored", () => {
+  afterEach(() => {
+    unregisterGofishLambda("testDerive")
+    unregisterGofishLambda("testGlyph")
+  })
+
+  it("calls a registered `derive` lambda", () => {
+    let called = 0
+    registerGofishLambda("testDerive", {
+      kind: "derive",
+      fn: (rs) => {
+        called += 1
+        return rs.map((r) => ({ ...r, v: 99 }))
+      },
+    })
+    const { marks } = interpretToMarks(
+      chartRoot([{ type: "derive", lambdaId: "testDerive" }, { type: "spread", by: "c", dir: "x" }], { type: "rect", h: { type: "field", name: "v" } }, [{ c: "A", v: 1 }]),
+      FRAME,
+      colorById
+    )
+    expect(called).toBeGreaterThan(0)
+    expect(marks.filter((m) => m.kind === "rect").length).toBe(1)
+  })
+
+  it("calls a registered `mark-fn` lambda and splices its primitives", () => {
+    let called = 0
+    registerGofishLambda("testGlyph", {
+      kind: "mark-fn",
+      fn: () => {
+        called += 1
+        return [{ kind: "polygon", points: [[0, 0], [1, 0], [0.5, 1]], fill: "#abc" }]
+      },
+    })
+    const { marks } = interpretToMarks(chartRoot([], { type: "mark-fn", lambdaId: "testGlyph" }, [{ a: 1 }]), FRAME, colorById)
+    expect(called).toBe(1)
+    expect(marks.some((m) => m.kind === "path")).toBe(true)
+  })
+
+  it("warns (not throws) when a lambda id is unregistered", () => {
+    const { warnings } = interpretToMarks(chartRoot([], { type: "mark-fn", lambdaId: "missing" }, [{ a: 1 }]), FRAME, colorById)
+    expect(warnings.some((w) => w.includes("missing"))).toBe(true)
+  })
+})
+
+// ── Unit-coord marks: literal fills, repeat, aspect-preserving fit ──────────
+
+describe("interpretGofishIR — unit-coord marks", () => {
+  const unitLayer = (children: unknown[], coord: Record<string, unknown> = {}): unknown => ({
+    type: "layer",
+    __combinator: true,
+    options: { coord: { type: "unit", ...coord } },
+    children,
+  })
+
+  it("paints fill:'none' literally rather than resolving a categorical color", () => {
+    const { marks } = interpretToMarks(
+      chartRoot(
+        [],
+        unitLayer([
+          { type: "polygon", points: { type: "datum", datum: [[0, 0], [1, 0], [1, 1]] }, fill: "none", stroke: "#222" },
+        ]),
+        [{ a: 1 }]
+      ),
+      FRAME,
+      colorById
+    )
+    const path = marks.find((m) => m.kind === "path")
+    expect(path?.style?.fill).toBe("none")
+  })
+
+  it("repeat instantiates one mark per array element, not per parent datum", () => {
+    const { marks } = interpretToMarks(
+      chartRoot(
+        [],
+        unitLayer([
+          {
+            type: "circle",
+            repeat: "items",
+            cx: { type: "field", name: "x" },
+            cy: { type: "field", name: "y" },
+            r: { type: "field", name: "r" },
+            fill: "#222",
+            interactive: false,
+          },
+        ]),
+        [{ items: [{ x: 0.2, y: 0.2, r: 0.05 }, { x: 0.8, y: 0.8, r: 0.05 }, { x: 0.5, y: 0.5, r: 0.05 }] }]
+      ),
+      FRAME,
+      colorById
+    )
+    expect(marks.filter((m) => m.kind === "circle").length).toBe(3)
+  })
+
+  it("fit:'uniform' scales x and y by one factor (square stays square)", () => {
+    const spec = (coord: Record<string, unknown>) =>
+      interpretToMarks(
+        chartRoot(
+          [],
+          unitLayer(
+            [
+              {
+                type: "circle",
+                repeat: "items",
+                cx: { type: "field", name: "x" },
+                cy: { type: "field", name: "y" },
+                r: 0.02,
+                fill: "#222",
+                interactive: false,
+              },
+            ],
+            coord
+          ),
+          [{ items: [{ x: 0.2, y: 0.2 }, { x: 0.7, y: 0.7 }] }]
+        ),
+        FRAME, // 400 × 200 — a 2:1 region exposes per-axis stretch
+        colorById
+      ).marks.filter((m) => m.kind === "circle") as Array<{ cx: number; cy: number }>
+
+    const uniform = spec({ fit: "uniform" })
+    expect(Math.abs(uniform[1].cx - uniform[0].cx)).toBeCloseTo(Math.abs(uniform[1].cy - uniform[0].cy), 5)
+
+    // Default "fill" stretches each axis independently → dx ≠ dy in a 2:1 box.
+    const fill = spec({})
+    expect(Math.abs(fill[1].cx - fill[0].cx)).not.toBeCloseTo(Math.abs(fill[1].cy - fill[0].cy), 1)
+  })
+})
+
+// ── Family routing (hybrid) ────────────────────────────────────────────────
+
+describe("fromGofishIR — family routing", () => {
+  it("routes the four free-coordinate charts to XY", () => {
+    for (const ir of [flowerIR, bottleIR, polarRibbonIR, titanicCircleTreemapIR]) {
+      const cfg = fromGofishIR(ir)
+      expect(cfg.family).toBe("xy")
+      expect(cfg.layout).toBeTypeOf("function")
+    }
+  })
+
+  it("routes the boba volume signature to ordinal", () => {
+    const cfg = fromGofishIR(bobaIR)
+    expect(cfg.family).toBe("ordinal")
+    expect(cfg.ordinalLayout).toBeTypeOf("function")
+    expect(cfg.categoryAccessor).toBe("name")
+    expect(cfg.data.length).toBe(4)
+  })
+
+  it("routes the memory diagram (arrow marks) to network", () => {
+    const cfg = fromGofishIR(pythonMemoryIR)
+    expect(cfg.family).toBe("network")
+    expect(cfg.networkLayout).toBeTypeOf("function")
+    expect(cfg.graph?.nodes.length).toBe(19)
+  })
+})
+
+// ── Each example renders on its frame ───────────────────────────────────────
+
+function makeXYCtx(data: Datum[]): LayoutContext {
+  const x = scaleLinear().domain([0, 10]).range([0, 600])
+  const y = scaleLinear().domain([0, 10]).range([400, 0])
+  return {
+    data,
+    scales: { x, y } as unknown as LayoutContext["scales"],
+    dimensions: { width: 600, height: 400, margin: { top: 0, right: 0, bottom: 0, left: 0 }, plot: { x: 0, y: 0, width: 600, height: 400 } },
+    theme: { semantic: { primary: "#4e79a7" } as LayoutContext["theme"]["semantic"], categorical: ["#4e79a7", "#f28e2c", "#e15759", "#76b7b2"] },
+    resolveColor: colorById,
+    config: {},
+  }
+}
+
+function makeOrdinalCtx(data: Datum[], categories: string[]): OrdinalLayoutContext {
+  const o = scaleBand<string>().domain(categories).range([0, 800]).padding(0.2)
+  const r = scaleLinear().domain([0, 600]).range([400, 0])
+  return {
+    data,
+    scales: { o, r, projection: "vertical" } as unknown as OrdinalLayoutContext["scales"],
+    dimensions: { width: 800, height: 430, margin: { top: 0, right: 0, bottom: 0, left: 0 }, plot: { x: 0, y: 0, width: 800, height: 430 } },
+    theme: { semantic: { primary: "#4e79a7" } as OrdinalLayoutContext["theme"]["semantic"], categorical: ["#4e79a7", "#f28e2c"] },
+    resolveColor: colorById,
+    config: {},
+  }
+}
+
+function makeNetworkCtx(nodes: Datum[], edges: Datum[], config: Record<string, unknown>): NetworkLayoutContext {
+  return {
+    nodes: nodes as unknown as NetworkLayoutContext["nodes"],
+    edges: edges as unknown as NetworkLayoutContext["edges"],
+    dimensions: { width: 880, height: 360, plot: { x: 0, y: 0, width: 880, height: 360 } },
+    theme: { semantic: { primary: "#4e79a7" } as NetworkLayoutContext["theme"]["semantic"], categorical: ["#4e79a7", "#f28e2c"] },
+    resolveColor: (k) => (k === "heap" ? "#59a14f" : "#4e79a7"),
+    config,
+    selection: null,
+  }
+}
+
+describe("fromGofishIR — examples interpret to non-empty output", () => {
+  it("XY examples emit marks (scene nodes and/or overlays)", () => {
+    for (const ex of gofishIRExamples) {
+      const cfg = fromGofishIR(ex.doc)
+      if (cfg.family !== "xy") continue
+      const result = cfg.layout!(makeXYCtx(cfg.data))
+      const hasOutput = (result.nodes?.length ?? 0) > 0 || result.overlays != null
+      expect(hasOutput, `${ex.key} should render something`).toBe(true)
+    }
+  })
+
+  it("boba interprets to one hit rect per cup + cup overlays", () => {
+    const cfg = fromGofishIR(bobaIR)
+    const categories = cfg.data.map((d) => String(d.name))
+    const result = cfg.ordinalLayout!(makeOrdinalCtx(cfg.data, categories))
+    const rects = (result.nodes ?? []).filter((n) => n.type === "rect")
+    expect(rects.length).toBe(4)
+    expect(result.overlays).not.toBeNull()
+    for (const node of rects) {
+      expect(typeof node.datum?.name).toBe("string")
+      expect(typeof node.datum?.teaVolume).toBe("number")
+    }
+  })
+
+  it("the bottle renders an image silhouette + a fill clipped to it per bottle", () => {
+    const cfg = fromGofishIR(bottleIR)
+    const result = cfg.layout!(makeXYCtx(cfg.data))
+    // The image + clipped fill are overlays; the hit target is a scene node.
+    const rects = (result.nodes ?? []).filter((n) => n.type === "rect")
+    expect(rects.length).toBe(bottleIR.root.type === "chart" ? cfg.data.length : 0)
+    // Overlays carry the <image> bottles and the clipped <rect> fills.
+    const overlayStr = JSON.stringify(result.overlays)
+    expect(overlayStr).toContain("image")
+    expect(overlayStr).toContain("clip")
+  })
+
+  it("XY interpreted layouts read the frame data so push/update state can replace inline IR rows", () => {
+    const cfg = fromGofishIR(bottleIR)
+    const result = cfg.layout!(makeXYCtx([{ id: "solo", category: "Solo", amount: 37 }]))
+    const rects = (result.nodes ?? []).filter((n) => n.type === "rect")
+
+    expect(rects.length).toBe(1)
+    expect(rects[0].datum?.category).toBe("Solo")
+    expect(rects[0].datum?.amount).toBe(37)
+  })
+
+  it("ordinal interpreted layouts read frame data and derive shared geometry before band grouping", () => {
+    const cfg = fromGofishIR(bobaIR)
+    const data = [
+      { ...cfg.data[0], name: "Solo" },
+      { ...cfg.data[1], name: "Double" },
+    ]
+    const result = cfg.ordinalLayout!(makeOrdinalCtx(data, ["Solo", "Double"]))
+    const rects = (result.nodes ?? []).filter((n) => n.type === "rect")
+
+    expect(rects.length).toBe(2)
+    expect(rects.map((node) => node.datum?.name)).toEqual(["Solo", "Double"])
+    const boxes = rects.map((node) => JSON.stringify((node.datum?._g as BobaCellGeometry | undefined)?.box))
+    expect(new Set(boxes).size).toBe(1)
+  })
+
+  it("the memory diagram emits network scene nodes + edges", () => {
+    const cfg = fromGofishIR(pythonMemoryIR)
+    const result = cfg.networkLayout!(makeNetworkCtx(cfg.graph!.nodes, cfg.graph!.edges, cfg.layoutConfig))
+    expect((result.sceneNodes ?? []).length).toBeGreaterThan(0)
+    expect((result.sceneEdges ?? []).length).toBeGreaterThan(0)
+  })
+})
+
+// ── bobaGeometry derive (the boba volume → drink-height escape hatch) ────────
+
+describe("bobaGeometry derive", () => {
+  const rows = bobaIR.root.type === "chart" && bobaIR.root.data?.type === "inline" ? bobaIR.root.data.rows : []
+
+  it("packs pearls + ice + tea from the per-cup volumes", () => {
+    const out = bobaGeometryLambda.fn(rows as Datum[]) as Array<Datum & { _g: BobaCellGeometry }>
+    const byName = (name: string) => out.find((r) => r.name === name)!._g
+
+    const classic = byName("Classic")
+    expect(classic.pearls.length).toBeGreaterThan(0)
+    expect(classic.ice.length).toBeGreaterThan(0)
+    expect(classic.tea).not.toBeNull()
+    expect(classic.totalVolume).toBe(classic.teaVolume + classic.bobaVolume + classic.iceVolume)
+
+    // Composition reads from the data: Extra Boba stacks more pearls than Classic;
+    // Light Ice carries fewer cubes than Classic.
+    expect(byName("Extra Boba").numBobas).toBeGreaterThan(classic.numBobas)
+    expect(byName("Light Ice").numIce).toBeLessThan(classic.numIce)
+  })
+
+  it("normalizes every cup against one shared box (so the menu shares a scale)", () => {
+    const out = bobaGeometryLambda.fn(rows as Datum[]) as Array<Datum & { _g: BobaCellGeometry }>
+    const boxes = new Set(out.map((r) => `${r._g.box[0].toFixed(6)},${r._g.box[1].toFixed(6)}`))
+    expect(boxes.size).toBe(1)
+    // Largest dimension across the menu normalizes to 1.
+    expect(Math.max(...out[0]._g.box)).toBeCloseTo(1, 6)
+  })
+
+  it("bottom-aligns cups: every cup's lowest point lands at the shared box bottom", () => {
+    const out = bobaGeometryLambda.fn(rows as Datum[]) as Array<Datum & { _g: BobaCellGeometry }>
+    for (const r of out) {
+      const g = r._g
+      const cupBottom = Math.max(...g.cup.map((p) => p[1]))
+      expect(cupBottom).toBeCloseTo(g.box[1], 5)
+    }
+  })
+})

--- a/src/components/recipes/gofishIR.ts
+++ b/src/components/recipes/gofishIR.ts
@@ -1,0 +1,372 @@
+import type { Datum } from "../charts/shared/datumTypes"
+import type { CustomLayout } from "../stream/customLayout"
+import type { NetworkCustomLayout } from "../stream/networkCustomLayout"
+import type { OrdinalCustomLayout } from "../stream/ordinalCustomLayout"
+import { buildPythonTutorMemoryGraph, gofishPythonTutorNetworkLayout } from "./gofish"
+import type { GofishPythonTutorConfig, PythonTutorDiagram } from "./gofish"
+import { interpretToOrdinalLayout, interpretToXYLayout } from "./gofishInterpreter"
+import type { GofishLambda } from "./gofishLambdas"
+
+/**
+ * Experimental GoFish Frontend IR → Semiotic custom-layout adapter.
+ *
+ * This is the GoFish analogue of `fromVegaLite`. Where `fromVegaLite` maps a
+ * Vega-Lite spec onto a built-in HOC component + props, `unstable_fromGofishIR` maps a
+ * GoFish *Frontend IR* document (the JSON artifact GoFish's `to_ir` /
+ * serialization frontend emits — see the `gofish-ir` package) onto Semiotic's
+ * custom-layout surface.
+ *
+ * Unlike a recognizer, this *interprets* the spec: `unstable_fromGofishIR` picks a
+ * frame family, then hands the IR to `interpretGofishIR` (see
+ * `gofishInterpreter.ts`), which walks `data → operators → mark` and executes
+ * `group`/`spread`/`stack`/`scatter`/`treemap`/`layer`, the `polar`/`unit`
+ * coordinate transforms, mark channels through scales, and `connect`/`ref`/
+ * `arrow` relations. The two sanctioned non-grammar paths — `derive` and
+ * `mark-fn` — resolve through the lambda registry. Any spec built from the
+ * supported grammar renders; it is not limited to known archetypes.
+ *
+ * Frame family (hybrid): `arrow`/pointer specs → network; the boba volume
+ * signature → ordinal (Semiotic owns the category axis, the interpreter owns
+ * the within-cup composition); everything else → XY. The Python Tutor memory
+ * diagram is a genuinely bespoke diagram beyond the grammar, so it stays a
+ * chart-level escape hatch rendered by `gofishPythonTutorNetworkLayout`.
+ *
+ * Scope: GoFish Frontend IR v0. This is a PR-preview adapter named
+ * `unstable-gofish-ir-adapter`, not a release API commitment. Constructs outside the interpreter's
+ * allocation model (`table`, `cut`, `mask`, free-form `.constrain`, …) record
+ * a warning and fall back rather than silently mis-rendering.
+ */
+
+export const EXPERIMENTAL_GOFISH_ADAPTER_NAME = "unstable-gofish-ir-adapter"
+
+// ── IR types (subset of gofish-ir Frontend v0; see packages/gofish-ir) ───────
+
+/** Explicit field-accessor channel form, emitted by `field(name)`. */
+export interface GofishFieldAccessor {
+  type: "field"
+  name: string
+  measure?: string
+}
+
+/** A data-driven channel value, emitted by `datum(v)` / `v(...)`. */
+export interface GofishDatumValue {
+  type: "datum"
+  datum?: unknown
+  offset?: number
+  [key: string]: unknown
+}
+
+/** The right-hand side of a mark or operator channel (`h: …`, `fill: …`). */
+export type GofishChannelValue =
+  | string
+  | number
+  | boolean
+  | null
+  | GofishFieldAccessor
+  | GofishDatumValue
+  | { __gofish_lambda: string }
+
+export interface GofishOperatorIR {
+  type: string
+  by?: string
+  dir?: "x" | "y"
+  x?: GofishChannelValue
+  y?: GofishChannelValue
+  spacing?: number | [number, number]
+  [key: string]: unknown
+}
+
+export interface GofishMarkIR {
+  type: string
+  __combinator?: true
+  children?: GofishMarkIR[]
+  source?: GofishMarkIR
+  options?: Record<string, unknown>
+  origin?: { name?: string }
+  name?: string
+  [key: string]: unknown
+}
+
+export interface GofishChartIR {
+  type: "chart"
+  data?: GofishDataIR | null
+  operators?: GofishOperatorIR[]
+  mark: GofishMarkIR
+  options?: Record<string, unknown>
+  connect?: GofishMarkIR
+  name?: string
+}
+
+export interface GofishLayerIR {
+  type: "layer"
+  charts: GofishChartIR[]
+  options?: Record<string, unknown>
+}
+
+export interface GofishRawMarkIR {
+  type: "raw-mark"
+  mark: GofishMarkIR
+  options?: Record<string, unknown>
+}
+
+export type GofishDataIR =
+  | { type: "inline"; rows: Array<Record<string, unknown>> }
+  | { type: "select"; layer: string; mode?: "one" | "all" }
+  | { type: "external"; id?: string }
+
+export type GofishRootIR = GofishChartIR | GofishLayerIR | GofishRawMarkIR
+
+export interface GofishIRDocument {
+  irVersion: number
+  ir: string
+  $schema?: string
+  root: GofishRootIR
+}
+
+// ── Output ───────────────────────────────────────────────────────────────
+
+export type GofishChartFamily = "xy" | "network" | "ordinal"
+
+export type GofishRecipeName =
+  /** XY / ordinal charts are produced by the IR interpreter, not a named recipe. */
+  | "gofishInterpreter"
+  /** The Python Tutor memory diagram is a bespoke network glyph (chart-level escape hatch). */
+  | "gofishPythonTutorNetworkLayout"
+
+/**
+ * The translated chart, spreadable into `XYCustomChart` / `NetworkCustomChart`.
+ * Mirrors `fromVegaLite`'s `{ component, props, warnings }` for the
+ * custom-layout surface.
+ */
+export interface GofishChartConfig {
+  family: GofishChartFamily
+  /** Which `gofish.tsx` recipe the IR resolved to. */
+  recipe: GofishRecipeName
+  /** Layout function to pass as `layout` on `XYCustomChart` — null otherwise. */
+  layout: CustomLayout<Record<string, unknown>> | null
+  /** Layout function to pass as `layout` on `NetworkCustomChart` — null otherwise. */
+  networkLayout: NetworkCustomLayout<Record<string, unknown>> | null
+  /** Layout function to pass as `layout` on `OrdinalCustomChart` — null otherwise. */
+  ordinalLayout: OrdinalCustomLayout<Record<string, unknown>> | null
+  /** Accessor config derived from the IR; pass as `layoutConfig`. */
+  layoutConfig: Record<string, unknown>
+  /** Category accessor for ordinal charts (the frame builds the o-scale from it). */
+  categoryAccessor?: string
+  /** Value accessor for ordinal charts (the frame builds the r-scale from it). */
+  valueAccessor?: string
+  /** Inline data to seed the chart (`data` / `pushMany`). Empty for network. */
+  data: Datum[]
+  /** Node/edge graph for `NetworkCustomChart` (memory diagram only). */
+  graph: { nodes: Datum[]; edges: Datum[] } | null
+  irVersion: number
+  warnings?: string[]
+}
+
+// ── Channel / tree helpers ─────────────────────────────────────────────────
+
+function stripDatumPrefix(name: string): string {
+  return name.startsWith("datum.") ? name.slice("datum.".length) : name
+}
+
+function rootCharts(root: GofishRootIR): GofishChartIR[] {
+  if (root.type === "chart") return [root]
+  if (root.type === "layer") return root.charts
+  return []
+}
+
+/** Depth-first walk of every mark reachable from a root. */
+function walkMarks(root: GofishRootIR, visit: (mark: GofishMarkIR) => void): void {
+  const recurse = (mark: GofishMarkIR | undefined) => {
+    if (!mark) return
+    visit(mark)
+    if (mark.children) for (const child of mark.children) recurse(child)
+    if (mark.source) recurse(mark.source)
+  }
+  if (root.type === "raw-mark") {
+    recurse(root.mark)
+    return
+  }
+  for (const chart of rootCharts(root)) {
+    recurse(chart.mark)
+    recurse(chart.connect)
+  }
+}
+
+function collectMarks(root: GofishRootIR): GofishMarkIR[] {
+  const out: GofishMarkIR[] = []
+  walkMarks(root, (m) => out.push(m))
+  return out
+}
+
+function collectOperators(root: GofishRootIR): GofishOperatorIR[] {
+  return rootCharts(root).flatMap((chart) => chart.operators ?? [])
+}
+
+/** First inline data rows found anywhere in the document. */
+function collectInlineData(root: GofishRootIR): Array<Record<string, unknown>> {
+  for (const chart of rootCharts(root)) {
+    if (chart.data?.type === "inline") return chart.data.rows
+  }
+  if (root.type === "raw-mark") return []
+  return []
+}
+
+function dataFieldSet(rows: Array<Record<string, unknown>>): Set<string> {
+  const fields = new Set<string>()
+  for (const row of rows.slice(0, 8)) {
+    for (const key of Object.keys(row)) fields.add(key)
+  }
+  return fields
+}
+
+function findOperator(operators: GofishOperatorIR[], type: string): GofishOperatorIR | undefined {
+  return operators.find((op) => op.type === type)
+}
+
+/** A diagram-shaped inline row, used by the memory-diagram chart. */
+function findDiagram(root: GofishRootIR): PythonTutorDiagram | undefined {
+  for (const chart of rootCharts(root)) {
+    if (chart.data?.type !== "inline") continue
+    for (const row of chart.data.rows) {
+      const candidate = row as unknown as PythonTutorDiagram
+      if (row && Array.isArray(candidate.stack) && Array.isArray(candidate.heap)) {
+        return candidate
+      }
+    }
+  }
+  return undefined
+}
+
+// ── Family inference + dispatch ─────────────────────────────────────────────
+
+/**
+ * Pick the Semiotic frame that best hosts a spec (hybrid model):
+ * - `arrow`/pointer relations → network (bespoke diagram escape hatch).
+ * - the boba volume signature → ordinal (category axis + per-cup composition).
+ * - everything else → XY (free-coordinate interpretation).
+ */
+function inferFamily(
+  markTypes: Set<string>,
+  fields: Set<string>,
+  operators: GofishOperatorIR[]
+): GofishChartFamily {
+  if (markTypes.has("arrow")) return "network"
+  const bobaDerive = operators.some(
+    (op) => op.type === "derive" && String(op.lambdaId ?? "").toLowerCase().includes("boba")
+  )
+  if (bobaDerive || (fields.has("teaVolume") && fields.has("bobaVolume"))) return "ordinal"
+  return "xy"
+}
+
+/**
+ * The Python Tutor memory diagram is a genuinely bespoke visualization beyond
+ * the grammar — in GoFish it bottoms out in custom frame/heap glyphs. We honor
+ * that as a chart-level escape hatch: the structural IR carries the snapshot as
+ * an inline row, which the dedicated network layout renders (with particles).
+ */
+function buildPythonMemory(root: GofishRootIR, irVersion: number, warnings: string[]): GofishChartConfig {
+  const diagram = findDiagram(root)
+  if (!diagram) {
+    warnings.push(
+      "Memory-diagram IR carried no inline {stack, heap, heapArrangement} row; rendering an empty graph."
+    )
+  }
+  const graph = diagram
+    ? buildPythonTutorMemoryGraph(diagram)
+    : { nodes: [] as Datum[], edges: [] as Datum[] }
+  const config: GofishPythonTutorConfig = diagram ? { diagram } : {}
+  return {
+    family: "network",
+    recipe: "gofishPythonTutorNetworkLayout",
+    layout: null,
+    networkLayout: gofishPythonTutorNetworkLayout as NetworkCustomLayout<Record<string, unknown>>,
+    ordinalLayout: null,
+    layoutConfig: config as Record<string, unknown>,
+    data: [],
+    graph,
+    irVersion,
+    warnings: warnings.length ? warnings : undefined,
+  }
+}
+
+// ── Public entry ───────────────────────────────────────────────────────────
+
+export interface FromGofishIROptions {
+  /** Force a frame family instead of inferring it. */
+  family?: GofishChartFamily
+  /** Per-call `derive`/`mark-fn` lambda overrides (merged over the registry). */
+  lambdas?: Record<string, GofishLambda>
+}
+
+/**
+ * Translate a GoFish Frontend IR document into a Semiotic custom-layout config
+ * by *interpreting* the spec.
+ *
+ * @example
+ * ```tsx
+ * import { unstable_fromGofishIR } from "semiotic/experimental"
+ * import { XYCustomChart } from "semiotic/xy"
+ *
+ * const cfg = unstable_fromGofishIR(flowerIR)
+ * <XYCustomChart data={cfg.data} layout={cfg.layout} />
+ * ```
+ */
+export function unstable_fromGofishIR(doc: GofishIRDocument, options: FromGofishIROptions = {}): GofishChartConfig {
+  const warnings: string[] = []
+  if (!doc || doc.ir !== "gofish-frontend") {
+    warnings.push(
+      `Expected a "gofish-frontend" IR document but got ir="${doc?.ir}". Attempting best-effort translation.`
+    )
+  }
+  if (doc?.irVersion !== 0) {
+    warnings.push(
+      `This adapter targets GoFish Frontend IR v0; document declares irVersion=${doc?.irVersion}. Newer fields are ignored.`
+    )
+  }
+
+  const root = doc.root
+  const marks = collectMarks(root)
+  const operators = collectOperators(root)
+  const rows = collectInlineData(root)
+  const fields = dataFieldSet(rows)
+  const markTypes = new Set(marks.map((m) => m.type))
+  const family = options.family ?? inferFamily(markTypes, fields, operators)
+  const lambdas = options.lambdas
+
+  if (family === "network") return buildPythonMemory(root, doc.irVersion, warnings)
+
+  if (family === "ordinal") {
+    const spread = findOperator(operators, "spread")
+    const categoryAccessor = (spread?.by && stripDatumPrefix(spread.by)) || "name"
+    return {
+      family: "ordinal",
+      recipe: "gofishInterpreter",
+      layout: null,
+      networkLayout: null,
+      ordinalLayout: interpretToOrdinalLayout(root, categoryAccessor, { lambdas, warnings }),
+      layoutConfig: {},
+      categoryAccessor,
+      valueAccessor: fields.has("teaVolume") ? "teaVolume" : undefined,
+      data: rows as Datum[],
+      graph: null,
+      irVersion: doc.irVersion,
+      warnings: warnings.length ? warnings : undefined,
+    }
+  }
+
+  return {
+    family: "xy",
+    recipe: "gofishInterpreter",
+    layout: interpretToXYLayout(root, { lambdas, warnings }),
+    networkLayout: null,
+    ordinalLayout: null,
+    layoutConfig: {},
+    data: rows as Datum[],
+    graph: null,
+    irVersion: doc.irVersion,
+    warnings: warnings.length ? warnings : undefined,
+  }
+}
+
+/** @deprecated Internal compatibility alias for the temporary GoFish PR preview. */
+export const fromGofishIR = unstable_fromGofishIR

--- a/src/components/recipes/gofishIRExamples.ts
+++ b/src/components/recipes/gofishIRExamples.ts
@@ -1,0 +1,560 @@
+import type { GofishIRDocument } from "./gofishIR"
+
+/**
+ * Canonical GoFish Frontend IR documents for the five gallery charts the
+ * `gofish.tsx` recipes reproduce. These are the JSON artifacts a GoFish
+ * `to_ir` / serialization-frontend pass emits (see the `gofish-ir` package):
+ * `data → operators → mark` trees with lowercase `type` tags, the
+ * `__combinator` flag on combinator-form marks, and tagged `{type:"field"}`
+ * channel accessors.
+ *
+ * They are the single source of truth for `/features/gofish-layouts`: the page
+ * runs each through `unstable_fromGofishIR` to obtain a Semiotic custom layout, its
+ * accessor `layoutConfig`, and the inline data. They double as the adapter's
+ * test fixtures, so they must stay faithful to the upstream GoFish examples
+ * they mirror:
+ *
+ * - flower            → stories/lowlevel/FlowerChart.stories.tsx
+ * - bottle            → stories/piccl/Bottle.stories.tsx
+ * - polar ribbon      → src/tests/fishPolarRibbonChart.ts
+ * - circle treemap    → stories/lowlevel/CircleTreemap.stories.tsx (Titanic fields)
+ * - memory diagram    → stories/bluefish/PythonTutor/PythonTutor.stories.tsx
+ */
+
+const seafoodRows = [
+  { lake: "Erie", species: "Walleye", count: 48, x: 0 },
+  { lake: "Erie", species: "Perch", count: 31, x: 0 },
+  { lake: "Erie", species: "Trout", count: 16, x: 0 },
+  { lake: "Huron", species: "Walleye", count: 26, x: 1 },
+  { lake: "Huron", species: "Perch", count: 18, x: 1 },
+  { lake: "Huron", species: "Trout", count: 35, x: 1 },
+  { lake: "Michigan", species: "Walleye", count: 18, x: 2 },
+  { lake: "Michigan", species: "Perch", count: 42, x: 2 },
+  { lake: "Michigan", species: "Trout", count: 27, x: 2 },
+  { lake: "Ontario", species: "Walleye", count: 22, x: 3 },
+  { lake: "Ontario", species: "Perch", count: 21, x: 3 },
+  { lake: "Ontario", species: "Trout", count: 43, x: 3 },
+  { lake: "Superior", species: "Walleye", count: 14, x: 4 },
+  { lake: "Superior", species: "Perch", count: 24, x: 4 },
+  { lake: "Superior", species: "Trout", count: 57, x: 4 }
+]
+
+const bottleRows = [
+  { id: "planning", category: "Planning", amount: 64 },
+  { id: "design", category: "Design", amount: 82 },
+  { id: "build", category: "Build", amount: 46 },
+  { id: "review", category: "Review", amount: 71 },
+  { id: "ship", category: "Ship", amount: 55 }
+]
+
+/** The Python Tutor heap/stack snapshot, inlined as a single IR data row. */
+export const pythonTutorDiagramRow = {
+  kind: "memory-snapshot",
+  stack: [
+    { name: "c", value: { pointer: 0 } },
+    { name: "d", value: { pointer: 1 } },
+    { name: "x", value: "5" }
+  ],
+  heap: [
+    {
+      values: ["12", { pointer: 1 }, "1", "0", { pointer: 2 }, { pointer: 3 }]
+    },
+    { values: ["1", "4"] },
+    { values: ["3", "10", "7", "8", { pointer: 4 }] },
+    { values: ["2", { pointer: 4 }] },
+    { values: ["3"] }
+  ],
+  heapArrangement: [
+    [0, null, 3, null],
+    [null, 1, 2, 4]
+  ]
+}
+
+/**
+ * Deterministic Titanic passenger sample (no RNG), mirroring the docs page so
+ * the IR document is self-contained. Kept modest per class so the inline rows
+ * stay reasonable to ship and display.
+ */
+export function buildTitanicSampleRows(): Array<Record<string, unknown>> {
+  const rows: Array<Record<string, unknown>> = []
+  const classSpecs = [
+    { pclass: 1, count: 90, fareBase: 24, fareSpread: 126, survivalRate: 0.64 },
+    { pclass: 2, count: 60, fareBase: 10, fareSpread: 56, survivalRate: 0.46 },
+    { pclass: 3, count: 150, fareBase: 4, fareSpread: 26, survivalRate: 0.25 }
+  ]
+  for (const spec of classSpecs) {
+    for (let i = 0; i < spec.count; i++) {
+      const wave = Math.sin(i * 1.7 + spec.pclass) * 0.5 + 0.5
+      const tail = Math.pow(1 - i / spec.count, 2.15)
+      const jitter = ((i * 37) % 23) / 23
+      const fare =
+        Math.round(
+          (spec.fareBase +
+            tail * spec.fareSpread +
+            wave * spec.fareSpread * 0.08 +
+            jitter * spec.fareSpread * 0.05) *
+            10
+        ) / 10
+      rows.push({
+        name: `class-${spec.pclass}-${i}`,
+        pclass: spec.pclass,
+        survived: ((i * 73 + spec.pclass * 29) % 100) / 100 < spec.survivalRate,
+        fare
+      })
+    }
+  }
+  return rows
+}
+
+const field = (name: string) => ({ type: "field" as const, name })
+
+// ── Flower ───────────────────────────────────────────────────────────────
+
+/**
+ * A meadow: one green stem per lake (a `scatter` placing each lake's bar at its
+ * x), topped by a polar fan of species petals. Single-chart form so the
+ * interpreter renders it directly: `scatter(by:lake)` → per lake a `layer` of
+ * a stem `rect` (height = summed catch) and a `polar` `stack` of `petal`s
+ * around the angle axis.
+ */
+export const flowerIR: GofishIRDocument = {
+  irVersion: 0,
+  ir: "gofish-frontend",
+  root: {
+    type: "chart",
+    data: { type: "inline", rows: seafoodRows },
+    operators: [{ type: "scatter", by: "lake", x: field("x") }],
+    mark: {
+      type: "layer",
+      __combinator: true,
+      children: [
+        {
+          type: "rect",
+          origin: { name: "stem" },
+          w: 5,
+          h: field("count"),
+          fill: "#2f8f46"
+        },
+        {
+          type: "layer",
+          __combinator: true,
+          options: { coord: { type: "polar" } },
+          children: [
+            {
+              type: "stack",
+              __combinator: true,
+              options: { dir: "x", by: "species", spacing: 0 },
+              children: [
+                { type: "petal", h: field("count"), fill: field("species") }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+
+// ── Bottle fill ────────────────────────────────────────────────────────────
+
+/**
+ * A row of pictorial bottles, one per category, each filled to its `amount`
+ * percentage. Grammar-first with one `derive`: `bottleGeometry` emits the
+ * per-bottle normalized geometry under `_b`; the marks render it with the
+ * reusable `image` + clip primitives — an `image` of the bottle silhouette, a
+ * green fill `rect` clipped to that silhouette, a fill line, a percentage
+ * label, a category label, and a transparent hit rect carrying the datum.
+ */
+export const bottleIR: GofishIRDocument = {
+  irVersion: 0,
+  ir: "gofish-frontend",
+  root: {
+    type: "chart",
+    data: { type: "inline", rows: bottleRows },
+    options: { axes: false },
+    operators: [
+      { type: "spread", by: "category", dir: "x", spacing: 20 },
+      { type: "derive", lambdaId: "bottleGeometry" }
+    ],
+    mark: {
+      type: "layer",
+      __combinator: true,
+      options: { coord: { type: "unit" } },
+      children: [
+        {
+          type: "image",
+          origin: { name: "bottle" },
+          href: field("_b.imageHref"),
+          x: 0,
+          y: 0,
+          w: 1,
+          h: 1
+        },
+        {
+          type: "rect",
+          origin: { name: "fill" },
+          x: field("_b.fill.x"),
+          y: field("_b.fill.y"),
+          w: field("_b.fill.w"),
+          h: field("_b.fill.h"),
+          fill: field("_b.fillFill"),
+          opacity: 0.82,
+          clip: field("_b.silhouette"),
+          interactive: false
+        },
+        {
+          type: "line",
+          origin: { name: "fillLine" },
+          x1: field("_b.fillLine.x1"),
+          x2: field("_b.fillLine.x2"),
+          y1: field("_b.fillLine.y"),
+          y2: field("_b.fillLine.y"),
+          stroke: "#6b7e88",
+          strokeWidth: 1
+        },
+        {
+          type: "text",
+          origin: { name: "pct" },
+          text: field("_b.pct.text"),
+          x: field("_b.pct.x"),
+          y: field("_b.pct.y"),
+          textAnchor: "start",
+          fontSize: 11
+        },
+        {
+          type: "text",
+          origin: { name: "label" },
+          text: field("_b.label.text"),
+          x: field("_b.label.x"),
+          y: field("_b.label.y"),
+          textAnchor: "middle",
+          fontSize: 11
+        },
+        {
+          type: "rect",
+          origin: { name: "hit" },
+          x: 0,
+          y: 0,
+          w: 1,
+          h: 1,
+          fill: "rgba(0,0,0,0)"
+        }
+      ]
+    }
+  }
+}
+
+// ── Polar ribbon ─────────────────────────────────────────────────────────
+
+/**
+ * Stacked species bars laid out radially per lake (polar coord), with one
+ * cross-lake ribbon per species connecting the matching segments.
+ */
+export const polarRibbonIR: GofishIRDocument = {
+  irVersion: 0,
+  ir: "gofish-frontend",
+  root: {
+    type: "chart",
+    data: { type: "inline", rows: seafoodRows },
+    mark: {
+      type: "layer",
+      __combinator: true,
+      options: { coord: { type: "polar", innerRadius: 0.22 } },
+      children: [
+        // Lakes spread around the angle axis (one thin radial spoke each); within
+        // a spoke the species stack outward in radius on a shared scale, so a
+        // bigger-catch lake reaches farther out.
+        {
+          type: "spread",
+          __combinator: true,
+          options: { dir: "x", by: "lake" },
+          children: [
+            {
+              type: "stack",
+              __combinator: true,
+              options: { dir: "y", by: "species", sort: "asc" },
+              children: [
+                {
+                  type: "rect",
+                  w: 0.34,
+                  h: field("count"),
+                  fill: field("species")
+                }
+              ]
+            }
+          ]
+        },
+        // One smooth ribbon per species, stitched across the lake sectors.
+        {
+          type: "connect",
+          __combinator: true,
+          options: { by: "species", opacity: 0.28 },
+          children: [{ type: "ref", selection: "species" }]
+        }
+      ]
+    }
+  }
+}
+
+// ── Titanic circle treemap ─────────────────────────────────────────────────
+
+/**
+ * A bar chart that's treemap-filled and circle-filled: a `spread` lays one
+ * equal-width bar per passenger class whose HEIGHT encodes the class's total
+ * fare (`sizeBy`), and that bar rectangle becomes a squarified `treemap` of its
+ * passengers — every fare-sized cell rendered as an inscribed circle coloured
+ * by survival.
+ */
+export const titanicCircleTreemapIR: GofishIRDocument = {
+  irVersion: 0,
+  ir: "gofish-frontend",
+  root: {
+    type: "chart",
+    data: { type: "inline", rows: buildTitanicSampleRows() },
+    mark: {
+      type: "spread",
+      __combinator: true,
+      options: { by: "pclass", dir: "x", sizeBy: "fare", spacing: 18 },
+      children: [
+        {
+          type: "treemap",
+          __combinator: true,
+          options: { valueField: "fare", paddingInner: 1.5 },
+          children: [{ type: "circle", fill: field("survived") }],
+        },
+      ],
+    },
+  },
+}
+
+// ── Python Tutor memory diagram ─────────────────────────────────────────────
+
+/**
+ * A Python Tutor runtime memory diagram: a global frame of variable bindings
+ * whose pointers arrow into a heap of linked tuples. Encoded as a `layer` of a
+ * `spread` (frame + heap) plus `arrow` connectors over `ref`s; the snapshot
+ * itself travels as a single inline data row consumed by the network recipe.
+ */
+export const pythonMemoryIR: GofishIRDocument = {
+  irVersion: 0,
+  ir: "gofish-frontend",
+  root: {
+    type: "chart",
+    data: { type: "inline", rows: [pythonTutorDiagramRow] },
+    mark: {
+      type: "layer",
+      __combinator: true,
+      children: [
+        {
+          type: "spread",
+          __combinator: true,
+          options: { dir: "x", alignment: "start", spacing: 100 },
+          children: [
+            { type: "rect", origin: { name: "globalFrame" } },
+            { type: "rect", origin: { name: "heap" } }
+          ]
+        },
+        {
+          type: "arrow",
+          __combinator: true,
+          options: { stroke: "#1A5683" },
+          children: [
+            { type: "ref", selection: "globalFrame" },
+            { type: "ref", selection: "heap" }
+          ]
+        }
+      ]
+    }
+  }
+}
+
+// ── Boba (bubble tea) cups ───────────────────────────────────────────────
+
+/**
+ * A boba-shop menu: four bubble-tea drinks spread along the category axis, each
+ * fully data-driven. Per drink, the tea + tapioca + ice volumes (plus the
+ * cup-size parameters) add up to a total volume that determines the drink
+ * height; the pearls stack at the bottom and the ice floats at the surface — so
+ * "Extra Boba" grows a taller pearl bed, "Light Ice" reads as mostly tea, and
+ * "Mega" is a bigger cup of everything.
+ *
+ * Grammar-first, per the "follow the spec as far as it can" rule: the cup, tea,
+ * straw, and lid are real `polygon`/`line` marks and the pearls/ice are real
+ * `circle`/`rect` marks. The one genuinely non-grammar step — the
+ * frustum-volume → drink-height solve and tapioca/ice packing — lives in a
+ * single `derive` lambda (`bobaGeometry`) that emits each cup's geometry the
+ * marks read (`_g.*`) plus a shared `_g.box` aspect for the `uniform` unit fit,
+ * so the cups sit on one shelf with aligned straws. Derived from Krist
+ * Wongsuphasawat's "Boba Science" notebook. Routed to the ordinal frame.
+ */
+export const bobaIR: GofishIRDocument = {
+  irVersion: 0,
+  ir: "gofish-frontend",
+  root: {
+    type: "chart",
+    data: {
+      type: "inline",
+      rows: [
+        {
+          name: "Classic",
+          teaVolume: 470,
+          bobaVolume: 95,
+          iceVolume: 60,
+          cupHeight: 15.5,
+          cupTopRadius: 4.75,
+          cupBottomRadius: 3.75,
+          bobaRadius: 0.6
+        },
+        {
+          name: "Extra Boba",
+          teaVolume: 360,
+          bobaVolume: 240,
+          iceVolume: 45,
+          cupHeight: 15.5,
+          cupTopRadius: 4.75,
+          cupBottomRadius: 3.75,
+          bobaRadius: 0.6
+        },
+        {
+          name: "Light Ice",
+          teaVolume: 500,
+          bobaVolume: 95,
+          iceVolume: 12,
+          cupHeight: 15.5,
+          cupTopRadius: 4.75,
+          cupBottomRadius: 3.75,
+          bobaRadius: 0.6
+        },
+        {
+          name: "Mega",
+          teaVolume: 660,
+          bobaVolume: 150,
+          iceVolume: 120,
+          cupHeight: 18,
+          cupTopRadius: 5.6,
+          cupBottomRadius: 4.4,
+          bobaRadius: 0.6
+        }
+      ]
+    },
+    operators: [
+      { type: "spread", by: "name", dir: "x", spacing: 24 },
+      { type: "derive", lambdaId: "bobaGeometry" }
+    ],
+    mark: {
+      type: "layer",
+      __combinator: true,
+      // `uniform` fit reads the shared content box so every cup scales by one
+      // factor; `anchorY: "end"` bottom-aligns them onto a shared shelf.
+      options: { coord: { type: "unit", fit: "uniform", boxField: "_g.box", anchorY: "end" } },
+      children: [
+        {
+          type: "polygon",
+          origin: { name: "tea" },
+          points: field("_g.tea"),
+          fill: field("teaFill")
+        },
+        {
+          type: "circle",
+          origin: { name: "pearl" },
+          repeat: "_g.pearls",
+          cx: field("x"),
+          cy: field("y"),
+          r: field("r"),
+          fill: field("fill"),
+          opacity: 0.85,
+          interactive: false
+        },
+        {
+          type: "rect",
+          origin: { name: "ice" },
+          repeat: "_g.ice",
+          x: field("x"),
+          y: field("y"),
+          w: field("w"),
+          h: field("w"),
+          rotate: field("rot"),
+          fill: field("fill"),
+          opacity: 0.85,
+          interactive: false
+        },
+        {
+          type: "polygon",
+          origin: { name: "cup" },
+          points: field("_g.cup"),
+          fill: "none",
+          stroke: field("cupStroke"),
+          strokeWidth: 2.5
+        },
+        {
+          type: "line",
+          origin: { name: "lid" },
+          x1: field("_g.lid.x1"),
+          x2: field("_g.lid.x2"),
+          y1: field("_g.lid.y"),
+          y2: field("_g.lid.y"),
+          stroke: field("lidFill"),
+          strokeWidth: 4
+        },
+        {
+          type: "polygon",
+          origin: { name: "straw" },
+          points: field("_g.straw"),
+          fill: field("strawFill"),
+          stroke: field("cupStroke"),
+          strokeWidth: 1,
+          opacity: 0.85
+        }
+      ]
+    }
+  }
+}
+
+export interface GofishIRExample {
+  key: "flower" | "bottle" | "polar" | "titanic" | "python" | "boba"
+  label: string
+  doc: GofishIRDocument
+  source: string
+}
+
+/** All five examples, in gallery order. */
+export const gofishIRExamples: readonly GofishIRExample[] = [
+  {
+    key: "flower",
+    label: "Flower chart",
+    doc: flowerIR,
+    source: "https://gofish.graphics/js/examples/flower-chart.html"
+  },
+  {
+    key: "bottle",
+    label: "Bottle fill",
+    doc: bottleIR,
+    source: "https://gofish.graphics/js/examples/bottle-fill-chart.html"
+  },
+  {
+    key: "polar",
+    label: "Polar ribbon",
+    doc: polarRibbonIR,
+    source: "https://gofish.graphics/js/examples/polar-ribbon-chart.html"
+  },
+  {
+    key: "titanic",
+    label: "Fare circle treemap",
+    doc: titanicCircleTreemapIR,
+    source:
+      "https://gofish.graphics/js/examples/titanic-fare-circle-treemap.html"
+  },
+  {
+    key: "python",
+    label: "Python memory",
+    doc: pythonMemoryIR,
+    source:
+      "https://gofish.graphics/js/examples/python-tutor-memory-diagram.html"
+  },
+  {
+    key: "boba",
+    label: "Boba cups",
+    doc: bobaIR,
+    source: "https://observablehq.com/@kristw/boba-science"
+  }
+]

--- a/src/components/recipes/gofishInterpreter.ts
+++ b/src/components/recipes/gofishInterpreter.ts
@@ -1,0 +1,1363 @@
+import { hierarchy, treemap as d3treemap, treemapSquarify } from "d3-hierarchy"
+import type { Datum } from "../charts/shared/datumTypes"
+import type { CustomLayout, LayoutContext } from "../stream/customLayout"
+import type { OrdinalCustomLayout, OrdinalLayoutContext } from "../stream/ordinalCustomLayout"
+import type { OrdinalSceneNode } from "../stream/ordinalTypes"
+import type { Style } from "../stream/types"
+import type { GofishGlyphMark } from "./gofish"
+import { createGofishGlyphLayout, datumFromFields, petalPath, polarPoint, smoothClosedPath, stableGlyphId } from "./gofish"
+import { resolveLambda } from "./gofishLambdas"
+import type { GofishLambda, GofishLambdaPrimitive } from "./gofishLambdas"
+import type {
+  GofishChannelValue,
+  GofishMarkIR,
+  GofishOperatorIR,
+  GofishRootIR,
+} from "./gofishIR"
+
+/**
+ * GoFish IR interpreter.
+ *
+ * Walks a `data → operators → mark` tree and *executes* the grammar —
+ * `group`/`spread`/`stack`/`scatter`/`treemap`/`layer`, the `polar`/`unit`
+ * coordinate transforms, mark channels through scales, and `connect`/`ref`/
+ * `arrow` relations — emitting positioned primitives. This is a real
+ * translator, not a recognizer: any spec built from these constructs renders.
+ *
+ * It is NOT GoFish's full constraint solver. GoFish elaborates `spread` to
+ * `layer + distribute + align` over a linear-system bbox; we implement the
+ * deterministic allocation/accumulation model the common acyclic specs reduce
+ * to. Constructs outside it (`table`, `cut`, `mask`, `over`/`inside`/`xor`,
+ * free-form `.constrain`) record a warning and fall back, never silently
+ * mis-render. The two sanctioned non-grammar paths — `derive` and `mark-fn`
+ * lambdas — resolve through the lambda registry.
+ */
+
+export interface InterpretOptions {
+  /** Per-call lambda overrides for `derive`/`mark-fn` (merged over the registry). */
+  lambdas?: Record<string, GofishLambda>
+  /** Collected warnings for unsupported constructs / unresolved lambdas. */
+  warnings?: string[]
+}
+
+type Coord = "none" | "unit" | "polar"
+
+interface Region {
+  /** Local-space box. `none`: pixels. `unit`: [0,1]. `polar`: θ∈[0,2π] × r∈[0,Rpx]. */
+  x0: number
+  y0: number
+  x1: number
+  y1: number
+}
+
+interface PolarFrame {
+  cx: number
+  cy: number
+  rMax: number
+}
+
+interface NamedFrame {
+  name: string
+  /** Pixel bbox + anchor (center). */
+  cx: number
+  cy: number
+  bbox: { x: number; y: number; w: number; h: number }
+}
+
+interface Relation {
+  kind: "connect" | "arrow"
+  refs: string[]
+  fill?: string
+  stroke?: string
+  opacity?: number
+  interpolation?: "linear" | "bezier"
+}
+
+interface Engine {
+  marks: GofishGlyphMark[]
+  frames: Map<string, NamedFrame>
+  relations: Relation[]
+  resolveColor: (key: string, datum?: Datum) => string
+  options: InterpretOptions
+  warnings: string[]
+  ids: { n: number }
+  /** Max absolute value per numeric field across all rows — the shared value scale. */
+  domains: Map<string, number>
+  /**
+   * Transient per-sibling-set scale override. A `spread`/`scatter` that
+   * aggregates a size channel (e.g. a stem = sum of a lake's catch) sets the
+   * domain to the max *aggregated* sibling value here, so bars scale against
+   * each other rather than the max single row. Restored after the subtree.
+   */
+  sizeOverride: Map<string, number>
+  /** Polar segments recorded for ribbon stitching (a `connect` over series). */
+  polarSegments: Array<{ group?: string; cx: number; cy: number; innerR: number; outerR: number; theta0: number; theta1: number }>
+}
+
+// ── Channel resolution ───────────────────────────────────────────────────
+
+function readField(datum: Datum | undefined, path: string): unknown {
+  if (!datum) return undefined
+  if (!path.includes(".")) return datum[path]
+  return path.split(".").reduce<unknown>((acc, key) => (acc == null ? undefined : (acc as Datum)[key]), datum)
+}
+
+/** Resolve a channel to a concrete value for a datum. */
+function channel(value: GofishChannelValue | undefined, datum: Datum | undefined): unknown {
+  if (value == null) return undefined
+  if (typeof value === "object") {
+    const v = value as { type?: string; name?: string; datum?: unknown }
+    if (v.type === "field" && typeof v.name === "string") return readField(datum, v.name)
+    if (v.type === "datum") return v.datum
+    return undefined
+  }
+  if (typeof value === "string") {
+    const field = readField(datum, value)
+    return field !== undefined ? field : value // bare string = field, else literal
+  }
+  return value
+}
+
+function numChannel(value: GofishChannelValue | undefined, datum: Datum | undefined): number | undefined {
+  const v = channel(value, datum)
+  const n = Number(v)
+  return Number.isFinite(n) ? n : undefined
+}
+
+function sumChannel(value: GofishChannelValue | undefined, rows: Datum[]): number {
+  let sum = 0
+  for (const r of rows) {
+    const n = numChannel(value, r)
+    if (n != null) sum += n
+  }
+  return sum
+}
+
+/** The data field a channel reads, or null for a literal. */
+function fieldOf(value: GofishChannelValue | undefined): string | null {
+  if (value == null) return null
+  if (typeof value === "object") {
+    const v = value as { type?: string; name?: string }
+    return v.type === "field" && typeof v.name === "string" ? v.name : null
+  }
+  return null
+}
+
+/**
+ * Pixel extent for a size channel within an axis extent:
+ * - field  → value-scaled bar (sum / global-max × extent)
+ * - number → literal pixels (clamped)
+ * - absent → fills the extent
+ */
+function sizePx(value: GofishChannelValue | undefined, rows: Datum[], extent: number, engine: Engine): number {
+  const field = fieldOf(value)
+  if (field) {
+    const max = engine.sizeOverride.get(field) ?? engine.domains.get(field) ?? 0
+    if (max <= 0) return extent
+    return Math.max(0, Math.min(1, sumChannel(value, rows) / max)) * extent
+  }
+  if (typeof value === "number") return Math.min(value, extent)
+  return extent
+}
+
+/** The field a node's cross-axis size channel reads (first such leaf), or null. */
+function leafSizeField(node: GofishMarkIR, axis: "x" | "y"): string | null {
+  if (isCombinator(node)) {
+    for (const child of node.children ?? []) {
+      const f = leafSizeField(child, axis)
+      if (f) return f
+    }
+    return null
+  }
+  return fieldOf((axis === "y" ? node.h : node.w) as GofishChannelValue)
+}
+
+/**
+ * Set the shared scale for a value-scaled sibling set: the domain is the max
+ * *aggregated* value across groups (so a summed stem isn't measured against the
+ * max single row). Returns a restore fn. No-op when there is no field/`by`.
+ */
+function withAggregatedScale(
+  node: GofishMarkIR,
+  groups: Array<{ rows: Datum[] }>,
+  axis: "x" | "y",
+  engine: Engine
+): () => void {
+  const template = (node.children ?? [])[0]
+  if (!template || groups.length === 0) return () => {}
+  const field = leafSizeField(template, axis)
+  if (!field) return () => {}
+  const channel: GofishChannelValue = { type: "field", name: field }
+  const max = Math.max(...groups.map((g) => sumChannel(channel, g.rows)), 0)
+  if (max <= (engine.domains.get(field) ?? 0)) return () => {}
+  const prev = engine.sizeOverride.get(field)
+  engine.sizeOverride.set(field, max)
+  return () => {
+    if (prev === undefined) engine.sizeOverride.delete(field)
+    else engine.sizeOverride.set(field, prev)
+  }
+}
+
+// ── Operator/mark helpers ──────────────────────────────────────────────────
+
+const LAYOUT_OPS = new Set(["spread", "stack", "scatter", "treemap", "group"])
+const DATA_OPS = new Set(["derive", "log"])
+
+function applyDataOperators(
+  rows: Datum[],
+  operators: GofishOperatorIR[],
+  options: InterpretOptions,
+  warnings: string[]
+): Datum[] {
+  let next = rows
+  for (const op of operators) {
+    if (op.type === "derive") {
+      const id = op.lambdaId as string | undefined
+      const lambda = id ? resolveLambda(id, options.lambdas) : undefined
+      if (lambda && lambda.kind === "derive") next = lambda.fn(next)
+      else if (id) warnings.push(`derive lambda "${id}" is not registered; passing data through.`)
+    }
+  }
+  return next
+}
+
+function rootWithFrameData(root: GofishRootIR, data: Datum[]): GofishRootIR {
+  const rows = data as Array<Record<string, unknown>>
+  if (root.type === "chart") {
+    if (root.data?.type !== "inline") return root
+    return { ...root, data: { ...root.data, rows } }
+  }
+  if (root.type === "layer") {
+    return {
+      ...root,
+      charts: root.charts.map((chart) =>
+        chart.data?.type === "inline"
+          ? { ...chart, data: { ...chart.data, rows } }
+          : chart
+      ),
+    }
+  }
+  return root
+}
+
+/** Fold a chart's `.flow()` operators into a single combinator-mark tree around the mark. */
+function chartToNode(operators: GofishOperatorIR[], mark: GofishMarkIR): GofishMarkIR {
+  let node = mark
+  for (let i = operators.length - 1; i >= 0; i--) {
+    const op = operators[i]
+    node = {
+      type: op.type,
+      __combinator: true,
+      options: { ...op },
+      children: [node],
+    } as GofishMarkIR
+  }
+  return node
+}
+
+function partition(rows: Datum[], by: string): Array<{ key: string; rows: Datum[] }> {
+  const order: string[] = []
+  const map = new Map<string, Datum[]>()
+  const field = by.startsWith("datum.") ? by.slice("datum.".length) : by
+  for (const r of rows) {
+    const k = String(readField(r, field))
+    if (!map.has(k)) {
+      map.set(k, [])
+      order.push(k)
+    }
+    map.get(k)!.push(r)
+  }
+  return order.map((key) => ({ key, rows: map.get(key)! }))
+}
+
+/** Raw (unscaled) size of a node along an axis — used to allocate stacks. */
+function sizeValue(node: GofishMarkIR, rows: Datum[], axis: "x" | "y"): number {
+  if (isCombinator(node)) {
+    const dir = (node.options?.dir as string) ?? "y"
+    const kids = node.children ?? []
+    if (node.type === "stack") {
+      // glued: sum along its dir, else max
+      const childSizes = kids.map((k) => sizeValue(k, rows, axis))
+      return dir === axis ? childSizes.reduce((a, b) => a + b, 0) : Math.max(0, ...childSizes)
+    }
+    return Math.max(0, ...kids.map((k) => sizeValue(k, rows, axis)), 1)
+  }
+  const ch = axis === "y" ? node.h : node.w
+  const v = sumChannel(ch as GofishChannelValue, rows)
+  return v > 0 ? v : rows.length || 1
+}
+
+function isCombinator(node: GofishMarkIR): boolean {
+  return node.__combinator === true && Array.isArray(node.children)
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function nextId(engine: Engine, prefix: string): string {
+  engine.ids.n += 1
+  return `${prefix}-${engine.ids.n}`
+}
+
+/** Sample `n+1` points along an arc — for filled polar wedges / ribbons. */
+function sampleArc(cx: number, cy: number, r: number, t0: number, t1: number, n: number): Array<[number, number]> {
+  const pts: Array<[number, number]> = []
+  for (let i = 0; i <= n; i++) pts.push(polarPoint(cx, cy, r, t0 + (t1 - t0) * (i / n)))
+  return pts
+}
+
+// ── Core walk ────────────────────────────────────────────────────────────
+
+function place(
+  node: GofishMarkIR,
+  region: Region,
+  rows: Datum[],
+  coord: Coord,
+  polar: PolarFrame | null,
+  engine: Engine,
+  fill = false
+): void {
+  // Coordinate transform on this node?
+  const coordObj = node.options?.coord as UnitCoordOption | undefined
+  const coordOpt = coordObj?.type
+  if (coordOpt === "polar" && coord !== "polar") {
+    const cx = (region.x0 + region.x1) / 2
+    const cy = (region.y0 + region.y1) / 2
+    const rMax = Math.min(Math.abs(region.x1 - region.x0), Math.abs(region.y1 - region.y0)) / 2
+    const pf: PolarFrame = { cx, cy, rMax }
+    // An inner-radius fraction leaves a center hole (radial bars start there).
+    const innerR = typeof coordObj?.innerRadius === "number" ? Math.max(0, Math.min(0.95, coordObj.innerRadius)) * rMax : 0
+    const polarRegion: Region = { x0: 0, y0: innerR, x1: 2 * Math.PI, y1: rMax }
+    placeChildrenInto(node, polarRegion, rows, "polar", pf, engine)
+    return
+  }
+  if (coordOpt === "unit" && coord !== "unit") {
+    // Establish a unit [0,1] region mapped onto the pixel region. The default
+    // `fill` projection stretches [0,1]² across the region; `fit: "uniform"`
+    // scales x/y by a single factor (aspect-preserving) so a pictorial glyph —
+    // round pearls, square ice — isn't distorted, and anchors the content box
+    // within the region (e.g. cups sitting on a shared baseline).
+    const proj = makeUnitProjection(region, coordObj, rows[0])
+    for (const child of node.children ?? []) emitLeafUnit(child, region, rows, engine, proj)
+    return
+  }
+
+  if (isCombinator(node)) {
+    placeCombinator(node, region, rows, coord, polar, engine, fill)
+    return
+  }
+  emitLeaf(node, region, rows, coord, polar, engine, fill)
+}
+
+/** Re-dispatch a coord-wrapping `layer`/combinator's children in the new coord. */
+function placeChildrenInto(
+  node: GofishMarkIR,
+  region: Region,
+  rows: Datum[],
+  coord: Coord,
+  polar: PolarFrame | null,
+  engine: Engine
+): void {
+  for (const child of node.children ?? []) place(child, region, rows, coord, polar, engine)
+}
+
+interface UnitCoordOption {
+  type?: string
+  innerRadius?: number
+  /** `"fill"` (default) stretches [0,1]² across the region; `"uniform"` preserves aspect. */
+  fit?: "fill" | "uniform"
+  /** Datum field carrying the content box `[bw, bh]` (uniform fit only); default `[1, 1]`. */
+  boxField?: string
+  /** Horizontal anchor of the content box within the region (uniform fit). @default "center" */
+  anchorX?: "start" | "center" | "end"
+  /** Vertical anchor of the content box within the region (uniform fit). @default "center" */
+  anchorY?: "start" | "center" | "end"
+}
+
+/** Maps unit [0,1] coords onto a pixel region — `ux`/`uy` for points, `us` for sizes/radii. */
+interface UnitProjection {
+  ux: (v: number) => number
+  uy: (v: number) => number
+  us: (v: number) => number
+}
+
+function makeUnitProjection(region: Region, coord: UnitCoordOption | undefined, datum: Datum | undefined): UnitProjection {
+  const x0 = Math.min(region.x0, region.x1)
+  const y0 = Math.min(region.y0, region.y1)
+  const w = Math.abs(region.x1 - region.x0)
+  const h = Math.abs(region.y1 - region.y0)
+  if (coord?.fit !== "uniform") {
+    return { ux: (v) => x0 + v * w, uy: (v) => y0 + v * h, us: (v) => v * Math.min(w, h) }
+  }
+  let bw = 1
+  let bh = 1
+  const box = coord.boxField ? readField(datum, coord.boxField) : undefined
+  if (Array.isArray(box) && box.length === 2) {
+    bw = Number(box[0]) > 0 ? Number(box[0]) : 1
+    bh = Number(box[1]) > 0 ? Number(box[1]) : 1
+  }
+  const s = Math.min(w / bw, h / bh)
+  const slackX = w - s * bw
+  const slackY = h - s * bh
+  const offX = coord.anchorX === "start" ? 0 : coord.anchorX === "end" ? slackX : slackX / 2
+  const offY = coord.anchorY === "start" ? 0 : coord.anchorY === "end" ? slackY : slackY / 2
+  return { ux: (v) => x0 + offX + v * s, uy: (v) => y0 + offY + v * s, us: (v) => v * s }
+}
+
+function placeCombinator(
+  node: GofishMarkIR,
+  region: Region,
+  rows: Datum[],
+  coord: Coord,
+  polar: PolarFrame | null,
+  engine: Engine,
+  fill: boolean
+): void {
+  const opt = node.options ?? {}
+  const type = node.type
+
+  if (type === "derive" || type === "log") {
+    const id = opt.lambdaId as string | undefined
+    let next = rows
+    if (type === "derive") {
+      const lambda = id ? resolveLambda(id, engine.options.lambdas) : undefined
+      if (lambda && lambda.kind === "derive") next = lambda.fn(rows)
+      else if (id) engine.warnings.push(`derive lambda "${id}" is not registered; passing data through.`)
+    }
+    for (const child of node.children ?? []) place(child, region, next, coord, polar, engine, fill)
+    return
+  }
+
+  if (type === "layer") {
+    const kids = node.children ?? []
+    const isBar = (c: GofishMarkIR): boolean =>
+      !isCombinator(c) && (c.type === "rect" || c.type === "area") && fieldOf((c.h ?? c.w) as GofishChannelValue) != null
+    const hasPolar = (c: GofishMarkIR): boolean => (c.options?.coord as { type?: string } | undefined)?.type === "polar"
+    const bars = kids.filter(isBar)
+    // Anchor glyph siblings (e.g. a polar flower head) to the top of a value-bar
+    // sibling, so a flower sits atop its stem instead of floating mid-column.
+    let anchorY: number | null = null
+    let anchorX: number | null = null
+    for (const child of bars) {
+      place(child, region, rows, coord, polar, engine, fill)
+      if (coord === "none") {
+        const h = sizePx(child.h as GofishChannelValue, rows, region.y1 - region.y0, engine)
+        anchorY = region.y1 - h
+        anchorX = (region.x0 + region.x1) / 2
+      }
+    }
+    for (const child of kids) {
+      if (isBar(child)) continue
+      if (anchorY != null && anchorX != null && hasPolar(child)) {
+        // The polar layer may set `radiusFactor` (fraction of the column) to
+        // size its glyph head; default 0.2.
+        const factor = typeof child.options?.radiusFactor === "number" ? (child.options.radiusFactor as number) : 0.2
+        const radius = Math.min(Math.abs(region.x1 - region.x0), Math.abs(region.y1 - region.y0)) * factor
+        const sub: Region = { x0: anchorX - radius, y0: anchorY - radius, x1: anchorX + radius, y1: anchorY + radius }
+        place(child, sub, rows, coord, polar, engine, fill)
+      } else {
+        place(child, region, rows, coord, polar, engine, fill)
+      }
+    }
+    return
+  }
+
+  const by = opt.by as string | undefined
+
+  if (type === "group") {
+    const groups = by ? partition(rows, by) : [{ key: "", rows }]
+    const child = (node.children ?? [])[0]
+    if (!child) return
+    for (const g of groups) place(child, region, g.rows, coord, polar, engine, fill)
+    return
+  }
+
+  if (type === "spread") {
+    distribute(node, region, rows, coord, polar, engine, false)
+    return
+  }
+  if (type === "stack") {
+    distribute(node, region, rows, coord, polar, engine, true)
+    return
+  }
+  if (type === "scatter") {
+    scatter(node, region, rows, coord, polar, engine)
+    return
+  }
+  if (type === "treemap") {
+    treemap(node, region, rows, coord, polar, engine)
+    return
+  }
+  if (type === "connect" || type === "arrow") {
+    recordRelation(node, rows, engine)
+    return
+  }
+
+  engine.warnings.push(`Unsupported combinator "${type}" — children skipped.`)
+}
+
+/** Build the list of (child node, rows, key) instances a layout op lays out. */
+function instances(
+  node: GofishMarkIR,
+  rows: Datum[]
+): Array<{ node: GofishMarkIR; rows: Datum[]; key: string }> {
+  const by = node.options?.by as string | undefined
+  const kids = node.children ?? []
+  if (by) {
+    const template = kids[0]
+    return partition(rows, by).map((g) => ({ node: template, rows: g.rows, key: g.key }))
+  }
+  if (kids.length > 1) return kids.map((k, i) => ({ node: k, rows, key: String(i) }))
+  // single child: a leaf maps per row, a combinator takes the whole scope
+  const only = kids[0]
+  if (only && !isCombinator(only) && rows.length > 1) {
+    return rows.map((r, i) => ({ node: only, rows: [r], key: String(i) }))
+  }
+  return only ? [{ node: only, rows, key: "0" }] : []
+}
+
+function distribute(
+  node: GofishMarkIR,
+  region: Region,
+  rows: Datum[],
+  coord: Coord,
+  polar: PolarFrame | null,
+  engine: Engine,
+  glue: boolean
+): void {
+  const dir = ((node.options?.dir as string) ?? "x") === "y" ? "y" : "x"
+  const spacing = Number(node.options?.spacing) || 0
+  const items = instances(node, rows)
+  if (items.length === 0) return
+  // `sort: "asc" | "desc"` orders the segments by magnitude along this axis,
+  // per group — e.g. each polar spoke stacks its species by count. Default is
+  // insertion order.
+  const sort = node.options?.sort
+  if (sort === "asc" || sort === "desc") {
+    items.sort((a, b) => {
+      const av = sizeValue(a.node, a.rows, dir)
+      const bv = sizeValue(b.node, b.rows, dir)
+      return sort === "asc" ? av - bv : bv - av
+    })
+  }
+  const axisLo = dir === "x" ? region.x0 : region.y0
+  const axisHi = dir === "x" ? region.x1 : region.y1
+  const extent = axisHi - axisLo
+
+  if (!glue) {
+    // spread: even slots along `dir`; children value-scale within their slot
+    // against a shared scale over the max aggregated slot value.
+    const crossAxis = dir === "x" ? "y" : "x"
+    const restore = withAggregatedScale(node, items, crossAxis, engine)
+    // `sizeBy: <field>` makes this a bar chart: each slot's cross-extent (bar
+    // height for dir:"x") is sum(field) on a shared scale, anchored to the far
+    // edge — so the slot region a child fills is a value-scaled bar.
+    const sizeBy = node.options?.sizeBy as string | undefined
+    const crossVals = sizeBy ? items.map((it) => sumChannel({ type: "field", name: sizeBy }, it.rows)) : []
+    const crossMax = sizeBy ? Math.max(...crossVals, 0) : 0
+    const slot = (extent - spacing * (items.length - 1)) / items.length
+    items.forEach((it, i) => {
+      const lo = axisLo + i * (slot + spacing)
+      let sub = subRegion(region, dir, lo, lo + slot)
+      if (sizeBy && crossMax > 0) sub = barRegion(sub, crossAxis, Math.max(0.02, crossVals[i] / crossMax))
+      place(it.node, sub, it.rows, coord, polar, engine, false)
+    })
+    restore()
+    return
+  }
+
+  // stack: segments accumulate by value. By default the stack fills its extent
+  // (a 100%-style stack). But when an ancestor `spread`/`scatter` set a shared
+  // scale for this size field (e.g. radial bars across lakes), scale against
+  // that shared max instead — so a smaller-total stack is genuinely shorter.
+  const sizes = items.map((it) => sizeValue(it.node, it.rows, dir))
+  const total = sizes.reduce((a, b) => a + b, 0) || 1
+  const usable = extent - spacing * (items.length - 1)
+  const sizeField = items[0] ? leafSizeField(items[0].node, dir) : null
+  const sharedMax = sizeField ? engine.sizeOverride.get(sizeField) : undefined
+  const scale = sharedMax && sharedMax > 0 ? usable / sharedMax : usable / total
+  let cursor = axisLo
+  items.forEach((it, i) => {
+    const len = sizes[i] * scale
+    const sub = subRegion(region, dir, cursor, cursor + len)
+    place(it.node, sub, it.rows, coord, polar, engine, true)
+    cursor += len + spacing
+  })
+}
+
+function subRegion(region: Region, dir: "x" | "y", lo: number, hi: number): Region {
+  return dir === "x"
+    ? { x0: lo, y0: region.y0, x1: hi, y1: region.y1 }
+    : { x0: region.x0, y0: lo, x1: region.x1, y1: hi }
+}
+
+/** Shrink a region's cross axis to `frac`, anchored to the far edge (bar growth). */
+function barRegion(region: Region, crossAxis: "x" | "y", frac: number): Region {
+  if (crossAxis === "y") {
+    const h = (region.y1 - region.y0) * frac
+    return { ...region, y0: region.y1 - h } // grow up from the bottom
+  }
+  const w = (region.x1 - region.x0) * frac
+  return { ...region, x1: region.x0 + w } // grow right from the left
+}
+
+function scatter(
+  node: GofishMarkIR,
+  region: Region,
+  rows: Datum[],
+  coord: Coord,
+  polar: PolarFrame | null,
+  engine: Engine
+): void {
+  const opt = node.options ?? {}
+  const child = (node.children ?? [])[0]
+  if (!child) return
+  const by = opt.by as string | undefined
+
+  // With `by`: one positioned slot per group (the group's rows flow to the
+  // child, which aggregates). Without: one slot per row.
+  const slots = by
+    ? partition(rows, by).map((g) => ({ rows: g.rows, anchor: g.rows[0] }))
+    : rows.map((r) => ({ rows: [r], anchor: r }))
+
+  const anchors = slots.map((s) => s.anchor)
+  const xs = anchors.map((r) => numChannel(opt.x as GofishChannelValue, r)).filter((v): v is number => v != null)
+  const ys = anchors.map((r) => numChannel(opt.y as GofishChannelValue, r)).filter((v): v is number => v != null)
+  const regionW = Math.abs(region.x1 - region.x0)
+  const fullH = Math.abs(region.y1 - region.y0)
+  // Inset the position scales so edge glyphs aren't pinned to the plot border,
+  // and reserve top headroom (for a glyph atop a bar) + a little baseline room.
+  const xPad = Math.min(regionW * 0.5, (regionW / Math.max(1, slots.length)) * 0.5)
+  const topPad = fullH * 0.12
+  const botPad = fullH * 0.06
+  const xScale = makeScale(xs, region.x0 + xPad, region.x1 - xPad)
+  const yScale = makeScale(ys, region.y1 - botPad, region.y0 + topPad) // y inverted
+  // Bars across slots share a scale over the max aggregated slot value.
+  const restore = withAggregatedScale(node, slots, "y", engine)
+  for (const slot of slots) {
+    const cxv = numChannel(opt.x as GofishChannelValue, slot.anchor)
+    const cyv = numChannel(opt.y as GofishChannelValue, slot.anchor)
+    const px = cxv != null ? xScale(cxv) : (region.x0 + region.x1) / 2
+    const half = Math.min(regionW / Math.max(1, slots.length), fullH) * 0.4
+    const sub: Region = cyv != null && opt.y != null
+      ? { x0: px - half, y0: yScale(cyv) - half, x1: px + half, y1: yScale(cyv) + half }
+      : { x0: px - half, y0: region.y0 + topPad, x1: px + half, y1: region.y1 - botPad }
+    place(child, sub, slot.rows, coord, polar, engine)
+  }
+  restore()
+}
+
+function makeScale(values: number[], lo: number, hi: number): (v: number) => number {
+  if (values.length === 0) return () => (lo + hi) / 2
+  let min = Math.min(...values)
+  let max = Math.max(...values)
+  if (min === max) {
+    min -= 0.5
+    max += 0.5
+  }
+  return (v: number) => lo + ((v - min) / (max - min)) * (hi - lo)
+}
+
+interface TreemapDatum {
+  value?: number
+  item?: { rows: Datum[]; key: string }
+  children?: TreemapDatum[]
+}
+
+function treemap(
+  node: GofishMarkIR,
+  region: Region,
+  rows: Datum[],
+  coord: Coord,
+  polar: PolarFrame | null,
+  engine: Engine
+): void {
+  const opt = node.options ?? {}
+  const by = opt.by as string | undefined
+  const valueField = opt.valueField as string | undefined
+  const child = (node.children ?? [])[0]
+  if (!child) return
+  // Cells: one per `by` group, else one per row. Nest a `treemap` child to get
+  // a treemap-of-treemaps (e.g. classes → passengers).
+  const items = by ? partition(rows, by) : rows.map((r, i) => ({ key: String(i), rows: [r] }))
+  const valueOf = (rs: Datum[]): number =>
+    valueField ? Math.max(0, sumChannel({ type: "field", name: valueField }, rs)) : rs.length
+  const leaves: TreemapDatum[] = items
+    .map((it) => ({ value: valueOf(it.rows), item: { rows: it.rows, key: it.key } }))
+    .filter((l) => (l.value ?? 0) > 0)
+  if (leaves.length === 0) return
+  const w = Math.max(1, region.x1 - region.x0)
+  const h = Math.max(1, region.y1 - region.y0)
+  const pad = Number(opt.paddingInner) || 1
+  // Real squarified treemap (low-aspect cells) via d3-hierarchy.
+  const layout = d3treemap<TreemapDatum>().tile(treemapSquarify).size([w, h]).paddingInner(pad).round(true)
+  const root = layout(hierarchy<TreemapDatum>({ children: leaves }).sum((d) => d.value ?? 0))
+  for (const leaf of root.leaves()) {
+    const it = leaf.data.item
+    if (!it) continue
+    const cell: Region = {
+      x0: region.x0 + leaf.x0,
+      y0: region.y0 + leaf.y0,
+      x1: region.x0 + leaf.x1,
+      y1: region.y0 + leaf.y1,
+    }
+    place(child, cell, it.rows, coord, polar, engine, true)
+  }
+}
+
+// ── Leaf marks ──────────────────────────────────────────────────────────
+
+function emitLeaf(
+  node: GofishMarkIR,
+  region: Region,
+  rows: Datum[],
+  coord: Coord,
+  polar: PolarFrame | null,
+  engine: Engine,
+  fill: boolean
+): void {
+  if (node.type === "mark-fn") {
+    emitMarkFn(node, region, rows[0] ?? null, engine)
+    return
+  }
+  // `repeat`: iterate an array field of the single datum, instantiating per
+  // element in the region's unit space (fill projection). Strip `repeat` on the
+  // per-element node so the element's emission doesn't re-enter this branch.
+  const repeat = node.repeat as string | undefined
+  if (repeat) {
+    const arr = readField(rows[0], repeat)
+    if (Array.isArray(arr)) {
+      const proj = makeUnitProjection(region, undefined, rows[0])
+      const elNode = { ...node, repeat: undefined }
+      for (const el of arr) emitLeafUnit(elNode, region, [el as Datum], engine, proj)
+    }
+    return
+  }
+  if (coord === "polar" && polar) {
+    emitPolarLeaf(node, region, rows, polar, engine)
+    return
+  }
+  emitPixelLeaf(node, region, rows, engine, fill)
+}
+
+/** Project a unit-coord leaf ([0,1]) onto a pixel region via the unit projection. */
+function emitLeafUnit(node: GofishMarkIR, region: Region, rows: Datum[], engine: Engine, proj: UnitProjection): void {
+  const repeat = node.repeat as string | undefined
+  if (repeat) {
+    const arr = readField(rows[0], repeat)
+    if (Array.isArray(arr)) {
+      const elNode = { ...node, repeat: undefined }
+      for (const el of arr) emitLeafUnit(elNode, region, [el as Datum], engine, proj)
+    }
+    return
+  }
+  const { ux, uy, us } = proj
+  const datum = rows[0] ?? null
+  const id = node.origin?.name ?? node.name ?? nextId(engine, node.type)
+  // A `clip` channel (unit point array) → an SVG path in pixel coords, so a
+  // fill or image can be clipped to a silhouette.
+  const clipPts = channel(node.clip as GofishChannelValue, datum)
+  const clipPath = Array.isArray(clipPts) && clipPts.length
+    ? `M${(clipPts as Array<[number, number]>).map((p) => `${ux(p[0])},${uy(p[1])}`).join(" L")} Z`
+    : undefined
+
+  if (node.type === "polygon") {
+    const pts = channel(node.points as GofishChannelValue, datum) as Array<[number, number]> | undefined
+    if (!Array.isArray(pts) || pts.length === 0) return
+    const d = `M${pts.map((p) => `${ux(p[0])},${uy(p[1])}`).join(" L")} Z`
+    engine.marks.push({ kind: "path", id: nextId(engine, id), d, style: styleOf(node, datum, engine), clipPath })
+    return
+  }
+  if (node.type === "image") {
+    const href = channel(node.href as GofishChannelValue, datum)
+    if (typeof href !== "string" || !href) return
+    const x = numChannel(node.x as GofishChannelValue, datum) ?? 0
+    const y = numChannel(node.y as GofishChannelValue, datum) ?? 0
+    const iw = numChannel(node.w as GofishChannelValue, datum) ?? 1
+    const ih = numChannel(node.h as GofishChannelValue, datum) ?? 1
+    engine.marks.push({
+      kind: "image",
+      id: nextId(engine, id),
+      href,
+      x: ux(x),
+      y: uy(y),
+      width: ux(x + iw) - ux(x),
+      height: uy(y + ih) - uy(y),
+      opacity: numChannel(node.opacity as GofishChannelValue, datum),
+      clipPath,
+    })
+    return
+  }
+  if (node.type === "circle") {
+    const cx = numChannel(node.cx as GofishChannelValue, datum) ?? numChannel(node.x as GofishChannelValue, datum) ?? 0.5
+    const cy = numChannel(node.cy as GofishChannelValue, datum) ?? numChannel(node.y as GofishChannelValue, datum) ?? 0.5
+    const r = numChannel(node.r as GofishChannelValue, datum) ?? 0.02
+    engine.marks.push({
+      kind: "circle",
+      id: nextId(engine, id),
+      cx: ux(cx),
+      cy: uy(cy),
+      r: us(r),
+      style: styleOf(node, datum, engine),
+      datum: datum ?? undefined,
+      interactive: node.interactive as boolean | undefined,
+    })
+    return
+  }
+  if (node.type === "rect") {
+    const rot = numChannel(node.rotate as GofishChannelValue, datum)
+    if (rot != null) {
+      // Centered, square-ish glyph (e.g. a rotated ice cube): x/y are the center.
+      const cxp = ux(numChannel(node.x as GofishChannelValue, datum) ?? 0.5)
+      const cyp = uy(numChannel(node.y as GofishChannelValue, datum) ?? 0.5)
+      const side = us(numChannel(node.w as GofishChannelValue, datum) ?? 0.05)
+      const d = rotatedRectPath(cxp - side / 2, cyp - side / 2, side, side, rot, cxp, cyp)
+      engine.marks.push({ kind: "path", id: nextId(engine, id), d, style: styleOf(node, datum, engine) })
+      return
+    }
+    // Region rect: x/y are the top-left; width/height span the box (per axis,
+    // not the min dimension) so a full-slot fill or hit target works.
+    const x = numChannel(node.x as GofishChannelValue, datum) ?? 0
+    const y = numChannel(node.y as GofishChannelValue, datum) ?? 0
+    const rw = numChannel(node.w as GofishChannelValue, datum) ?? 1
+    const rh = numChannel(node.h as GofishChannelValue, datum) ?? 1
+    engine.marks.push({
+      kind: "rect",
+      id: nextId(engine, id),
+      x: ux(x),
+      y: uy(y),
+      width: ux(x + rw) - ux(x),
+      height: uy(y + rh) - uy(y),
+      style: styleOf(node, datum, engine),
+      datum: datum ?? undefined,
+      group: groupKey(node, datum),
+      interactive: node.interactive as boolean | undefined,
+      clipPath,
+    })
+    return
+  }
+  if (node.type === "line") {
+    engine.marks.push({
+      kind: "line",
+      id: nextId(engine, id),
+      x1: ux(numChannel(node.x1 as GofishChannelValue, datum) ?? 0),
+      y1: uy(numChannel(node.y1 as GofishChannelValue, datum) ?? 0),
+      x2: ux(numChannel(node.x2 as GofishChannelValue, datum) ?? 1),
+      y2: uy(numChannel(node.y2 as GofishChannelValue, datum) ?? 0),
+      style: styleOf(node, datum, engine),
+    })
+    return
+  }
+  if (node.type === "text") {
+    const text = channel(node.text as GofishChannelValue, datum)
+    engine.marks.push({
+      kind: "text",
+      id: nextId(engine, id),
+      x: ux(numChannel(node.x as GofishChannelValue, datum) ?? 0.5),
+      y: uy(numChannel(node.y as GofishChannelValue, datum) ?? 0.95),
+      text: text == null ? "" : String(text),
+      fontSize: Number(node.fontSize) || 11,
+      textAnchor: (node.textAnchor as "start" | "middle" | "end") ?? "middle",
+      style: { fill: "var(--semiotic-text-secondary, #667)" },
+    })
+    return
+  }
+  emitTextOrFallback(node, ux(0.5), uy(0.95), datum, engine)
+}
+
+/** Pixel-space leaf (coord none): fill (parent pre-sized it) or value-scale a bar. */
+function emitPixelLeaf(node: GofishMarkIR, region: Region, rows: Datum[], engine: Engine, fill: boolean): void {
+  const datum = rows[0] ?? null
+  const id = node.origin?.name ?? node.name ?? node.type
+  const x0 = Math.min(region.x0, region.x1)
+  const x1 = Math.max(region.x0, region.x1)
+  const y0 = Math.min(region.y0, region.y1)
+  const y1 = Math.max(region.y0, region.y1)
+  const literalOrFill = (v: GofishChannelValue | undefined, ext: number): number =>
+    typeof v === "number" ? Math.min(v, ext) : ext
+
+  if (node.type === "rect" || node.type === "image") {
+    const regionW = x1 - x0
+    const regionH = y1 - y0
+    // fill: the stack/treemap already sized this region by the value → fill it
+    // (honoring a literal w/h). Otherwise value-scale a bottom-anchored bar.
+    const w = fill ? literalOrFill(node.w as GofishChannelValue, regionW) : sizePx(node.w as GofishChannelValue, rows, regionW, engine)
+    const h = fill ? literalOrFill(node.h as GofishChannelValue, regionH) : sizePx(node.h as GofishChannelValue, rows, regionH, engine)
+    // Bars anchor to the bottom; width centers in the slot.
+    engine.marks.push({
+      kind: "rect",
+      id: nextId(engine, id),
+      x: x0 + (regionW - w) / 2,
+      y: y1 - h,
+      width: Math.max(0, w),
+      height: Math.max(0, h),
+      style: styleOf(node, datum, engine, rows),
+      datum: aggregateDatum(node, rows),
+      group: groupKey(node, datum),
+      interactive: node.interactive as boolean | undefined,
+    })
+    if (node.type === "image") {
+      engine.warnings.push(`image mark "${id}" rendered as a placeholder rect (href not loaded).`)
+    }
+    return
+  }
+  if (node.type === "circle") {
+    const cx = (x0 + x1) / 2
+    const cy = (y0 + y1) / 2
+    const r = Math.min(x1 - x0, y1 - y0) / 2
+    engine.marks.push({
+      kind: "circle",
+      id: nextId(engine, id),
+      cx,
+      cy,
+      r: Math.max(0, r),
+      style: styleOf(node, datum, engine, rows),
+      datum: aggregateDatum(node, rows),
+      group: groupKey(node, datum),
+      interactive: node.interactive as boolean | undefined,
+    })
+    return
+  }
+  if (node.type === "line") {
+    engine.marks.push({ kind: "line", id: nextId(engine, id), x1: x0, y1: y1, x2: x1, y2: y0, style: styleOf(node, datum, engine, rows) })
+    return
+  }
+  emitTextOrFallback(node, (x0 + x1) / 2, (y0 + y1) / 2, datum, engine)
+}
+
+/** Polar leaf: a rect becomes an annular band; circle a dot at (θ,r) center. */
+function emitPolarLeaf(node: GofishMarkIR, region: Region, rows: Datum[], polar: PolarFrame, engine: Engine): void {
+  const datum = rows[0] ?? null
+  const id = node.origin?.name ?? node.name ?? node.type
+  const theta0 = region.x0
+  const theta1 = region.x1
+  const r0 = region.y0
+  const r1 = region.y1
+  const style = styleOf(node, datum, engine, rows)
+
+  if (node.type === "petal") {
+    // A real petal: a teardrop across the θ slice. Its radial length encodes
+    // the petal's size channel (e.g. h:count) on the shared value scale, so a
+    // bigger count grows a longer petal — the custom layout reading the data.
+    const sizeCh = (node.h ?? node.size ?? node.r) as GofishChannelValue
+    const field = fieldOf(sizeCh)
+    let outerR = r1
+    if (field) {
+      const max = engine.sizeOverride.get(field) ?? engine.domains.get(field) ?? 0
+      if (max > 0) {
+        const frac = Math.max(0, Math.min(1, sumChannel(sizeCh, rows) / max))
+        // Floor so the smallest petal stays legible rather than collapsing.
+        outerR = r0 + (r1 - r0) * (0.35 + 0.65 * frac)
+      }
+    }
+    const d = petalPath(polar.cx, polar.cy, Math.max(1, outerR * 0.16), outerR, theta0, theta1)
+    engine.marks.push({ kind: "path", id: nextId(engine, id), d, style, datum: aggregateDatum(node, rows), group: groupKey(node, datum) })
+    recordFrame(node, polarPoint(polar.cx, polar.cy, (r0 + outerR) / 2, (theta0 + theta1) / 2), datum, engine)
+    return
+  }
+  if (node.type === "rect" || node.type === "area") {
+    // Annular wedge as a data-bearing AREA scene node (sampled arcs) — it gets
+    // hit testing / transitions / SSR from the frame, so no separate hit glyph
+    // is needed. A `w` channel sets the bar's angular width (radians), centered
+    // in the lake's slot — thin radial spokes rather than full-slot wedges.
+    const group = groupKey(node, datum)
+    const wRad = numChannel(node.w as GofishChannelValue, datum)
+    const tMid = (theta0 + theta1) / 2
+    const t0 = wRad != null ? tMid - wRad / 2 : theta0
+    const t1 = wRad != null ? tMid + wRad / 2 : theta1
+    const samples = Math.max(2, Math.ceil(Math.abs(t1 - t0) / 0.12))
+    const outerArc = sampleArc(polar.cx, polar.cy, r1, t0, t1, samples)
+    const innerArc = sampleArc(polar.cx, polar.cy, r0, t0, t1, samples)
+    engine.marks.push({
+      kind: "area",
+      id: nextId(engine, id),
+      topPath: outerArc,
+      bottomPath: innerArc,
+      style,
+      datum: rows.length ? rows : undefined,
+      group,
+    })
+    // Record the segment so a `connect` can stitch a per-series ribbon.
+    engine.polarSegments.push({ group, cx: polar.cx, cy: polar.cy, innerR: r0, outerR: r1, theta0: t0, theta1: t1 })
+    return
+  }
+  if (node.type === "circle") {
+    const [cx, cy] = polarPoint(polar.cx, polar.cy, (r0 + r1) / 2, (theta0 + theta1) / 2)
+    engine.marks.push({ kind: "circle", id: nextId(engine, id), cx, cy, r: 3, style, datum: datum ?? undefined, interactive: node.interactive as boolean | undefined })
+    return
+  }
+  const [tx, ty] = polarPoint(polar.cx, polar.cy, (r0 + r1) / 2, (theta0 + theta1) / 2)
+  emitTextOrFallback(node, tx, ty, datum, engine)
+}
+
+function emitTextOrFallback(node: GofishMarkIR, x: number, y: number, datum: Datum | null, engine: Engine): void {
+  if (node.type === "text") {
+    const text = channel(node.text as GofishChannelValue, datum ?? undefined)
+    engine.marks.push({
+      kind: "text",
+      id: nextId(engine, node.origin?.name ?? "text"),
+      x,
+      y,
+      text: text == null ? "" : String(text),
+      fontSize: Number(node.fontSize) || 11,
+      textAnchor: "middle",
+      style: { fill: "var(--semiotic-text-secondary, #667)" },
+    })
+    return
+  }
+  engine.warnings.push(`Unsupported leaf mark "${node.type}".`)
+}
+
+// ── mark-fn escape hatch ────────────────────────────────────────────────────
+
+function emitMarkFn(node: GofishMarkIR, region: Region, datum: Datum | null, engine: Engine): void {
+  const id = node.lambdaId as string | undefined
+  const lambda = id ? resolveLambda(id, engine.options.lambdas) : undefined
+  const x0 = Math.min(region.x0, region.x1)
+  const y0 = Math.min(region.y0, region.y1)
+  const w = Math.abs(region.x1 - region.x0)
+  const h = Math.abs(region.y1 - region.y0)
+  if (!lambda || lambda.kind !== "mark-fn") {
+    if (id) engine.warnings.push(`mark-fn lambda "${id}" is not registered; drawing a placeholder.`)
+    engine.marks.push({ kind: "rect", id: nextId(engine, "markfn"), x: x0, y: y0, width: w, height: h, style: { fill: "rgba(0,0,0,0.04)", stroke: "var(--semiotic-border,#bbb)" }, datum: datum ?? undefined })
+    return
+  }
+  const prims = lambda.fn(datum ?? {}, { x: x0, y: y0, w, h })
+  for (const p of prims) splicePrimitive(p, x0, y0, w, h, engine)
+}
+
+function splicePrimitive(p: GofishLambdaPrimitive, x0: number, y0: number, w: number, h: number, engine: Engine): void {
+  const ux = (v: number) => x0 + v * w
+  const uy = (v: number) => y0 + v * h
+  const us = (v: number) => v * Math.min(w, h)
+  if (p.kind === "polygon") {
+    const d = `M${p.points.map((pt) => `${ux(pt[0])},${uy(pt[1])}`).join(" L")} Z`
+    engine.marks.push({ kind: "path", id: nextId(engine, "mf-poly"), d, style: { fill: p.fill, stroke: p.stroke, strokeWidth: p.strokeWidth, opacity: p.opacity } })
+  } else if (p.kind === "circle") {
+    engine.marks.push({ kind: "circle", id: nextId(engine, "mf-c"), cx: ux(p.x), cy: uy(p.y), r: us(p.r), style: { fill: p.fill, stroke: p.stroke, opacity: p.opacity }, interactive: false })
+  } else if (p.kind === "rect") {
+    engine.marks.push({ kind: "rect", id: nextId(engine, "mf-r"), x: ux(p.x), y: uy(p.y), width: us(p.w), height: us(p.h), style: { fill: p.fill, stroke: p.stroke, opacity: p.opacity }, interactive: false })
+  } else if (p.kind === "text") {
+    engine.marks.push({ kind: "text", id: nextId(engine, "mf-t"), x: ux(p.x), y: uy(p.y), text: p.text, fontSize: p.fontSize ?? 11, textAnchor: "middle", style: { fill: p.fill } })
+  }
+}
+
+// ── Style / datum helpers ───────────────────────────────────────────────────
+
+/**
+ * A fill string the interpreter should paint verbatim rather than resolve
+ * through the categorical palette: explicit color literals (`#…`, `rgb(…)`,
+ * `hsl(…)`, `var(…)`) and the paint keywords `none` / `transparent` /
+ * `currentColor`. Without the keywords, a `fill: "none"` outline (the boba cup
+ * silhouette) gets a categorical color and paints a solid block over the glyph.
+ */
+function isLiteralColor(value: string): boolean {
+  if (value.startsWith("#") || value.startsWith("var(") || value.startsWith("rgb") || value.startsWith("hsl")) {
+    return true
+  }
+  const lower = value.toLowerCase()
+  return lower === "none" || lower === "transparent" || lower === "currentcolor"
+}
+
+function styleOf(node: GofishMarkIR, datum: Datum | undefined, engine: Engine, rows?: Datum[]): Style {
+  const fillCh = node.fill as GofishChannelValue | undefined
+  const strokeCh = node.stroke as GofishChannelValue | undefined
+  let fill: string | undefined
+  if (fillCh != null) {
+    const v = channel(fillCh, datum)
+    if (typeof v === "string" && isLiteralColor(v)) fill = v
+    else if (v != null) fill = engine.resolveColor(String(v), datum)
+  }
+  const stroke = typeof channel(strokeCh, datum) === "string" ? (channel(strokeCh, datum) as string) : undefined
+  void rows
+  return {
+    fill: fill ?? (node.type === "rect" || node.type === "circle" || node.type === "area" || node.type === "petal" ? engine.resolveColor(groupKey(node, datum) ?? "0", datum) : undefined),
+    stroke,
+    strokeWidth: typeof node.strokeWidth === "number" ? node.strokeWidth : undefined,
+    fillOpacity: typeof node.opacity === "number" ? node.opacity : undefined,
+  }
+}
+
+function groupKey(node: GofishMarkIR, datum: Datum | undefined): string | undefined {
+  const fillCh = node.fill as GofishChannelValue | undefined
+  if (fillCh && typeof fillCh === "object" && (fillCh as { type?: string }).type === "field") {
+    const v = readField(datum, (fillCh as { name: string }).name)
+    if (v != null) return String(v)
+  }
+  return undefined
+}
+
+function aggregateDatum(node: GofishMarkIR, rows: Datum[]): Datum | undefined {
+  if (rows.length === 0) return undefined
+  if (rows.length === 1) return rows[0]
+  // summarize the group: carry the first row + summed numeric size channels
+  return datumFromFields({ ...rows[0], _groupSize: rows.length })
+}
+
+function recordFrame(node: GofishMarkIR, anchor: [number, number], datum: Datum | undefined, engine: Engine): void {
+  const name = node.name ?? node.origin?.name
+  if (!name) return
+  engine.frames.set(name, { name, cx: anchor[0], cy: anchor[1], bbox: { x: anchor[0], y: anchor[1], w: 0, h: 0 } })
+}
+
+function recordRelation(node: GofishMarkIR, rows: Datum[], engine: Engine): void {
+  const opt = node.options ?? {}
+  const refs: string[] = []
+  for (const child of node.children ?? []) {
+    if (child.type === "ref") {
+      const sel = child.selection
+      if (Array.isArray(sel)) refs.push(sel.map(String).join("-"))
+      else if (sel != null) refs.push(String(sel))
+    }
+  }
+  engine.relations.push({
+    kind: node.type === "arrow" ? "arrow" : "connect",
+    refs,
+    fill: typeof opt.fill === "string" ? opt.fill : undefined,
+    stroke: typeof opt.stroke === "string" ? opt.stroke : undefined,
+    opacity: typeof opt.opacity === "number" ? opt.opacity : undefined,
+    interpolation: opt.interpolation === "bezier" ? "bezier" : "linear",
+  })
+  void rows
+}
+
+function rotatedRectPath(x: number, y: number, w: number, h: number, deg: number, cx: number, cy: number): string {
+  const rad = (deg * Math.PI) / 180
+  const cos = Math.cos(rad)
+  const sin = Math.sin(rad)
+  const pt = (px: number, py: number): string => {
+    const dx = px - cx
+    const dy = py - cy
+    return `${cx + dx * cos - dy * sin},${cy + dx * sin + dy * cos}`
+  }
+  return `M${pt(x, y)} L${pt(x + w, y)} L${pt(x + w, y + h)} L${pt(x, y + h)} Z`
+}
+
+// ── Relations → glyph marks (after placement) ───────────────────────────────
+
+function emitRelations(engine: Engine): void {
+  // Polar ribbons: a `connect` over recorded polar segments stitches one band
+  // per series (the relational case the named-ref path can't resolve —
+  // segments are grouped by their fill series, sorted by angle). The band rides
+  // each spoke's outer/inner edge and bridges the gaps with straight connectors
+  // (`interpolation: "linear"`, default) or a smooth curve (`"bezier"`).
+  const connect = engine.relations.find((r) => r.kind === "connect")
+  if (connect && engine.polarSegments.length >= 2) {
+    const bySeries = new Map<string, Engine["polarSegments"]>()
+    for (const seg of engine.polarSegments) {
+      const key = seg.group ?? ""
+      const list = bySeries.get(key) ?? []
+      list.push(seg)
+      bySeries.set(key, list)
+    }
+    for (const [series, segs] of bySeries) {
+      if (segs.length < 2) continue
+      const ordered = [...segs].sort((a, b) => (a.theta0 + a.theta1) / 2 - (b.theta0 + b.theta1) / 2)
+      // Each spoke contributes its outer arc endpoints (top) and inner arc
+      // endpoints (bottom); the closed band is outer-forward + inner-backward.
+      const top: Array<[number, number]> = []
+      const bottom: Array<[number, number]> = []
+      for (const s of ordered) {
+        top.push(polarPoint(s.cx, s.cy, s.outerR, s.theta0), polarPoint(s.cx, s.cy, s.outerR, s.theta1))
+        bottom.push(polarPoint(s.cx, s.cy, s.innerR, s.theta0), polarPoint(s.cx, s.cy, s.innerR, s.theta1))
+      }
+      const pts = [...top, ...bottom.reverse()]
+      const d = connect.interpolation === "bezier" ? smoothClosedPath(pts) : straightClosedPath(pts)
+      const color = engine.resolveColor(series)
+      engine.marks.push({
+        kind: "path",
+        id: nextId(engine, "ribbon"),
+        d,
+        style: { fill: color, fillOpacity: connect.opacity ?? 0.26, stroke: color, strokeWidth: 1, opacity: 0.9 },
+      })
+    }
+  }
+
+  for (const rel of engine.relations) {
+    const pts = rel.refs.map((r) => engine.frames.get(r)).filter((f): f is NamedFrame => !!f).map((f) => [f.cx, f.cy] as [number, number])
+    if (pts.length < 2) continue
+    const d = rel.interpolation === "bezier" || rel.kind === "connect" ? smoothOpenPath(pts) : `M${pts.map((p) => `${p[0]},${p[1]}`).join(" L")}`
+    engine.marks.push({
+      kind: "path",
+      id: nextId(engine, rel.kind),
+      d,
+      style: { fill: rel.fill ?? "none", stroke: rel.stroke ?? rel.fill ?? "var(--semiotic-border,#888)", opacity: rel.opacity ?? 0.8, strokeWidth: rel.fill && rel.fill !== "none" ? 0 : 1.5 },
+    })
+  }
+}
+
+function smoothOpenPath(points: [number, number][]): string {
+  if (points.length < 2) return ""
+  let d = `M${points[0][0]},${points[0][1]}`
+  for (let i = 1; i < points.length; i++) {
+    const prev = points[i - 1]
+    const curr = points[i]
+    const mx = (prev[0] + curr[0]) / 2
+    d += ` Q${mx},${prev[1]} ${curr[0]},${curr[1]}`
+  }
+  return d
+}
+
+/** A closed polygon through the points — straight edges, no smoothing bulge. */
+function straightClosedPath(points: [number, number][]): string {
+  if (points.length < 2) return ""
+  return `M${points.map((p) => `${p[0]},${p[1]}`).join(" L")} Z`
+}
+
+// ── Public: build an interpreted scene for a root + pixel frame ──────────────
+
+function runInterpreter(
+  root: GofishRootIR,
+  frame: { x: number; y: number; width: number; height: number },
+  resolveColor: (key: string) => string,
+  options: InterpretOptions
+): Engine {
+  const engine: Engine = {
+    marks: [],
+    frames: new Map(),
+    relations: [],
+    resolveColor,
+    options,
+    warnings: options.warnings ?? [],
+    ids: { n: 0 },
+    domains: new Map(),
+    sizeOverride: new Map(),
+    polarSegments: [],
+  }
+  const region: Region = { x0: frame.x, y0: frame.y, x1: frame.x + frame.width, y1: frame.y + frame.height }
+
+  const charts = root.type === "chart" ? [root] : root.type === "layer" ? root.charts : []
+  // Shared value scale: max absolute value per numeric field across all rows.
+  for (const chart of charts) {
+    if (chart.data?.type !== "inline") continue
+    for (const row of chart.data.rows) {
+      for (const [k, v] of Object.entries(row)) {
+        const n = Number(v)
+        if (Number.isFinite(n)) engine.domains.set(k, Math.max(engine.domains.get(k) ?? 0, Math.abs(n)))
+      }
+    }
+  }
+  if (root.type === "raw-mark") {
+    place(root.mark, region, [], "none", null, engine)
+  }
+  for (const chart of charts) {
+    const rows: Datum[] = chart.data?.type === "inline" ? (chart.data.rows as Datum[]) : []
+    const node = chartToNode(chart.operators ?? [], chart.mark)
+    place(node, region, rows, "none", null, engine)
+    if (chart.connect) place(chart.connect, region, rows, "none", null, engine)
+  }
+  emitRelations(engine)
+  return engine
+}
+
+// ── Frame bindings ───────────────────────────────────────────────────────
+
+/** XY binding — the default for free-coordinate GoFish charts. */
+export function interpretToXYLayout(root: GofishRootIR, options: InterpretOptions = {}): CustomLayout {
+  return (ctx: LayoutContext) => {
+    const engine = runInterpreter(rootWithFrameData(root, ctx.data), ctx.dimensions.plot, ctx.resolveColor, { ...options, warnings: options.warnings ?? [] })
+    const solver = createGofishGlyphLayout(() => ({ marks: engine.marks }))
+    return solver(ctx)
+  }
+}
+
+/**
+ * Ordinal binding — the top-level categorical `spread`/`group` maps to the
+ * frame's o-scale (one band per category); each category's subtree is
+ * interpreted within its full band column. A pictorial glyph that declares a
+ * `unit` coord with `fit: "uniform"` then scales aspect-correctly to fill the
+ * column (e.g. boba cups). Emits one data-bearing hit rect per category + the
+ * interpreted glyph as overlays.
+ *
+ * `config.glyphWidthRatio` (alias `cupWidthRatio`) insets the glyph column
+ * horizontally so neighboring glyphs breathe; default 0.9.
+ */
+export function interpretToOrdinalLayout(
+  root: GofishRootIR,
+  categoryAccessor: string,
+  options: InterpretOptions = {}
+): OrdinalCustomLayout {
+  return (ctx: OrdinalLayoutContext) => {
+    const { plot } = ctx.dimensions
+    const o = ctx.scales.o
+    const bandW = o.bandwidth()
+    const labelPad = 26
+    const topPad = 8
+    const availH = Math.max(1, plot.height - labelPad - topPad)
+    const cfg = (ctx.config ?? {}) as { glyphWidthRatio?: number; cupWidthRatio?: number }
+    const widthRatio = Math.max(0.2, Math.min(1, cfg.glyphWidthRatio ?? cfg.cupWidthRatio ?? 0.9))
+    const glyphW = bandW * widthRatio
+    const nodes: OrdinalSceneNode[] = []
+    const overlays: GofishGlyphMark[] = []
+    const warnings = options.warnings ?? []
+
+    // Pull the cup subtree = the chart mark with its operators minus the outer
+    // categorical spread; interpret it per category filling the band column.
+    const chart = root.type === "chart" ? root : root.type === "layer" ? root.charts[0] : undefined
+    if (!chart) return { nodes: [] }
+    const sourceRows = chart.data?.type === "inline" ? ctx.data : []
+    // Apply data operators (derive) once over all rows, then interpret the
+    // inner glyph per category. This keeps shared derived geometry (for
+    // example the boba menu's common aspect box) global instead of recomputing
+    // it independently inside each band.
+    const rows = applyDataOperators(sourceRows, chart.operators ?? [], options, warnings)
+    const innerNode = chartToNode((chart.operators ?? []).filter((op) => !DATA_OPS.has(op.type) && !LAYOUT_OPS.has(op.type)), chart.mark)
+
+    const byOp = (chart.operators ?? []).find((op) => op.type === "spread" || op.type === "group")
+    const byField = (byOp?.by ?? categoryAccessor).replace(/^datum\./, "")
+    const groups = partition(rows, byField)
+
+    for (const g of groups) {
+      const bandX = o(g.key)
+      if (bandX == null) continue
+      const fx = bandX + (bandW - glyphW) / 2
+      const fy = plot.y + topPad
+      const engine = runInterpreter(
+        { type: "chart", data: { type: "inline", rows: g.rows }, mark: innerNode } as GofishRootIR,
+        { x: fx, y: fy, width: glyphW, height: availH },
+        ctx.resolveColor,
+        { ...options, warnings }
+      )
+      // Each category runs its own interpreter (ids restart at 0), so namespace
+      // the mark ids by category to keep React keys unique across cups.
+      const prefix = stableGlyphId(g.key)
+      for (const m of engine.marks) m.id = `${prefix}-${m.id}`
+      overlays.push(...engine.marks)
+      // Data-bearing hit rect for the whole cup.
+      nodes.push({
+        type: "rect",
+        x: bandX,
+        y: plot.y + 8,
+        w: bandW,
+        h: availH,
+        style: { fill: "rgba(0,0,0,0)", stroke: "none" },
+        datum: g.rows[0] ?? null,
+        group: g.key,
+        _transitionKey: `cat-${stableGlyphId(g.key)}`,
+      } as OrdinalSceneNode)
+      // Category label.
+      overlays.push({ kind: "text", id: `lbl-${stableGlyphId(g.key)}`, x: bandX + bandW / 2, y: plot.y + plot.height - 8, text: g.key, fontSize: 12, textAnchor: "middle", style: { fill: "var(--semiotic-text,#333)" } })
+    }
+
+    // Compile overlay glyph marks via the shared compiler, but keep our hit rects.
+    const compiled = createGofishGlyphLayout(() => ({ marks: overlays }))({
+      data: ctx.data,
+      scales: { x: ctx.scales.r, y: ctx.scales.r } as unknown as LayoutContext["scales"],
+      dimensions: ctx.dimensions,
+      theme: ctx.theme,
+      resolveColor: ctx.resolveColor,
+      config: {},
+    })
+    return { nodes: [...nodes, ...(compiled.nodes as OrdinalSceneNode[])], overlays: compiled.overlays }
+  }
+}
+
+/** Interpret a root to raw marks (for tests / custom hosts). */
+export function interpretToMarks(
+  root: GofishRootIR,
+  frame: { x: number; y: number; width: number; height: number },
+  resolveColor: (key: string) => string = (k) => k,
+  options: InterpretOptions = {}
+): { marks: GofishGlyphMark[]; warnings: string[] } {
+  const engine = runInterpreter(root, frame, resolveColor, { ...options, warnings: options.warnings ?? [] })
+  return { marks: engine.marks, warnings: engine.warnings }
+}

--- a/src/components/recipes/gofishLambdas.ts
+++ b/src/components/recipes/gofishLambdas.ts
@@ -1,0 +1,430 @@
+import type { Datum } from "../charts/shared/datumTypes"
+
+/**
+ * GoFish escape-hatch lambda registry.
+ *
+ * GoFish's serialized IR cannot carry function bodies, so `derive` (a
+ * `(rows) => rows'` data transform) and `mark-fn` (a `(datum) => drawing`
+ * custom glyph) travel as a `lambdaId` that the host resolves through a
+ * bridge. This module is that bridge for the Semiotic interpreter: register a
+ * function under the id the IR references and `interpretGofishIR` will call it
+ * where the grammar genuinely can't reach.
+ *
+ * This is the *only* sanctioned non-grammar path. A spec that resolves to pure
+ * operators + marks needs no lambdas; one that reaches a `derive`/`mark-fn`
+ * names the computation here.
+ */
+
+export interface DeriveLambda {
+  kind: "derive"
+  /** Transform the in-scope rows — add columns, or emit new rows. */
+  fn: (rows: Datum[]) => Datum[]
+}
+
+export interface MarkFnLambda {
+  kind: "mark-fn"
+  /**
+   * Draw a bespoke glyph for one datum inside its allocated unit frame
+   * (coordinates in [0,1], mapped to pixels by the interpreter). Returns
+   * primitive marks the interpreter splices into the scene.
+   */
+  fn: (datum: Datum, frame: { x: number; y: number; w: number; h: number }) => GofishLambdaPrimitive[]
+}
+
+export type GofishLambda = DeriveLambda | MarkFnLambda
+
+/** A primitive a `mark-fn` may emit (unit coords). Mirrors the glyph vocabulary. */
+export type GofishLambdaPrimitive =
+  | { kind: "polygon"; points: Array<[number, number]>; fill?: string; stroke?: string; strokeWidth?: number; opacity?: number }
+  | { kind: "circle"; x: number; y: number; r: number; fill?: string; stroke?: string; opacity?: number }
+  | { kind: "rect"; x: number; y: number; w: number; h: number; fill?: string; stroke?: string; opacity?: number; rotate?: number }
+  | { kind: "text"; x: number; y: number; text: string; fill?: string; fontSize?: number }
+
+const registry = new Map<string, GofishLambda>()
+
+/** Register a `derive`/`mark-fn` implementation under the id the IR references. */
+export function registerGofishLambda(id: string, lambda: GofishLambda): () => void {
+  registry.set(id, lambda)
+  return () => {
+    if (registry.get(id) === lambda) registry.delete(id)
+  }
+}
+
+export function unregisterGofishLambda(id: string): void {
+  registry.delete(id)
+}
+
+export function getGofishLambda(id: string): GofishLambda | undefined {
+  return registry.get(id)
+}
+
+/** Merge a per-call lambda map over the module registry (per-call wins). */
+export function resolveLambda(
+  id: string,
+  perCall?: Record<string, GofishLambda>
+): GofishLambda | undefined {
+  return perCall?.[id] ?? registry.get(id)
+}
+
+// ── Built-in: bobaGeometry ───────────────────────────────────────────────
+//
+// The one escape hatch the boba cup needs: the genuinely non-grammar math
+// (frustum volume → drink height, tapioca/ice packing). Tea + tapioca + ice
+// volumes plus the cup-size parameters add up to a total volume, which a
+// frustum-inverse solve turns into a drink height; pearls pack at the bottom
+// and ice floats at the surface. It emits a per-cup `_g` block of geometry in
+// unit coords PLUS a shared `_g.box` ([bw, bh]) so an aspect-preserving unit
+// fit (`coord.fit: "uniform"`) draws each cup undistorted. The normalization is
+// shared across every cup in the menu and bottom-aligned, so a row of cups
+// sits on one shelf with their straws aligned at the top — taller cups simply
+// reach higher. Derived from Krist Wongsuphasawat's "Boba Science" notebook.
+
+const INCH_TO_CM = 2.54
+const ICE_WIDTH = 1.75
+const STRAW_HEIGHT_CM = 8 * INCH_TO_CM
+const STRAW_RADIUS_CM = 0.25 * INCH_TO_CM
+const CUP_OVERHANG_CM = 0.9 // lid/rim overhang past the cup's top radius
+const TEA_FILL = "#D2B799"
+const PEARL_FILL = "#222222"
+const ICE_FILL = "#a5f2f3"
+const STRAW_FILL = "#4F91CB"
+const CUP_STROKE = "#222222"
+
+interface Cup {
+  height: number
+  topRadius: number
+  bottomRadius: number
+}
+
+export interface BobaCellGeometry {
+  cup: Array<[number, number]>
+  tea: Array<[number, number]> | null
+  straw: Array<[number, number]> | null
+  /** Thick rim/lid bar across the cup top. */
+  lid: { x1: number; x2: number; y: number }
+  pearls: Array<{ x: number; y: number; r: number; fill: string }>
+  ice: Array<{ x: number; y: number; w: number; rot: number; fill: string }>
+  /** Content box `[bw, bh]` for the `uniform` unit fit; shared across the menu. */
+  box: [number, number]
+  numBobas: number
+  numIce: number
+  teaVolume: number
+  bobaVolume: number
+  iceVolume: number
+  totalVolume: number
+  cupStroke: string
+}
+
+/** cm-space geometry for one cup (cup centered on x=0; y grows down, 0 = rim). */
+interface BobaCm {
+  cupHeight: number
+  halfWidth: number
+  cup: Array<[number, number]>
+  tea: Array<[number, number]> | null
+  straw: Array<[number, number]> | null
+  lid: { x1: number; x2: number; y: number }
+  pearls: Array<{ x: number; z: number; r: number }>
+  ice: Array<{ cx: number; cy: number; w: number; rot: number }>
+  numBobas: number
+  numIce: number
+  teaVolume: number
+  bobaVolume: number
+  iceVolume: number
+  totalVolume: number
+}
+
+function frustumVolume(r1: number, r2: number, h: number): number {
+  return (Math.PI * h) / 3 * (r1 * r1 + r1 * r2 + r2 * r2)
+}
+function radiusAtDrinkHeight(cup: Cup, h: number): number {
+  return cup.topRadius + ((h - cup.height) / cup.height) * (cup.topRadius - cup.bottomRadius)
+}
+function volumeFromDrinkHeight(cup: Cup, h: number): number {
+  return frustumVolume(radiusAtDrinkHeight(cup, h), cup.bottomRadius, h)
+}
+function drinkHeightFromVolume(cup: Cup, v: number): number {
+  const r = (cup.topRadius + cup.bottomRadius) / 2
+  const area = Math.PI * r * r
+  let estimate = v / area
+  let diff = v - volumeFromDrinkHeight(cup, estimate)
+  let counter = 0
+  while (counter < 100 && Math.abs(diff) > 0.0001) {
+    estimate += diff / area
+    diff = v - volumeFromDrinkHeight(cup, estimate)
+    counter++
+  }
+  return estimate
+}
+function jitter(i: number, amount: number): number {
+  const f = Math.sin(i * 12.9898 + 78.233) * 43758.5453
+  return (f - Math.floor(f) - 0.5) * 2 * amount
+}
+function placeCirclesInside(rLarge: number, rSmall: number): Array<{ x: number; y: number }> {
+  if (rSmall > rLarge || rLarge < 2 * rSmall) return [{ x: 0, y: 0 }]
+  const circles: Array<{ x: number; y: number }> = []
+  const make = (rc: number): void => {
+    let no = Math.floor((2 * Math.PI * rc) / (2 * rSmall))
+    if (no < 1) no = 1
+    const dist = Math.hypot(rc - rc * Math.cos((2 * Math.PI) / no), -rc * Math.sin((2 * Math.PI) / no))
+    if (dist < 2 * rSmall && no > 1) no--
+    for (let i = 0; i < no; i++) {
+      circles.push({ x: rc * Math.cos((i * 2 * Math.PI) / no), y: rc * Math.sin((i * 2 * Math.PI) / no) })
+    }
+    const rcNext = rc - 2 * rSmall
+    if (rcNext >= rSmall) make(rcNext)
+    else if (rc > 2 * rSmall) circles.push({ x: 0, y: 0 })
+  }
+  make(rLarge - rSmall)
+  return circles
+}
+
+function num(value: unknown, fallback: number): number {
+  const n = Number(value)
+  return Number.isFinite(n) ? n : fallback
+}
+
+/** Solve one cup's frustum/packing math, returning cm-space geometry. */
+function computeBobaCm(row: Datum): BobaCm {
+  const cup: Cup = {
+    height: num(row.cupHeight, 15.5),
+    topRadius: num(row.cupTopRadius, 4.75),
+    bottomRadius: num(row.cupBottomRadius, 3.75),
+  }
+  const bobaRadius = num(row.bobaRadius, 0.6)
+  const teaVolume = Math.max(0, num(row.teaVolume, 450))
+  const bobaVolume = Math.max(0, num(row.bobaVolume, 110))
+  const iceVolume = Math.max(0, num(row.iceVolume, 135))
+
+  const bobaBallVolume = Math.PI * bobaRadius * bobaRadius
+  const numBobas = Math.floor(bobaVolume / bobaBallVolume)
+  const realBobaVolume = numBobas * bobaBallVolume
+  const numIce = Math.floor(iceVolume / (ICE_WIDTH * ICE_WIDTH * ICE_WIDTH))
+  const realIceVolume = numIce * ICE_WIDTH * ICE_WIDTH * ICE_WIDTH
+  // Drink height fills to tea + tapioca + ice, capped at the cup.
+  const totalVolume = teaVolume + realBobaVolume + realIceVolume
+  const drinkHeight = Math.min(cup.height, Math.max(0, drinkHeightFromVolume(cup, totalVolume)))
+  const drinkRadius = radiusAtDrinkHeight(cup, drinkHeight)
+
+  // Pearl layers (cm; origin cup-top-center, y down → pearl z = height - h).
+  const pearls: Array<{ x: number; z: number; r: number }> = []
+  let remaining = numBobas
+  let layer = 0
+  while (remaining > 0 && layer < 60) {
+    const h = bobaRadius * (1 + 2 * layer)
+    const ring = placeCirclesInside(radiusAtDrinkHeight(cup, h), bobaRadius)
+    const diff = ring.length - remaining
+    const chosen = diff > 1 ? ring.slice(Math.floor(diff / 2), Math.floor(diff / 2) + remaining) : ring
+    const z = cup.height - h
+    chosen.forEach((p, i) =>
+      pearls.push({ x: p.x + jitter(layer * 97 + i, 0.15), z: z + jitter(layer * 31 + i, 0.05), r: bobaRadius })
+    )
+    remaining -= chosen.length
+    layer++
+    if (chosen.length === 0) break
+  }
+  const bobaHeight = layer * bobaRadius * 2
+
+  // Ice layers (cm) floating just under the drink surface.
+  const ice: Array<{ cx: number; cy: number; w: number; rot: number }> = []
+  if (numIce > 0) {
+    let iceLayers = 0
+    let rem = numIce
+    while (rem > 0 && iceLayers < 60) {
+      const h = bobaHeight + (ICE_WIDTH / 2) * (1 + 2 * iceLayers)
+      const per = Math.max(1, Math.floor((2 * radiusAtDrinkHeight(cup, h)) / ICE_WIDTH))
+      rem -= per
+      iceLayers++
+    }
+    const iceHeight = iceLayers * ICE_WIDTH
+    const iceStartY = Math.max(bobaHeight, drinkHeight - iceHeight) + ICE_WIDTH / 2
+    let placed = 0
+    for (let i = 0; i < iceLayers && placed < numIce; i++) {
+      const h = iceStartY + ICE_WIDTH * i
+      const r = radiusAtDrinkHeight(cup, h)
+      const per = Math.max(1, Math.floor((2 * r) / ICE_WIDTH))
+      const gap = (2 * r - per * ICE_WIDTH) / (per + 1)
+      const startX = -r + gap
+      const yTop = cup.height - h - ICE_WIDTH / 2 - 0.1
+      for (let j = 0; j < per && placed < numIce; j++) {
+        ice.push({ cx: startX + (gap + ICE_WIDTH) * j + ICE_WIDTH / 2, cy: yTop + ICE_WIDTH / 2, w: ICE_WIDTH * 0.95, rot: jitter(i * 53 + j, 10) })
+        placed++
+      }
+    }
+  }
+
+  const H = cup.height
+  const strawTop = cup.height - STRAW_HEIGHT_CM
+  const teaY = H - drinkHeight
+  return {
+    cupHeight: H,
+    halfWidth: cup.topRadius + CUP_OVERHANG_CM,
+    cup: [
+      [-cup.topRadius, 0],
+      [-cup.bottomRadius, H],
+      [cup.bottomRadius, H],
+      [cup.topRadius, 0],
+    ],
+    tea: teaVolume > 0
+      ? [
+          [-drinkRadius, teaY],
+          [-cup.bottomRadius, H],
+          [cup.bottomRadius, H],
+          [drinkRadius, teaY],
+        ]
+      : null,
+    straw: [
+      [-STRAW_RADIUS_CM, strawTop],
+      [-STRAW_RADIUS_CM, H - 0.4],
+      [STRAW_RADIUS_CM, H - STRAW_RADIUS_CM * 2 - 0.4],
+      [STRAW_RADIUS_CM, strawTop],
+    ],
+    lid: { x1: -(cup.topRadius + CUP_OVERHANG_CM), x2: cup.topRadius + CUP_OVERHANG_CM, y: 0 },
+    pearls,
+    ice,
+    numBobas,
+    numIce,
+    teaVolume: Math.round(teaVolume),
+    bobaVolume: Math.round(realBobaVolume),
+    iceVolume: Math.round(realIceVolume),
+    totalVolume: Math.round(totalVolume),
+  }
+}
+
+interface BobaShared {
+  ref: number
+  halfWidth: number
+  topExtent: number
+}
+
+/**
+ * Project one cup's cm geometry into unit coords against a shared normalization
+ * so every cup in the menu uses one scale and one bottom baseline. `ref` is the
+ * largest dimension across the menu, so `max(bw, bh) === 1`. y is measured up
+ * from the shared shelf, so cup bottoms align and straws share a top line.
+ */
+function normalizeBobaCell(cm: BobaCm, shared: BobaShared): BobaCellGeometry {
+  const { ref, halfWidth, topExtent } = shared
+  const boxW = (2 * halfWidth) / ref
+  const boxH = topExtent / ref
+  const ux = (xcm: number): number => (xcm + halfWidth) / ref
+  const uy = (ycm: number): number => boxH - (cm.cupHeight - ycm) / ref
+  const ur = (rcm: number): number => rcm / ref
+  const pt = (p: [number, number]): [number, number] => [ux(p[0]), uy(p[1])]
+  return {
+    cup: cm.cup.map(pt),
+    tea: cm.tea ? cm.tea.map(pt) : null,
+    straw: cm.straw ? cm.straw.map(pt) : null,
+    lid: { x1: ux(cm.lid.x1), x2: ux(cm.lid.x2), y: uy(cm.lid.y) },
+    pearls: cm.pearls.map((p) => ({ x: ux(p.x), y: uy(p.z), r: ur(p.r), fill: PEARL_FILL })),
+    ice: cm.ice.map((p) => ({ x: ux(p.cx), y: uy(p.cy), w: ur(p.w), rot: p.rot, fill: ICE_FILL })),
+    box: [boxW, boxH],
+    numBobas: cm.numBobas,
+    numIce: cm.numIce,
+    teaVolume: cm.teaVolume,
+    bobaVolume: cm.bobaVolume,
+    iceVolume: cm.iceVolume,
+    totalVolume: cm.totalVolume,
+    cupStroke: CUP_STROKE,
+  }
+}
+
+/** Shared normalization across a menu of cups (or one cup, standalone). */
+function bobaShared(cms: BobaCm[]): BobaShared {
+  const halfWidth = Math.max(...cms.map((c) => c.halfWidth), 1)
+  const topExtent = Math.max(...cms.map((c) => Math.max(c.cupHeight, STRAW_HEIGHT_CM)), 1)
+  return { halfWidth, topExtent, ref: Math.max(2 * halfWidth, topExtent) }
+}
+
+/** Single-cup convenience (normalizes against itself). */
+export function computeBobaCellGeometry(row: Datum): BobaCellGeometry {
+  const cm = computeBobaCm(row)
+  return normalizeBobaCell(cm, bobaShared([cm]))
+}
+
+/**
+ * The built-in `bobaGeometry` derive: solve every cup, then attach `_g`
+ * (geometry against the shared menu-wide normalization) plus the fixed fills
+ * the marks read.
+ */
+export const bobaGeometryLambda: DeriveLambda = {
+  kind: "derive",
+  fn: (rows) => {
+    const cms = rows.map(computeBobaCm)
+    const shared = bobaShared(cms)
+    return rows.map((row, i) => ({
+      ...row,
+      _g: normalizeBobaCell(cms[i], shared),
+      teaFill: TEA_FILL,
+      strawFill: STRAW_FILL,
+      cupStroke: CUP_STROKE,
+      lidFill: CUP_STROKE,
+    }))
+  },
+}
+
+registerGofishLambda("bobaGeometry", bobaGeometryLambda)
+
+// ── Built-in: bottleGeometry ────────────────────────────────────────────────
+//
+// A pictorial bottle: an SVG bottle silhouette (as a self-contained data-URI
+// image), a green fill clipped to that silhouette to a height encoding
+// `amount`, a fill line, a percentage label, and a category label. Emits
+// NORMALIZED geometry ([0,1] within the slot) under `_b`; the marks render it.
+// Demonstrates the reusable `image` + `clipPath` glyph primitives.
+
+const BOTTLE_SILHOUETTE: Array<[number, number]> = [
+  [0.43, 0.04],
+  [0.57, 0.04],
+  [0.57, 0.2],
+  [0.8, 0.34],
+  [0.8, 0.82],
+  [0.72, 0.9],
+  [0.28, 0.9],
+  [0.2, 0.82],
+  [0.2, 0.34],
+  [0.43, 0.2],
+]
+
+/** A self-contained bottle SVG (glass fill + outline) as a data URI. */
+function bottleSvgDataUri(): string {
+  const d =
+    "M" +
+    BOTTLE_SILHOUETTE.map((p) => `${(p[0] * 100).toFixed(1)},${(p[1] * 100).toFixed(1)}`).join(" L") +
+    " Z"
+  const svg =
+    `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' preserveAspectRatio='none'>` +
+    `<path d='${d}' fill='rgba(150,180,195,0.30)' stroke='#6b7e88' stroke-width='2.4' stroke-linejoin='round'/></svg>`
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`
+}
+
+export interface BottleCellGeometry {
+  silhouette: Array<[number, number]>
+  imageHref: string
+  fill: { x: number; y: number; w: number; h: number }
+  fillLine: { x1: number; x2: number; y: number }
+  pct: { x: number; y: number; text: string }
+  label: { x: number; y: number; text: string }
+  fillFill: string
+}
+
+export function computeBottleCellGeometry(row: Datum): BottleCellGeometry {
+  const amount = Math.max(0, Math.min(100, num(row.amount, 50)))
+  const fillTopY = 0.9 - (amount / 100) * 0.8 // liquid surface, unit y (down)
+  return {
+    silhouette: BOTTLE_SILHOUETTE,
+    imageHref: bottleSvgDataUri(),
+    fill: { x: 0, y: fillTopY, w: 1, h: 1 - fillTopY },
+    fillLine: { x1: 0.12, x2: 0.96, y: fillTopY },
+    pct: { x: 0.84, y: fillTopY, text: `${Math.round(amount)}%` },
+    label: { x: 0.5, y: 0.975, text: String(row.category ?? "") },
+    fillFill: "#20bf55",
+  }
+}
+
+/** The built-in `bottleGeometry` derive: attach `_b` (normalized geometry) per bottle. */
+export const bottleGeometryLambda: DeriveLambda = {
+  kind: "derive",
+  fn: (rows) => rows.map((row) => ({ ...row, _b: computeBottleCellGeometry(row) })),
+}
+
+registerGofishLambda("bottleGeometry", bottleGeometryLambda)

--- a/src/components/semiotic-experimental.ts
+++ b/src/components/semiotic-experimental.ts
@@ -1,0 +1,40 @@
+/**
+ * Experimental entry point for temporary adapters and unstable previews.
+ *
+ * Anything imported from "semiotic/experimental" is intentionally outside
+ * Semiotic's stable public API. Exports may be renamed, moved, or removed
+ * without a deprecation window and are excluded from stable API-surface and
+ * bundle-size gates.
+ */
+
+// PR-preview surface for the GoFish collaboration. The adapter is intentionally
+// named `unstable-gofish-ir-adapter`; it is available here so GoFish can test
+// against Semiotic's custom chart pipeline without promoting the API to the
+// normal recipe catalog.
+export {
+  EXPERIMENTAL_GOFISH_ADAPTER_NAME,
+  unstable_fromGofishIR,
+} from "./recipes/gofishIR"
+export type {
+  GofishIRDocument as UnstableGofishIRDocument,
+  GofishChartConfig as UnstableGofishChartConfig,
+  GofishChartFamily as UnstableGofishChartFamily,
+  FromGofishIROptions as UnstableFromGofishIROptions,
+} from "./recipes/gofishIR"
+export {
+  registerGofishLambda as unstable_registerGofishLambda,
+  unregisterGofishLambda as unstable_unregisterGofishLambda,
+} from "./recipes/gofishLambdas"
+export type {
+  GofishLambda as UnstableGofishLambda,
+} from "./recipes/gofishLambdas"
+export {
+  gofishIRExamples as unstable_gofishIRExamples,
+  flowerIR as unstable_gofishFlowerIR,
+  bottleIR as unstable_gofishBottleIR,
+  polarRibbonIR as unstable_gofishPolarRibbonIR,
+  titanicCircleTreemapIR as unstable_gofishTitanicCircleTreemapIR,
+  pythonMemoryIR as unstable_gofishPythonMemoryIR,
+  bobaIR as unstable_gofishBobaIR,
+} from "./recipes/gofishIRExamples"
+export type { GofishIRExample as UnstableGofishIRExample } from "./recipes/gofishIRExamples"

--- a/src/components/semiotic-recipes.ts
+++ b/src/components/semiotic-recipes.ts
@@ -65,3 +65,13 @@ export type {
   OrdinalLayoutContext,
   OrdinalLayoutResult,
 } from "./stream/ordinalCustomLayout"
+
+export {
+  buildTooltipEntries,
+  extractTooltipDatum,
+  formatTooltipValue,
+} from "./recipes/customTooltip"
+export type {
+  CustomTooltipEntry,
+  CustomTooltipEntryOptions,
+} from "./recipes/customTooltip"

--- a/src/components/stream/NetworkPipelineStore.customLayout.test.ts
+++ b/src/components/stream/NetworkPipelineStore.customLayout.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest"
+import { afterEach, describe, it, expect, vi } from "vitest"
 import { NetworkPipelineStore } from "./NetworkPipelineStore"
 import type { NetworkPipelineConfig, NetworkCircleNode, NetworkLineEdge } from "./networkTypes"
 import type { NetworkLayoutContext } from "./networkCustomLayout"
@@ -12,6 +12,10 @@ function baseConfig(extra: Partial<NetworkPipelineConfig> = {}): NetworkPipeline
     ...extra,
   }
 }
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 describe("NetworkPipelineStore customNetworkLayout", () => {
   it("invokes customLayout instead of plugin dispatch", () => {
@@ -155,6 +159,24 @@ describe("NetworkPipelineStore customNetworkLayout", () => {
     store.buildScene([100, 100])
 
     expect(store.customLayoutOverlays).toBe(overlay)
+  })
+
+  it("warns when customNetworkLayout returns overlays without scene nodes", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    const overlay = { _sentinel: true } as unknown as React.ReactNode
+    const layout = () => ({
+      sceneNodes: [],
+      sceneEdges: [],
+      labels: [],
+      overlays: overlay,
+    })
+    const store = new NetworkPipelineStore(baseConfig({
+      customNetworkLayout: layout,
+    }))
+    store.ingestBounded([{ id: "a" }], [], [100, 100])
+    store.buildScene([100, 100])
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("returned overlays but no data-bearing scene nodes"))
   })
 
   it("clears overlays when customLayout is removed", () => {

--- a/src/components/stream/NetworkPipelineStore.ts
+++ b/src/components/stream/NetworkPipelineStore.ts
@@ -4,6 +4,7 @@ import { ParticlePool } from "./ParticlePool"
 import { getLayoutPlugin } from "./layouts"
 import type { NetworkLayoutContext } from "./networkCustomLayout"
 import { resolveCustomLayoutPalette, buildResolveColor } from "./customLayoutPalette"
+import { warnCustomLayoutDiagnostics } from "./customLayoutDiagnostics"
 import { computeEasing, computeRawProgress, lerp } from "./pipelineTransitionUtils"
 import { computeDecayOpacity } from "./pipelineDecay"
 import type { ActiveTransition } from "./pipelineTransitionUtils"
@@ -59,6 +60,7 @@ export class NetworkPipelineStore {
   labels: NetworkLabel[] = []
   /** Overlays returned from customNetworkLayout (consumed by StreamNetworkFrame). */
   customLayoutOverlays: import("react").ReactNode = null
+  private _customLayoutDiagnosticsWarned = new Set<string>()
 
   // ── Spatial index for node hit testing ─────────────────────────────────
   // Circle-node hit testing (force/orbit graphs) is O(n) per hover frame
@@ -646,6 +648,12 @@ export class NetworkPipelineStore {
       this.sceneEdges = result.sceneEdges ?? []
       this.labels = result.labels ?? []
       this.customLayoutOverlays = result.overlays ?? null
+      warnCustomLayoutDiagnostics({
+        label: "customNetworkLayout",
+        nodes: this.sceneNodes,
+        overlays: this.customLayoutOverlays,
+        warned: this._customLayoutDiagnosticsWarned,
+      })
       return
     }
 
@@ -1331,6 +1339,7 @@ export class NetworkPipelineStore {
     const previous = node.data ? { ...node.data } : {}
     node.data = updater(node.data ?? {})
     this.layoutVersion++
+    this.lastIngestTime = typeof performance !== "undefined" ? performance.now() : Date.now()
     return previous
   }
 
@@ -1354,7 +1363,10 @@ export class NetworkPipelineStore {
         if (newValue != null) edge.value = Number(newValue)
       }
     }
-    if (results.length > 0) this.layoutVersion++
+    if (results.length > 0) {
+      this.layoutVersion++
+      this.lastIngestTime = typeof performance !== "undefined" ? performance.now() : Date.now()
+    }
     return results
   }
 
@@ -1376,6 +1388,7 @@ export class NetworkPipelineStore {
       }
     }
     this.layoutVersion++
+    this.lastIngestTime = typeof performance !== "undefined" ? performance.now() : Date.now()
     return true
   }
 
@@ -1420,7 +1433,10 @@ export class NetworkPipelineStore {
       this.edges.delete(key)
       this.edgeTimestamps.delete(key)
     }
-    if (toDelete.length > 0) this.layoutVersion++
+    if (toDelete.length > 0) {
+      this.layoutVersion++
+      this.lastIngestTime = typeof performance !== "undefined" ? performance.now() : Date.now()
+    }
     return toDelete.length > 0
   }
 

--- a/src/components/stream/OrdinalPipelineStore.customLayout.test.ts
+++ b/src/components/stream/OrdinalPipelineStore.customLayout.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest"
+import { afterEach, describe, it, expect, vi } from "vitest"
 import { OrdinalPipelineStore } from "./OrdinalPipelineStore"
 import type { OrdinalPipelineConfig } from "./ordinalTypes"
 import type { OrdinalLayoutContext } from "./ordinalCustomLayout"
@@ -17,6 +17,10 @@ function baseConfig(extra: Partial<OrdinalPipelineConfig> = {}): OrdinalPipeline
     ...extra,
   }
 }
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 describe("OrdinalPipelineStore customLayout", () => {
   it("invokes customLayout instead of chart-type dispatch", () => {
@@ -60,6 +64,17 @@ describe("OrdinalPipelineStore customLayout", () => {
     store.computeScene({ width: 100, height: 100 })
 
     expect(store.customLayoutOverlays).toBe(sentinel)
+  })
+
+  it("warns when customLayout returns overlays without scene nodes", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    const sentinel = { _sentinel: true } as unknown as React.ReactNode
+    const layout = () => ({ nodes: [], overlays: sentinel })
+    const store = new OrdinalPipelineStore(baseConfig({ customLayout: layout }))
+    store.ingest({ inserts: [{ category: "A", value: 1 }], bounded: true })
+    store.computeScene({ width: 100, height: 100 })
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("returned overlays but no data-bearing scene nodes"))
   })
 
   it("clears overlays when customLayout is removed", () => {

--- a/src/components/stream/OrdinalPipelineStore.test.ts
+++ b/src/components/stream/OrdinalPipelineStore.test.ts
@@ -628,6 +628,27 @@ describe("OrdinalPipelineStore", () => {
     })
   })
 
+  // ── Staleness clock on in-place mutation ────────────────────────────
+  // A refill-style demo (e.g. boba) streams via update(); the staleness clock
+  // must treat that as activity so the chart isn't dimmed as "stale".
+  describe("staleness clock refresh", () => {
+    it("update() refreshes lastIngestTime", () => {
+      const store = new OrdinalPipelineStore(makeConfig({ dataIdAccessor: "category" }))
+      store.ingest({ inserts: makeData(["A"], [10]), bounded: true })
+      store.lastIngestTime = 1 // simulate a long-idle (would-be-stale) clock
+      store.update("A", (d) => ({ ...d, value: 99 }))
+      expect(store.lastIngestTime).toBeGreaterThan(1)
+    })
+
+    it("remove() refreshes lastIngestTime", () => {
+      const store = new OrdinalPipelineStore(makeConfig({ dataIdAccessor: "category" }))
+      store.ingest({ inserts: makeData(["A", "B"], [10, 20]), bounded: true })
+      store.lastIngestTime = 1
+      store.remove("B")
+      expect(store.lastIngestTime).toBeGreaterThan(1)
+    })
+  })
+
   // ── rExtent with zero ─────────────────────────────────────────────────
 
   describe("rExtent with explicit zero", () => {

--- a/src/components/stream/OrdinalPipelineStore.ts
+++ b/src/components/stream/OrdinalPipelineStore.ts
@@ -45,6 +45,7 @@ import { buildConnectors } from "./ordinalSceneBuilders/connectorScene"
 import type { OrdinalSceneContext, SceneBuilderFn } from "./ordinalSceneBuilders/types"
 import type { OrdinalLayoutContext } from "./ordinalCustomLayout"
 import { resolveCustomLayoutPalette, buildResolveColor } from "./customLayoutPalette"
+import { warnCustomLayoutDiagnostics } from "./customLayoutDiagnostics"
 import type { MarginType } from "../types/marginType"
 
 const SCENE_BUILDERS: Record<string, SceneBuilderFn> = {
@@ -110,6 +111,7 @@ export class OrdinalPipelineStore {
   columns: Record<string, OrdinalColumn> = {}
   /** Overlays returned from customLayout (consumed by StreamOrdinalFrame). */
   customLayoutOverlays: import("react").ReactNode = null
+  private _customLayoutDiagnosticsWarned = new Set<string>()
   version = 0
   /** Bumped whenever the buffer is mutated. Used to invalidate per-frame caches. */
   private _dataVersion = 0
@@ -727,7 +729,14 @@ export class OrdinalPipelineStore {
         return []
       }
       this.customLayoutOverlays = result.overlays ?? null
-      return result.nodes ?? []
+      const nodes = result.nodes ?? []
+      warnCustomLayoutDiagnostics({
+        label: "ordinal customLayout",
+        nodes,
+        overlays: this.customLayoutOverlays,
+        warned: this._customLayoutDiagnosticsWarned,
+      })
+      return nodes
     }
 
     // Built-in chart types: clear stale overlays from a prior customLayout run.
@@ -1432,6 +1441,8 @@ export class OrdinalPipelineStore {
 
     this._dataVersion++
     this.version++
+    // A removal is data activity — refresh the staleness clock.
+    this.lastIngestTime = typeof performance !== "undefined" ? performance.now() : Date.now()
     return removed
   }
 
@@ -1470,6 +1481,9 @@ export class OrdinalPipelineStore {
 
     this._dataVersion++
     this.version++
+    // An in-place update is data activity — refresh the staleness clock so a
+    // chart streamed via update() (e.g. a refill demo) isn't flagged stale.
+    this.lastIngestTime = typeof performance !== "undefined" ? performance.now() : Date.now()
     return previous
   }
 

--- a/src/components/stream/PipelineStore.cache.test.ts
+++ b/src/components/stream/PipelineStore.cache.test.ts
@@ -238,6 +238,24 @@ describe("buffer array cache invalidation", () => {
     store.clear()
     expect(store.getData()).toHaveLength(0)
   })
+
+  // update()/remove() are data activity — they must refresh the staleness clock
+  // so a chart streamed via in-place mutation isn't falsely flagged stale.
+  it("update() refreshes lastIngestTime", () => {
+    const store = makeStore({ pointIdAccessor: "id" })
+    setData(store, [{ id: "a", x: 1, y: 10 }])
+    store.lastIngestTime = 1 // simulate a long-idle (would-be-stale) clock
+    store.update("a", (d) => ({ ...d, y: 99 }))
+    expect(store.lastIngestTime).toBeGreaterThan(1)
+  })
+
+  it("remove() refreshes lastIngestTime", () => {
+    const store = makeStore({ pointIdAccessor: "id" })
+    setData(store, [{ id: "a", x: 1, y: 10 }, { id: "b", x: 2, y: 20 }])
+    store.lastIngestTime = 1
+    store.remove("b")
+    expect(store.lastIngestTime).toBeGreaterThan(1)
+  })
 })
 
 // ── Scene rebuild after config changes ───────────────────────────────────

--- a/src/components/stream/PipelineStore.customLayout.test.ts
+++ b/src/components/stream/PipelineStore.customLayout.test.ts
@@ -1,7 +1,11 @@
-import { describe, it, expect } from "vitest"
+import { afterEach, describe, it, expect, vi } from "vitest"
 import { PipelineStore } from "./PipelineStore"
 import type { LayoutContext } from "./customLayout"
 import type { RectSceneNode, AreaSceneNode } from "./types"
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 describe("PipelineStore customLayout integration", () => {
   it("invokes customLayout instead of chart-type dispatch", () => {
@@ -61,6 +65,55 @@ describe("PipelineStore customLayout integration", () => {
     store.computeScene({ width: 100, height: 100 })
 
     expect(store.customLayoutOverlays).toBe(sentinel)
+  })
+
+  it("warns when customLayout returns overlays without scene nodes", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    const sentinel = { _sentinel: true } as unknown as React.ReactNode
+    const layout = () => ({ nodes: [], overlays: sentinel })
+    const store = new PipelineStore({
+      chartType: "custom",
+      windowSize: 100,
+      windowMode: "sliding",
+      arrowOfTime: "right",
+      extentPadding: 0,
+      xAccessor: "x",
+      yAccessor: "y",
+      customLayout: layout,
+    })
+    store.ingest({ inserts: [{ x: 1, y: 1 }], bounded: true })
+    store.computeScene({ width: 100, height: 100 })
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("returned overlays but no data-bearing scene nodes"))
+  })
+
+  it("warns when customLayout scene nodes all have null datums", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    const layout = () => ({
+      nodes: [{
+        type: "rect",
+        x: 0,
+        y: 0,
+        w: 10,
+        h: 10,
+        style: { fill: "#000" },
+        datum: null,
+      } satisfies RectSceneNode],
+    })
+    const store = new PipelineStore({
+      chartType: "custom",
+      windowSize: 100,
+      windowMode: "sliding",
+      arrowOfTime: "right",
+      extentPadding: 0,
+      xAccessor: "x",
+      yAccessor: "y",
+      customLayout: layout,
+    })
+    store.ingest({ inserts: [{ x: 1, y: 1 }], bounded: true })
+    store.computeScene({ width: 100, height: 100 })
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("every scene-node datum is null"))
   })
 
   it("renders empty scene when layout throws", () => {

--- a/src/components/stream/PipelineStore.ts
+++ b/src/components/stream/PipelineStore.ts
@@ -70,6 +70,7 @@ import { buildSwarmScene } from "./xySceneBuilders/swarmScene"
 import { buildWaterfallScene } from "./xySceneBuilders/waterfallScene"
 import { buildCandlestickScene } from "./xySceneBuilders/candlestickScene"
 import type { CustomLayout, LayoutContext } from "./customLayout"
+import { warnCustomLayoutDiagnostics } from "./customLayoutDiagnostics"
 import type { MarginType } from "../types/marginType"
 
 // ── Axis direction helpers ─────────────────────────────────────────────
@@ -403,6 +404,7 @@ export class PipelineStore {
   version = 0
   /** Overlays returned from customLayout (consumed by StreamXYFrame for SVGOverlay). */
   customLayoutOverlays: import("react").ReactNode = null
+  private _customLayoutDiagnosticsWarned = new Set<string>()
 
   /** True when the x accessor returns Date objects (auto-detected on first data ingestion) */
   xIsDate = false
@@ -1199,7 +1201,14 @@ export class PipelineStore {
         return []
       }
       this.customLayoutOverlays = result.overlays ?? null
-      return result.nodes ?? []
+      const nodes = result.nodes ?? []
+      warnCustomLayoutDiagnostics({
+        label: "customLayout",
+        nodes,
+        overlays: this.customLayoutOverlays,
+        warned: this._customLayoutDiagnosticsWarned,
+      })
+      return nodes
     }
 
     // Built-in chart types: ensure stale overlays from a prior customLayout
@@ -1654,6 +1663,9 @@ export class PipelineStore {
     this.needsFullRebuild = true
     this._bufferDirty = true
     this._ingestVersion++
+    // A removal is data activity — refresh the staleness clock so a chart
+    // mutated via remove() isn't flagged stale.
+    this.lastIngestTime = typeof performance !== "undefined" ? performance.now() : Date.now()
     return removed
   }
 
@@ -1706,6 +1718,9 @@ export class PipelineStore {
     this.needsFullRebuild = true
     this._bufferDirty = true
     this._ingestVersion++
+    // An in-place update is data activity — refresh the staleness clock so a
+    // chart streamed via update() isn't flagged stale between updates.
+    this.lastIngestTime = typeof performance !== "undefined" ? performance.now() : Date.now()
     return previous
   }
 

--- a/src/components/stream/StreamOrdinalFrame.tsx
+++ b/src/components/stream/StreamOrdinalFrame.tsx
@@ -396,6 +396,7 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
     const [currentScales, setCurrentScales] = useState<OrdinalScales | null>(null)
     const [annotationFrame, setAnnotationFrame] = useState(0)
     const [isStale, setIsStale] = useState(false)
+    const lastSceneDimsRef = useRef({ w: -1, h: -1 })
     // customLayout overlays are read straight from store.customLayoutOverlays at
     // render time (see the foregroundGraphics composition below) — same pattern
     // as StreamXYFrame / StreamNetworkFrame. The render loop's `setAnnotationFrame`
@@ -805,15 +806,21 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
       const transitionActive = store.advanceTransition(reducedMotionRef.current ? now + 1e6 : now)
       const isTransitioning = reducedMotionRef.current ? false : transitionActive
 
+      const dimsChanged =
+        lastSceneDimsRef.current.w !== adjustedWidth || lastSceneDimsRef.current.h !== adjustedHeight
       const wasDirty = dirtyRef.current
-      if (wasDirty && !transitionActive) {
+      let computedSceneThisFrame = false
+
+      if ((wasDirty || dimsChanged) && (!isTransitioning || dimsChanged)) {
         store.computeScene({ width: adjustedWidth, height: adjustedHeight })
+        lastSceneDimsRef.current = { w: adjustedWidth, h: adjustedHeight }
+        computedSceneThisFrame = true
         emitLegendCategories()
-        dirtyRef.current = false
       }
+      dirtyRef.current = wasDirty && isTransitioning && !computedSceneThisFrame
 
       // Update canvas aria-label imperatively after scene changes
-      if (wasDirty || isTransitioning) {
+      if (computedSceneThisFrame || isTransitioning) {
         canvas.setAttribute("aria-label", computeCanvasAriaLabel(store.scene, chartType + " chart"))
       }
 
@@ -902,7 +909,7 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
       }
 
       // Push scales to React state for SVG overlay
-      if (wasDirty && store.scales) {
+      if (computedSceneThisFrame && store.scales) {
         setCurrentScales(store.scales)
         setAnnotationFrame(f => f + 1)
       }

--- a/src/components/stream/StreamXYFrame.tsx
+++ b/src/components/stream/StreamXYFrame.tsx
@@ -486,6 +486,14 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
     // note #3.
     const dirtyRef = useRef(false)
 
+    // Last plot dimensions a computeScene ran at. A responsive width change
+    // must re-solve the scene even mid-transition — otherwise the canvas keeps
+    // the pre-measure width while the viewBox-scaled SVG overlay already
+    // reflects the new width, drifting custom-layout overlays off their canvas
+    // scene nodes (progressively, since the error scales with x) until the
+    // transition ends.
+    const lastSceneDimsRef = useRef({ w: -1, h: -1 })
+
     // XY resolves foreground/background locally (not via useFrame) because
     // the marginalGraphics branch below may expand margin, and function-form
     // graphics must be evaluated against the final margin. Having useFrame
@@ -1141,13 +1149,24 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
       const transitionActive = store.advanceTransition(reducedMotionRef.current ? now + 1e6 : now)
       const isTransitioning = reducedMotionRef.current ? false : transitionActive
 
+      // A responsive resize must re-solve the scene at the new dimensions even
+      // mid-transition, so canvas scene nodes and the viewBox-scaled SVG overlay
+      // stay aligned (otherwise custom-layout overlays drift off their nodes
+      // until the transition ends).
+      const dimsChanged =
+        lastSceneDimsRef.current.w !== adjustedWidth || lastSceneDimsRef.current.h !== adjustedHeight
+
       // Determine if data canvas needs repaint (data/props changed or animating).
       // Use transitionActive so reduced-motion fast-forwarded transitions still repaint.
-      const needsDataRepaint = dirtyRef.current || transitionActive
+      const needsDataRepaint = dirtyRef.current || transitionActive || dimsChanged
+      let computedSceneThisFrame = false
 
-      // Compute scene graph (scales + scene nodes) — only when data changed
-      if (needsDataRepaint && !isTransitioning) {
+      // Compute scene graph (scales + scene nodes) — when data changed, or when
+      // the dimensions changed (the latter wins over an active transition).
+      if (needsDataRepaint && (!isTransitioning || dimsChanged)) {
         store.computeScene({ width: adjustedWidth, height: adjustedHeight })
+        lastSceneDimsRef.current = { w: adjustedWidth, h: adjustedHeight }
+        computedSceneThisFrame = true
         emitLegendCategories()
       }
 
@@ -1282,7 +1301,11 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
 
       // ── React state updates ──────────────────────────────────────────
       const wasDirty = dirtyRef.current
-      dirtyRef.current = false
+      // If a prop/layout/size change arrives while a transition is active,
+      // computeScene is intentionally deferred. Keep the dirty flag set so
+      // the next non-transition frame applies the new responsive dimensions
+      // instead of leaving canvas scene nodes and SVG overlays out of sync.
+      dirtyRef.current = wasDirty && isTransitioning && !computedSceneThisFrame
 
       // Push scales into React state so SVGOverlay renders axes/grid
       if (wasDirty && store.scales) {
@@ -1315,8 +1338,12 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
         }
       }
 
-      // Trigger React re-render for SVG annotations
-      if (wasDirty && annotations && annotations.length > 0) {
+      // Trigger React re-render for SVG annotations and custom-layout overlays.
+      // CustomLayout overlays are stored on PipelineStore during computeScene;
+      // without this, responsive first paint can leave the canvas scene at the
+      // latest measured width while overlay glyphs remain from the prior solve
+      // until another React state change happens.
+      if (computedSceneThisFrame && ((annotations && annotations.length > 0) || customLayout)) {
         setAnnotationFrame(f => f + 1)
       }
 

--- a/src/components/stream/customLayoutDiagnostics.ts
+++ b/src/components/stream/customLayoutDiagnostics.ts
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react"
+
+export interface CustomLayoutDiagnosticNode {
+  datum?: unknown
+}
+
+export interface CustomLayoutDiagnosticsOptions {
+  label: string
+  nodes: readonly CustomLayoutDiagnosticNode[]
+  overlays?: ReactNode
+  warned: Set<string>
+}
+
+export function warnCustomLayoutDiagnostics(options: CustomLayoutDiagnosticsOptions): void {
+  if (process.env.NODE_ENV === "production") return
+
+  const { label, nodes, overlays, warned } = options
+  if (hasRenderableOverlay(overlays) && nodes.length === 0) {
+    warnOnce(
+      warned,
+      "overlay-only",
+      `[semiotic] ${label} returned overlays but no data-bearing scene nodes. ` +
+        "Overlays do not participate in hover, selection, transitions, SSR evidence, or accessibility tables. " +
+        "Emit at least one scene node with a datum, or mark the overlay-only chart as intentionally decorative."
+    )
+  }
+
+  if (nodes.length > 0 && nodes.every((node) => node.datum == null)) {
+    warnOnce(
+      warned,
+      "null-datums",
+      `[semiotic] ${label} returned scene nodes, but every scene-node datum is null. ` +
+        "Hover, callbacks, selection, and tooltip helpers need data-bearing nodes. " +
+        "Attach a user-facing datum to each interactive node, or set interactive overlays outside the chart."
+    )
+  }
+}
+
+function hasRenderableOverlay(overlays: ReactNode): boolean {
+  if (overlays == null || overlays === false || overlays === "") return false
+  if (Array.isArray(overlays)) return overlays.some(hasRenderableOverlay)
+  return true
+}
+
+function warnOnce(warned: Set<string>, key: string, message: string): void {
+  if (warned.has(key)) return
+  warned.add(key)
+  console.warn(message)
+}

--- a/src/components/stream/renderers/pointCanvasRenderer.test.ts
+++ b/src/components/stream/renderers/pointCanvasRenderer.test.ts
@@ -75,25 +75,28 @@ describe("pointCanvasRenderer", () => {
     expect(ctx.fillStyle).toBe("#4e79a7")
   })
 
-  it("sets globalAlpha from style.opacity", () => {
+  it("applies style.opacity to globalAlpha", () => {
     const ctx = createMockCanvasContext()
+    const alphaValues: number[] = []
+    let _alpha = 1
+    Object.defineProperty(ctx, "globalAlpha", { get: () => _alpha, set: (v: number) => { _alpha = v; alphaValues.push(v) } })
     const node = makePointNode({ style: { fill: "#4e79a7", opacity: 0.5 } })
 
     pointCanvasRenderer(ctx, [node], makeScales(), makeLayout())
 
-    expect(ctx.globalAlpha).toBe(1) // reset at end
-    // Verify alpha was set to 0.5 at some point during rendering
-    // Since resetMocks is on, we check the final reset
+    expect(alphaValues).toContain(0.5)
   })
 
-  it("sets globalAlpha from style.fillOpacity when opacity is absent", () => {
+  it("applies style.fillOpacity to globalAlpha when opacity is absent", () => {
     const ctx = createMockCanvasContext()
+    const alphaValues: number[] = []
+    let _alpha = 1
+    Object.defineProperty(ctx, "globalAlpha", { get: () => _alpha, set: (v: number) => { _alpha = v; alphaValues.push(v) } })
     const node = makePointNode({ style: { fill: "#4e79a7", fillOpacity: 0.3 } })
 
     pointCanvasRenderer(ctx, [node], makeScales(), makeLayout())
 
-    // globalAlpha is reset to 1 at the end of the loop
-    expect(ctx.globalAlpha).toBe(1)
+    expect(alphaValues).toContain(0.3)
   })
 
   it("renders pulse glow when _pulseIntensity > 0", () => {
@@ -177,7 +180,7 @@ describe("pointCanvasRenderer", () => {
     expect(ctx.fill).toHaveBeenCalledTimes(3)
   })
 
-  it("resets globalAlpha to 1 after rendering each node", () => {
+  it("applies each node's alpha without clobbering between nodes (relies on save/restore)", () => {
     const ctx = createMockCanvasContext()
     const alphaValues: number[] = []
 
@@ -198,9 +201,30 @@ describe("pointCanvasRenderer", () => {
 
     pointCanvasRenderer(ctx, nodes, makeScales(), makeLayout())
 
-    // Each node: set opacity, then reset to 1
-    // So we expect: 0.3, 1, 0.7, 1
-    expect(alphaValues).toEqual([0.3, 1, 0.7, 1])
+    // One alpha set per node (base 1 × node alpha); no per-node reset to 1.
+    expect(alphaValues).toEqual([0.3, 0.7])
+    expect(ctx.restore).toHaveBeenCalled()
+  })
+
+  it("multiplies node alpha into the incoming base alpha for EVERY node (staleness dim)", () => {
+    const ctx = createMockCanvasContext()
+    const alphaValues: number[] = []
+    // Incoming chart-wide dim (e.g. staleness) before the renderer runs.
+    let _alpha = 0.5
+    Object.defineProperty(ctx, "globalAlpha", {
+      get: () => _alpha,
+      set: (v: number) => {
+        _alpha = v
+        alphaValues.push(v)
+      }
+    })
+
+    const nodes = [makePointNode({ style: { fill: "#f00" } }), makePointNode({ style: { fill: "#0f0" } })]
+    pointCanvasRenderer(ctx, nodes, makeScales(), makeLayout())
+
+    // Every node honors the 0.5 base — not just the first (the bug was the
+    // rest resetting to full opacity).
+    expect(alphaValues).toEqual([0.5, 0.5])
   })
 
   it("handles decay via reduced style.opacity", () => {
@@ -221,7 +245,5 @@ describe("pointCanvasRenderer", () => {
     pointCanvasRenderer(ctx, [node], makeScales(), makeLayout())
 
     expect(alphaValues[0]).toBe(0.2)
-    // Reset at end
-    expect(alphaValues[alphaValues.length - 1]).toBe(1)
   })
 })

--- a/src/components/stream/renderers/pointCanvasRenderer.ts
+++ b/src/components/stream/renderers/pointCanvasRenderer.ts
@@ -15,14 +15,17 @@ export const pointCanvasRenderer: StreamRendererFn = (ctx, nodes, _scales, _layo
 
   ctx.save()
   try {
+    // Preserve the incoming canvas alpha (e.g. a chart-wide staleness dim) and
+    // multiply each node's own opacity into it, rather than clobbering it to 1
+    // — otherwise only the first node honored the dim and the rest reset to
+    // full. `ctx.restore()` puts the base alpha back when we're done.
+    const baseAlpha = ctx.globalAlpha
     for (const node of pointNodes) {
       ctx.beginPath()
       ctx.arc(node.x, node.y, node.r, 0, Math.PI * 2)
 
-      const alpha = node.style.opacity ?? node.style.fillOpacity
-      if (alpha != null) {
-        ctx.globalAlpha = alpha
-      }
+      const alpha = node.style.opacity ?? node.style.fillOpacity ?? 1
+      ctx.globalAlpha = baseAlpha * alpha
 
       ctx.fillStyle = resolveCanvasFill(ctx, node.style.fill, "#4e79a7")
       ctx.fill()
@@ -35,8 +38,6 @@ export const pointCanvasRenderer: StreamRendererFn = (ctx, nodes, _scales, _layo
 
       // Pulse glow ring
       renderCirclePulse(ctx, node)
-
-      ctx.globalAlpha = 1
     }
   } finally {
     ctx.restore()


### PR DESCRIPTION

<img width="749" height="663" alt="Screenshot 2026-06-17 at 7 39 53 PM" src="https://github.com/user-attachments/assets/853200e5-9c61-43e4-9a96-b893c6a3ac78" />


Introduce an experimental GoFish Frontend IR adapter and supporting UI/docs. Adds a new GoFishLayouts feature page, a blog draft (Making Better Custom Charts), nav entry, and route; links Custom Charts docs to the new page and documents recipe authoring, push semantics, and network diagrams. Implements adapter/runtime pieces under src/components/recipes (gofish interpreter, lambdas, examples, tests), exposes experimental APIs in semiotic-experimental, and updates semiotic-recipes usage. Adds integration tests and example pages for custom layout behavior, diagnostic helpers, and multiple stream/pipeline test updates. Also updates package/scripts and API surface docs to reflect the new experimental surface.

This pull request adds a new draft blog entry, "Making Better Custom Charts," and introduces documentation and navigation updates to support new experimental features, particularly the GoFish IR interpreter and custom charting capabilities. It also enhances the documentation for custom chart authoring, including best practices and API usage.

**Key changes:**

**New blog entry and content:**
- Added a draft blog post, `making-better-custom-charts.js`, which discusses the evolution of Semiotic's custom chart surface, the scene-node/overlay contract, domain-driven layouts (with a Kafka Streams example), and the new GoFish IR interpreter that can execute foreign chart grammars. The post includes a live demo and detailed explanations of when and how to use custom charts.
- Registered the new blog entry in `entries-meta.js` and included it in the blog entry list for drafts and previews. [[1]](diffhunk://#diff-b29e7c9dae4d0d98a41b08dcc1c22f652d850291523ccac53d1f8c1cb180e3a6R22-R33) [[2]](diffhunk://#diff-4881dbd01f8f6229bd95bffab70304d66b1c9794f5db134b0d994f62c6c77934R61) [[3]](diffhunk://#diff-4881dbd01f8f6229bd95bffab70304d66b1c9794f5db134b0d994f62c6c77934R78)

**Navigation and documentation updates:**
- Added "Experimental GoFish Adapter" to the navigation menu, linking to `/features/gofish-layouts`, and registered the new route and page in the app. [[1]](diffhunk://#diff-0e9b4495873193679d9f273691fe01757f807fcafbf78074bdb2c758b56986a1R128) [[2]](diffhunk://#diff-0a39c0f0ea64594aef352a62c1b59bc44814bbfb1dc3c9e2511acd9770a281f2R107) [[3]](diffhunk://#diff-0a39c0f0ea64594aef352a62c1b59bc44814bbfb1dc3c9e2511acd9770a281f2R438)

**Custom chart documentation enhancements:**
- Expanded the "Custom Charts" documentation page with new sections on recipe authoring contracts, push semantics, and network diagrams. These sections provide guidance on scene node vs. overlay responsibilities, tooltip construction, and when to use custom layouts versus built-in charts. [[1]](diffhunk://#diff-7e7540f1849caecbde3e3dd3c9fe39d462a6aac9a66b9efd537a0596e0a12646R769-R855) [[2]](diffhunk://#diff-7e7540f1849caecbde3e3dd3c9fe39d462a6aac9a66b9efd537a0596e0a12646R874)

**Experimental features and API exposure:**
- Exposed and documented the use of `buildTooltipEntries` from `semiotic/recipes` for consistent tooltip payloads in custom charts.

These changes collectively improve the documentation and developer experience for advanced chart customization and experimental grammar interpretation in Semiotic.