### PR TITLE
Unwrap network hover wrapper for tooltips

### DIFF
--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -334,6 +334,21 @@ describe("normalizeTooltip", () => {
     expect(rendered).not.toBeNull()
     expect(rendered?.props.children).toBe("A")
   })
+
+  it("does not unwrap already-raw network datums that merely have a `.data` field (e.g. NetworkCustomChart scene datum)", () => {
+    const fn = (d: Datum) => d.id
+    const wrapped = normalizeTooltip(fn) as (d: Datum) => TooltipElement | null
+    const hoverData = {
+      __semioticHoverData: true,
+      nodeOrEdge: "node",
+      x: 10,
+      y: 20,
+      data: { id: "A", data: { nested: true } },
+    }
+    const rendered = wrapped(hoverData)
+    expect(rendered).not.toBeNull()
+    expect(rendered?.props.children).toBe("A")
+  })
 })
 
 describe("buildDefaultTooltip with title role", () => {

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -270,6 +270,70 @@ describe("normalizeTooltip", () => {
   it("returns false for undefined", () => {
     expect(normalizeTooltip(undefined)).toBe(false)
   })
+
+  it("unwraps a network EDGE wrapper to the raw datum (source/target as ids, not node objects)", () => {
+    // A custom tooltip that renders `edge.source` directly. Before the fix it
+    // received the RealtimeEdge whose `source` is a node OBJECT, throwing
+    // "Objects are not valid as a React child" on hover.
+    const fn = (d: Datum) => `${d.source} -> ${d.target} (${d.flowType})`
+    const wrapped = normalizeTooltip(fn) as (d: Datum) => TooltipElement | null
+    // RealtimeEdge after sankey layout: source/target resolved to node
+    // objects, raw user edge preserved at `.data`.
+    const hoverData = {
+      __semioticHoverData: true,
+      nodeOrEdge: "edge",
+      x: 10,
+      y: 20,
+      data: {
+        source: { id: "A", x0: 0, x1: 12, sourceLinks: [], targetLinks: [] },
+        target: { id: "B", x0: 80, x1: 92, sourceLinks: [], targetLinks: [] },
+        value: 5,
+        sankeyWidth: 5,
+        data: { source: "A", target: "B", value: 5, flowType: "transition" },
+      },
+    }
+    const rendered = wrapped(hoverData)
+    expect(rendered).not.toBeNull()
+    expect(rendered?.props.children).toBe("A -> B (transition)")
+  })
+
+  it("unwraps a network NODE wrapper to the raw datum", () => {
+    const fn = (d: Datum) => `${d.label} / ${d.type}`
+    const wrapped = normalizeTooltip(fn) as (d: Datum) => TooltipElement | null
+    const hoverData = {
+      __semioticHoverData: true,
+      nodeOrEdge: "node",
+      x: 10,
+      y: 20,
+      data: {
+        id: "A",
+        x0: 0,
+        x1: 12,
+        value: 5,
+        sourceLinks: [],
+        targetLinks: [],
+        data: { id: "A", label: "Alpha", type: "Teacher" },
+      },
+    }
+    const rendered = wrapped(hoverData)
+    expect(rendered).not.toBeNull()
+    expect(rendered?.props.children).toBe("Alpha / Teacher")
+  })
+
+  it("leaves the network wrapper intact when it carries no raw `.data` payload", () => {
+    const fn = (d: Datum) => d.id
+    const wrapped = normalizeTooltip(fn) as (d: Datum) => TooltipElement | null
+    const hoverData = {
+      __semioticHoverData: true,
+      nodeOrEdge: "node",
+      x: 10,
+      y: 20,
+      data: { id: "A", x0: 0, x1: 12, value: 5 },
+    }
+    const rendered = wrapped(hoverData)
+    expect(rendered).not.toBeNull()
+    expect(rendered?.props.children).toBe("A")
+  })
 })
 
 describe("buildDefaultTooltip with title role", () => {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -491,7 +491,28 @@ export function normalizeTooltip(tooltip: TooltipProp | undefined): false | Tool
         && typeof hoverData.x === "number"
         && typeof hoverData.y === "number"
         && hasLegacyFrameMarker)
-      const datum = normalizeHoverDatum(looksLikeHoverWrapper ? (hoverData.data ?? {}) : hoverData)
+      let datum = normalizeHoverDatum(looksLikeHoverWrapper ? (hoverData.data ?? {}) : hoverData)
+      // Network frames wrap the user's datum twice. HoverData.data is the
+      // RealtimeNode/RealtimeEdge that layout produced (carrying x0/y0/
+      // sourceLinks — and, for edges, `source`/`target` resolved to node
+      // OBJECTS), while the raw datum the user passed in `nodes`/`edges`
+      // sits one level deeper at `.data`. Unwrap that extra level so network
+      // HOC tooltips receive raw data, matching the XY/ordinal contract.
+      // Without it a custom tooltip rendering `edge.source` gets a node
+      // object and React throws "Objects are not valid as a React child".
+      // `nodeOrEdge` is set only by StreamNetworkFrame, so XY/ordinal hover
+      // data is left untouched.
+      const isNetworkHover =
+        hoverData?.nodeOrEdge === "node" || hoverData?.nodeOrEdge === "edge"
+      if (
+        isNetworkHover &&
+        datum &&
+        typeof datum === "object" &&
+        datum.data &&
+        typeof datum.data === "object"
+      ) {
+        datum = datum.data
+      }
       const result = userFn(datum)
       if (result === null || result === undefined) return null
       return (

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -500,14 +500,22 @@ export function normalizeTooltip(tooltip: TooltipProp | undefined): false | Tool
       // HOC tooltips receive raw data, matching the XY/ordinal contract.
       // Without it a custom tooltip rendering `edge.source` gets a node
       // object and React throws "Objects are not valid as a React child".
-      // `nodeOrEdge` is set only by StreamNetworkFrame, so XY/ordinal hover
-      // data is left untouched.
-      const isNetworkHover =
-        hoverData?.nodeOrEdge === "node" || hoverData?.nodeOrEdge === "edge"
+      //
+      // Match only genuine RealtimeNode/RealtimeEdge wrappers, not just the
+      // presence of `nodeOrEdge` + a nested `.data`: every node built by the
+      // network pipeline has numeric x0/x1 (createNode), and every edge a
+      // numeric sankeyWidth (0 for non-sankey layouts). A customNetworkLayout
+      // hit whose datum is the user's own object — even one that happens to
+      // carry an incidental `.data` field — lacks those layout fields and is
+      // passed through untouched.
+      const isNodeWrapper =
+        hoverData?.nodeOrEdge === "node" &&
+        typeof datum?.x0 === "number" &&
+        typeof datum?.x1 === "number"
+      const isEdgeWrapper =
+        hoverData?.nodeOrEdge === "edge" && typeof datum?.sankeyWidth === "number"
       if (
-        isNetworkHover &&
-        datum &&
-        typeof datum === "object" &&
+        (isNodeWrapper || isEdgeWrapper) &&
         datum.data &&
         typeof datum.data === "object"
       ) {


### PR DESCRIPTION
When tooltip callbacks received hover payloads from network frames, they were getting the RealtimeNode/RealtimeEdge (with resolved node objects) instead of the raw user datum. normalizeTooltip now detects StreamNetworkFrame hover wrappers and unwraps an inner `.data` payload so user tooltip functions get the original datum (e.g. edge.source as an id, not a node object). This prevents errors like "Objects are not valid as a React child" for custom tooltip renderers. Added tests covering edge/node unwrapping and the case where no inner `.data` exists.
