### PR TITLE
Fix edge widths, label overlap, custom layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **ForceDirectedGraph edge width now honors a weight field.** A string `edgeWidth`
+  accessor (e.g. `edgeWidth="weight"`) read the property off the `RealtimeEdge`
+  wrapper instead of the underlying edge data, so every edge silently fell back to
+  width 1. Field and function `edgeWidth` accessors now resolve against the raw edge
+  (mirroring node styling), and the `semiotic/server` `renderChart` path gained the
+  same `edgeWidth`/`edgeColor`/`edgeOpacity` handling for SSR parity.
+- **Crowded bar-chart category labels no longer overlap.** Ordinal category axes
+  (BarChart and siblings) now thin their tick labels to an evenly-spaced subset when
+  too many bins crowd the axis — the classic temporal-histogram case. Charts with few
+  enough categories to fit are unchanged.
+- **Custom-layout overlays no longer drift on the first responsive resize.** XY custom
+  layouts (`XYCustomChart`, GoFish recipes) skipped the layout re-run on a
+  dimension-only change and took `computeScene`'s fast coordinate-remap path, which
+  rescales canvas scene nodes but never regenerates the SVG overlays — so glyph chrome
+  (e.g. the GoFish flower petals) stayed at the pre-measurement width and sat offset
+  from their scene nodes until any other change forced a rebuild. Custom layouts now
+  always re-run on a size change, keeping overlays and scene nodes aligned.
+
+### Changed
+
+- **BarChart suggestion caveat for temporal categories.** When a BarChart's category
+  axis holds time-bin labels (month/weekday names, `YYYY-MM`, `Q3`, `Week 12`, or a
+  temporal field name), `suggestCharts` now surfaces a caveat pointing toward a
+  time-aware treatment (real dates + LineChart/AreaChart, or a temporal histogram for
+  streaming counts).
+
 ## [3.7.4] - 2026-06-15
 
 ### Added

--- a/docs/src/pages/features/GoFishLayoutsPage.js
+++ b/docs/src/pages/features/GoFishLayoutsPage.js
@@ -43,6 +43,18 @@ const bottleData = [
   { id: "ship", category: "Ship", amount: 55 },
 ]
 
+// The boba volume sliders edit the last cup on the menu (the IR's final row).
+// Read its name + original volumes from the IR so the controls stay in sync if
+// the spec changes.
+const bobaCupRows = bobaIR?.root?.data?.rows ?? []
+const lastBobaCup = bobaCupRows[bobaCupRows.length - 1] ?? {}
+const lastBobaCupName = lastBobaCup.name ?? "the last cup"
+const bobaVolumeDefaults = {
+  bobaTeaVolume: Number(lastBobaCup.teaVolume) || 660,
+  bobaBobaVolume: Number(lastBobaCup.bobaVolume) || 150,
+  bobaIceVolume: Number(lastBobaCup.iceVolume) || 120,
+}
+
 // IR docs can carry large inline datasets (Titanic). Abridge long `rows`
 // arrays so the spec stays readable when shown in the page.
 function irForDisplay(doc) {
@@ -200,7 +212,7 @@ const demoMeta = {
     visualConfig: (c) => ({ cupWidthRatio: c.cupWidth }),
     question: "Can an ordinal frame render a menu of bespoke, data-driven pictorial glyphs as separate categories?",
     contract:
-      "Each drink is one ordinal item on the band scale. Its tea + tapioca + ice volumes (plus cup-size params) add up to a drink height the derive lambda solves; the cups share one scale and a baseline so they read as a menu on a shelf. A transparent hit rect per cup carries the volumes and pearl/ice counts into the scene graph; the cup outline, tea, tapioca pearls, ice, lid, and straw are keyed SVG overlays. Refilling a cup's boba volume re-solves and re-renders its pearl bed in place.",
+      "Each drink is one ordinal item on the band scale. Its tea + tapioca + ice volumes (plus cup-size params) add up to a drink height the derive lambda solves; the cups share one scale and a baseline so they read as a menu on a shelf. A transparent hit rect per cup carries the volumes and pearl/ice counts into the scene graph; the cup outline, tea, tapioca pearls, ice, lid, and straw are keyed SVG overlays. The tea / boba / ice sliders edit the last cup's volumes; because the layout re-runs the derive over the live buffer, each edit re-solves and re-renders that cup's tea fill, pearl bed, and ice in place.",
   },
 }
 
@@ -225,69 +237,120 @@ function getDemo(active, controls, cfg) {
   }
 }
 
-function getControl(active, controls, setControls) {
+// Returns the ordered list of slider controls for the active demo. Most demos
+// have a single visual control; boba adds three data controls that edit the
+// last cup's tea / boba / ice volumes.
+function getControls(active, controls, setControls) {
   const update = (key) => (event) =>
     setControls((prev) => ({ ...prev, [key]: Number(event.target.value) }))
   if (active === "flower") {
-    return {
-      label: "Petal radius",
-      value: controls.flowerRadius,
-      min: 22,
-      max: 48,
-      onChange: update("flowerRadius"),
-      suffix: "px",
-    }
+    return [
+      {
+        key: "flowerRadius",
+        label: "Petal radius",
+        value: controls.flowerRadius,
+        min: 22,
+        max: 48,
+        onChange: update("flowerRadius"),
+        suffix: "px",
+      },
+    ]
   }
   if (active === "bottle") {
-    return {
-      label: "Bottle height",
-      value: controls.bottleHeight,
-      min: 150,
-      max: 260,
-      onChange: update("bottleHeight"),
-      suffix: "px",
-    }
+    return [
+      {
+        key: "bottleHeight",
+        label: "Bottle height",
+        value: controls.bottleHeight,
+        min: 150,
+        max: 260,
+        onChange: update("bottleHeight"),
+        suffix: "px",
+      },
+    ]
   }
   if (active === "polar") {
-    return {
-      label: "Outer radius",
-      value: controls.outerRadius,
-      min: 112,
-      max: 178,
-      onChange: update("outerRadius"),
-      suffix: "px",
-    }
+    return [
+      {
+        key: "outerRadius",
+        label: "Outer radius",
+        value: controls.outerRadius,
+        min: 112,
+        max: 178,
+        onChange: update("outerRadius"),
+        suffix: "px",
+      },
+    ]
   }
   if (active === "titanic") {
-    return {
-      label: "Treemap padding",
-      value: controls.treemapPadding,
-      min: 0,
-      max: 6,
-      step: 0.5,
-      onChange: update("treemapPadding"),
-      suffix: "px",
-    }
+    return [
+      {
+        key: "treemapPadding",
+        label: "Treemap padding",
+        value: controls.treemapPadding,
+        min: 0,
+        max: 6,
+        step: 0.5,
+        onChange: update("treemapPadding"),
+        suffix: "px",
+      },
+    ]
   }
   if (active === "boba") {
-    return {
-      label: "Cup width",
-      value: controls.cupWidth,
-      min: 0.6,
-      max: 1,
-      step: 0.01,
-      onChange: update("cupWidth"),
-      suffix: "× band",
-    }
+    return [
+      {
+        key: "cupWidth",
+        label: "Cup width",
+        value: controls.cupWidth,
+        min: 0.6,
+        max: 1,
+        step: 0.01,
+        onChange: update("cupWidth"),
+        suffix: "× band",
+      },
+      {
+        key: "bobaTeaVolume",
+        label: `${lastBobaCupName} tea`,
+        value: controls.bobaTeaVolume,
+        min: 0,
+        max: 800,
+        step: 10,
+        onChange: update("bobaTeaVolume"),
+        suffix: " ml",
+      },
+      {
+        key: "bobaBobaVolume",
+        label: `${lastBobaCupName} boba`,
+        value: controls.bobaBobaVolume,
+        min: 0,
+        max: 400,
+        step: 5,
+        onChange: update("bobaBobaVolume"),
+        suffix: " ml",
+      },
+      {
+        key: "bobaIceVolume",
+        label: `${lastBobaCupName} ice`,
+        value: controls.bobaIceVolume,
+        min: 0,
+        max: 250,
+        step: 5,
+        onChange: update("bobaIceVolume"),
+        suffix: " ml",
+      },
+    ]
   }
-  return {
-    label: "Heap gap",
-    value: controls.heapGap,
-    min: 4,
-    max: 34,
-    onChange: update("heapGap"),
-    suffix: "px",
-  }
+  return [
+    {
+      key: "heapGap",
+      label: "Heap gap",
+      value: controls.heapGap,
+      min: 4,
+      max: 34,
+      onChange: update("heapGap"),
+      suffix: "px",
+    },
+  ]
 }
 
 function extractObservedDatum(obs) {
@@ -370,13 +433,15 @@ export default function GoFishLayoutsPage() {
     treemapPadding: 2,
     heapGap: 18,
     cupWidth: 0.92,
+    ...bobaVolumeDefaults,
   })
   const irDoc = useMemo(() => applyControlsToIR(active, controls), [active, controls])
   const adapterCfg = useMemo(() => unstable_fromGofishIR(irDoc), [irDoc])
   const demo = useMemo(() => getDemo(active, controls, adapterCfg), [active, controls, adapterCfg])
   const irText = useMemo(() => irForDisplay(irDoc), [irDoc])
-  const control = getControl(active, controls, setControls)
+  const controlList = getControls(active, controls, setControls)
   const seedData = demo.data
+  const lastCupName = seedData?.[seedData.length - 1]?.name
 
   // Staleness is a streaming feature: only arm it while the demo is actively
   // auto-streaming, so a static gallery view never dims to "stale" on idle (and
@@ -426,6 +491,37 @@ export default function GoFishLayoutsPage() {
     const timer = window.setInterval(pushOne, 1100)
     return () => window.clearInterval(timer)
   }, [active, pushOne, streaming])
+
+  // Boba: apply the volume sliders to the last cup in place. The ordinal layout
+  // re-runs the `bobaGeometry` derive over the live buffer on every solve, so
+  // mutating the cup's raw volumes via the ref re-renders its tea fill, pearl
+  // bed, and ice with the chart's normal transition — no full clear/re-push,
+  // which would flash every cup. Runs after the reset effect above on a demo
+  // switch (effects fire in order), so the cup exists before we update it.
+  useEffect(() => {
+    if (active !== "boba" || !lastCupName) return
+    chartRef.current?.update?.(lastCupName, (d) => ({
+      ...d,
+      teaVolume: controls.bobaTeaVolume,
+      bobaVolume: controls.bobaBobaVolume,
+      iceVolume: controls.bobaIceVolume,
+    }))
+  }, [
+    active,
+    lastCupName,
+    controls.bobaTeaVolume,
+    controls.bobaBobaVolume,
+    controls.bobaIceVolume,
+  ])
+
+  // Reset re-seeds the original menu and, for boba, returns the volume sliders
+  // to the cup's original volumes so the controls and chart stay in sync.
+  const handleReset = useCallback(() => {
+    resetPushData()
+    if (active === "boba") {
+      setControls((prev) => ({ ...prev, ...bobaVolumeDefaults }))
+    }
+  }, [resetPushData, active])
 
   return (
     <PageLayout
@@ -605,19 +701,25 @@ export default function GoFishLayoutsPage() {
             }}
           >
             <h3 style={{ marginTop: 0 }}>Controls</h3>
-            <label style={{ display: "block", fontSize: 13, fontWeight: 700, marginBottom: 8 }}>
-              {control.label}: {control.value}
-              {control.suffix}
-            </label>
-            <input
-              type="range"
-              min={control.min}
-              max={control.max}
-              step={control.step ?? 1}
-              value={control.value}
-              onChange={control.onChange}
-              style={{ width: "100%" }}
-            />
+            {controlList.map((control) => (
+              <div key={control.key} style={{ marginBottom: 12 }}>
+                <label
+                  style={{ display: "block", fontSize: 13, fontWeight: 700, marginBottom: 8 }}
+                >
+                  {control.label}: {control.value}
+                  {control.suffix}
+                </label>
+                <input
+                  type="range"
+                  min={control.min}
+                  max={control.max}
+                  step={control.step ?? 1}
+                  value={control.value}
+                  onChange={control.onChange}
+                  style={{ width: "100%" }}
+                />
+              </div>
+            ))}
             {active === "python" ? (
               <p style={{ marginTop: 12 }}>
                 Pointer edges are rendered by <code>NetworkCustomChart</code> with particles
@@ -645,7 +747,7 @@ export default function GoFishLayoutsPage() {
                 >
                   {streaming ? "Stop stream" : "Auto stream"}
                 </button>
-                <button type="button" style={smallButtonStyle} onClick={resetPushData}>
+                <button type="button" style={smallButtonStyle} onClick={handleReset}>
                   Reset
                 </button>
                 <span

--- a/src/components/ai/suggestCharts.test.ts
+++ b/src/components/ai/suggestCharts.test.ts
@@ -60,6 +60,30 @@ describe("suggestCharts", () => {
     expect(suggestions[0].props.valueAccessor).toBe("units")
   })
 
+  it("caveats BarChart when its category axis is really time bins", () => {
+    // String month labels profile as plain categories (no real date field),
+    // so BarChart fits and ranks — but it is acting as a temporal histogram.
+    const monthlyBins = [
+      { month: "Jan", count: 12 },
+      { month: "Feb", count: 18 },
+      { month: "Mar", count: 9 },
+      { month: "Apr", count: 22 },
+      { month: "May", count: 15 },
+      { month: "Jun", count: 27 },
+    ]
+    const suggestions = suggestCharts(monthlyBins, { intent: "compare-categories", includeVariants: false })
+    const bar = suggestions.find((s) => s.component === "BarChart")
+    expect(bar).toBeDefined()
+    expect(bar!.caveats.some((c) => /time bin|temporal/i.test(c))).toBe(true)
+  })
+
+  it("does not caveat BarChart for ordinary (non-temporal) categories", () => {
+    const suggestions = suggestCharts(categorical, { intent: "rank", includeVariants: false })
+    const bar = suggestions.find((s) => s.component === "BarChart")
+    expect(bar).toBeDefined()
+    expect(bar!.caveats.some((c) => /time bin|temporal/i.test(c))).toBe(false)
+  })
+
   it("ranks Histogram highly for distribution intent", () => {
     const suggestions = suggestCharts(distributionData, { intent: "distribution", includeVariants: false })
     expect(suggestions[0].component).toBe("Histogram")

--- a/src/components/charts/network/ForceDirectedGraph.test.tsx
+++ b/src/components/charts/network/ForceDirectedGraph.test.tsx
@@ -198,6 +198,36 @@ describe("ForceDirectedGraph", () => {
     expect(style.opacity).toBe(0.6)
   })
 
+  it("edgeStyle reads width from a string field on the wrapped edge data", () => {
+    render(
+      <TooltipProvider>
+        <ForceDirectedGraph nodes={sampleNodes} edges={sampleEdges} edgeWidth="weight" />
+      </TooltipProvider>
+    )
+
+    const styleFn = lastNetworkFrameProps.edgeStyle
+    // Frame callbacks receive a RealtimeEdge wrapper; user data is on .data
+    expect(styleFn({ data: { source: "A", target: "B", weight: 5 } }).strokeWidth).toBe(5)
+    // Missing / non-positive weight falls back to 1
+    expect(styleFn({ data: { source: "A", target: "B" } }).strokeWidth).toBe(1)
+    expect(styleFn({ data: { source: "A", target: "B", weight: 0 } }).strokeWidth).toBe(1)
+  })
+
+  it("edgeStyle reads width from a function accessor against raw edge data", () => {
+    render(
+      <TooltipProvider>
+        <ForceDirectedGraph
+          nodes={sampleNodes}
+          edges={sampleEdges}
+          edgeWidth={(e: { weight?: number }) => (e.weight ?? 1) * 2}
+        />
+      </TooltipProvider>
+    )
+
+    const styleFn = lastNetworkFrameProps.edgeStyle
+    expect(styleFn({ data: { source: "A", target: "B", weight: 3 } }).strokeWidth).toBe(6)
+  })
+
   it("applies custom width and height", () => {
     render(
       <TooltipProvider>

--- a/src/components/charts/network/ForceDirectedGraph.test.tsx
+++ b/src/components/charts/network/ForceDirectedGraph.test.tsx
@@ -199,9 +199,14 @@ describe("ForceDirectedGraph", () => {
   })
 
   it("edgeStyle reads width from a string field on the wrapped edge data", () => {
+    const weightedEdges = [
+      { source: "A", target: "B", weight: 5 },
+      { source: "B", target: "C", weight: 2 },
+      { source: "C", target: "A", weight: 1 }
+    ]
     render(
       <TooltipProvider>
-        <ForceDirectedGraph nodes={sampleNodes} edges={sampleEdges} edgeWidth="weight" />
+        <ForceDirectedGraph nodes={sampleNodes} edges={weightedEdges} edgeWidth="weight" />
       </TooltipProvider>
     )
 

--- a/src/components/charts/network/ForceDirectedGraph.tsx
+++ b/src/components/charts/network/ForceDirectedGraph.tsx
@@ -295,13 +295,29 @@ export const ForceDirectedGraph = forwardRef(function ForceDirectedGraph<TNode e
     [baseNodeStyle, stroke, strokeWidth, opacity]
   )
 
-  // Edge style function
+  // Edge style function — d is a RealtimeEdge wrapper; user data lives on
+  // d.data (mirrors baseNodeStyle's `d.data || d`). A field/function
+  // accessor must resolve against the raw edge, not the wrapper, or the
+  // weight is never read and edge width silently falls back to 1.
   const baseEdgeStyle = useMemo(() => {
-    return (d: Datum) => ({
-      stroke: edgeColor,
-      strokeWidth: typeof edgeWidth === "number" ? edgeWidth : typeof edgeWidth === "function" ? edgeWidth(d) : d[edgeWidth] || 1,
-      opacity: edgeOpacity
-    })
+    return (d: Datum) => {
+      const edge = d.data || d
+      let resolvedWidth: number
+      if (typeof edgeWidth === "number") {
+        resolvedWidth = edgeWidth
+      } else if (typeof edgeWidth === "function") {
+        resolvedWidth = edgeWidth(edge)
+      } else {
+        const raw = edge[edgeWidth]
+        const n = typeof raw === "number" ? raw : Number(raw)
+        resolvedWidth = Number.isFinite(n) && n > 0 ? n : 1
+      }
+      return {
+        stroke: edgeColor,
+        strokeWidth: resolvedWidth,
+        opacity: edgeOpacity
+      }
+    }
   }, [edgeWidth, edgeColor, edgeOpacity])
 
   // Top-level primitive props also apply to edges (stroke color, width, opacity).

--- a/src/components/charts/ordinal/BarChart.capability.ts
+++ b/src/components/charts/ordinal/BarChart.capability.ts
@@ -1,8 +1,11 @@
 import type { ChartCapability, ChartDataProfile } from "../../ai/chartCapabilityTypes"
 import { scaleHints } from "../../ai/dataScaleProfile"
 
-// Field names that signal the category axis is really a time bin.
-const TEMPORAL_NAME = /(date|time|timestamp|month|week|day|year|quarter|qtr|hour|minute)/i
+// Field names that signal the category axis is really a time bin. Matched at
+// token boundaries (not substrings) so ordinary words that merely contain a
+// temporal token — "candidate" (date), "holiday"/"payday" (day), "runtime"
+// (time), "yearly"/"monthly" (year/month + suffix) — don't false-positive.
+const TEMPORAL_NAME = /(^|[^a-z])(date|time|timestamp|month|week|day|year|quarter|qtr|hour|minute)(?=[^a-z]|$)/i
 // Month / weekday names (full + common abbreviations).
 const MONTH_OR_WEEKDAY = /^(jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec|january|february|march|april|june|july|august|september|october|november|december|mon|tue|wed|thu|fri|sat|sun|monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/i
 // Period-style bin labels: ISO date / year-month, "2026", "Q3", "Week 12".
@@ -21,7 +24,10 @@ const PERIOD_LABEL = /^(\d{4}(-\d{1,2}(-\d{1,2})?)?|q[1-4]|week\s*\d+|wk\s*\d+|\
 function looksTemporalCategory(profile: ChartDataProfile): boolean {
   const field = profile.primary.category
   if (!field) return false
-  if (TEMPORAL_NAME.test(field)) return true
+  // Split camelCase ("saleMonth" → "sale Month") so the boundary regex sees the
+  // temporal token as its own word.
+  const tokenizedField = field.replace(/([a-z])([A-Z])/g, "$1 $2")
+  if (TEMPORAL_NAME.test(tokenizedField)) return true
 
   const rows = profile.data
   if (!rows || rows.length === 0) return false

--- a/src/components/charts/ordinal/BarChart.capability.ts
+++ b/src/components/charts/ordinal/BarChart.capability.ts
@@ -1,5 +1,41 @@
-import type { ChartCapability } from "../../ai/chartCapabilityTypes"
+import type { ChartCapability, ChartDataProfile } from "../../ai/chartCapabilityTypes"
 import { scaleHints } from "../../ai/dataScaleProfile"
+
+// Field names that signal the category axis is really a time bin.
+const TEMPORAL_NAME = /(date|time|timestamp|month|week|day|year|quarter|qtr|hour|minute)/i
+// Month / weekday names (full + common abbreviations).
+const MONTH_OR_WEEKDAY = /^(jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec|january|february|march|april|june|july|august|september|october|november|december|mon|tue|wed|thu|fri|sat|sun|monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/i
+// Period-style bin labels: ISO date / year-month, "2026", "Q3", "Week 12".
+const PERIOD_LABEL = /^(\d{4}(-\d{1,2}(-\d{1,2})?)?|q[1-4]|week\s*\d+|wk\s*\d+|\d{1,2}:\d{2})$/i
+
+/**
+ * Heuristic: does BarChart's category axis actually hold ordered time bins?
+ * The data profiler classes string labels like "Jan" or "2026-01" as plain
+ * categories (date *typing* only happens for real Date/parsable values, which
+ * would be picked as an x-axis and reject BarChart outright). So a bar chart
+ * over string time bins — the temporal-histogram case — is invisible to the
+ * profiler. Detect it from the field name or the shape of the labels so we can
+ * surface an honest caveat. Conservative on values (needs a majority match) to
+ * avoid false positives on ordinary categories.
+ */
+function looksTemporalCategory(profile: ChartDataProfile): boolean {
+  const field = profile.primary.category
+  if (!field) return false
+  if (TEMPORAL_NAME.test(field)) return true
+
+  const rows = profile.data
+  if (!rows || rows.length === 0) return false
+  let matches = 0
+  let seen = 0
+  for (const row of rows) {
+    const raw = (row as Record<string, unknown>)[field]
+    if (raw == null) continue
+    seen++
+    const label = String(raw).trim()
+    if (MONTH_OR_WEEKDAY.test(label) || PERIOD_LABEL.test(label)) matches++
+  }
+  return seen > 0 && matches / seen >= 0.6
+}
 
 export const BarChartCapability: ChartCapability = {
   component: "BarChart",
@@ -35,6 +71,16 @@ export const BarChartCapability: ChartCapability = {
     "rank": 5,
     "part-to-whole": (p) => ((p.categoryCount ?? 0) <= 8 ? 3 : 2),
     "distribution": 1,
+  },
+
+  caveats: (profile) => {
+    const out: string[] = []
+    if (looksTemporalCategory(profile)) {
+      out.push(
+        "category axis looks like time bins — for a time series, supply real dates and use LineChart/AreaChart (reads trend, scales the time axis); for streaming counts use a temporal histogram"
+      )
+    }
+    return out
   },
 
   variants: [

--- a/src/components/server/integration.test.tsx
+++ b/src/components/server/integration.test.tsx
@@ -94,6 +94,22 @@ describe("SVG generation (end-to-end)", () => {
     }
   })
 
+  it("ForceDirectedGraph honors edgeWidth field for edge stroke widths", () => {
+    const svg = renderChart("ForceDirectedGraph", {
+      nodes: [{ id: "X" }, { id: "Y" }, { id: "Z" }],
+      edges: [
+        { source: "X", target: "Y", weight: 8 },
+        { source: "Y", target: "Z", weight: 2 },
+      ],
+      edgeWidth: "weight",
+      width: 300, height: 200,
+    })
+    expect(isValidSVG(svg)).toBe(true)
+    // Each weight maps directly to a stroke width on the edge line.
+    expect(svg).toMatch(/stroke-width="8(?:[^0-9]|$)/)
+    expect(svg).toMatch(/stroke-width="2(?:[^0-9]|$)/)
+  })
+
   it("renderToStaticSVG dispatches correctly for all frame types", () => {
     const xy = renderToStaticSVG("xy", { chartType: "line", data: lineData, xAccessor: "x", yAccessor: "y", size: [300, 200] } as StaticFrameProps)
     const ordinal = renderToStaticSVG("ordinal", { chartType: "bar", data: barData, oAccessor: "category", rAccessor: "value", size: [300, 200] } as StaticFrameProps)

--- a/src/components/server/serverChartConfigs.ts
+++ b/src/components/server/serverChartConfigs.ts
@@ -655,25 +655,58 @@ const gaugeChart: ChartConfig = {
 
 const forceDirectedGraph: ChartConfig = {
   frameType: "network",
-  buildProps: (data, colorBy, colorScheme, common, rest) => ({
-    chartType: "force",
-    nodes: rest.nodes,
-    edges: rest.edges,
-    nodeIDAccessor: rest.nodeIDAccessor,
-    sourceAccessor: rest.sourceAccessor,
-    targetAccessor: rest.targetAccessor,
-    colorBy,
-    colorScheme,
-    iterations: rest.iterations,
-    forceStrength: rest.forceStrength,
-    showLabels: rest.showLabels,
-    nodeLabel: rest.nodeLabel,
-    nodeSize: rest.nodeSize,
-    nodeSizeRange: rest.nodeSizeRange,
-    nodeStyle: rest.nodeStyle,
-    edgeStyle: rest.edgeStyle,
-    ...common,
-  }),
+  buildProps: (data, colorBy, colorScheme, common, rest) => {
+    // Mirror the HOC's edgeWidth/edgeColor/edgeOpacity handling so that
+    // `renderChart("ForceDirectedGraph", { edgeWidth: "weight" })` honors
+    // edge weight in SSR. An explicit edgeStyle wins; otherwise synthesize
+    // one when any edge primitive prop is set. The edge callback receives a
+    // RealtimeEdge wrapper (user data on .data) — read field/function
+    // accessors against the raw edge, matching the HOC.
+    const { edgeWidth, edgeColor, edgeOpacity } = rest
+    const hasEdgePrimitives =
+      edgeWidth !== undefined || edgeColor !== undefined || edgeOpacity !== undefined
+    const edgeStyle =
+      rest.edgeStyle ??
+      (hasEdgePrimitives
+        ? (d: Datum) => {
+            const edge = (d?.data as Datum) || d
+            let strokeWidth = 1
+            if (typeof edgeWidth === "number") {
+              strokeWidth = edgeWidth
+            } else if (typeof edgeWidth === "function") {
+              strokeWidth = edgeWidth(edge)
+            } else if (typeof edgeWidth === "string") {
+              const raw = edge?.[edgeWidth]
+              const n = typeof raw === "number" ? raw : Number(raw)
+              strokeWidth = Number.isFinite(n) && n > 0 ? n : 1
+            }
+            return {
+              stroke: edgeColor ?? "#999",
+              strokeWidth,
+              opacity: edgeOpacity ?? 0.6,
+            }
+          }
+        : undefined)
+    return {
+      chartType: "force",
+      nodes: rest.nodes,
+      edges: rest.edges,
+      nodeIDAccessor: rest.nodeIDAccessor,
+      sourceAccessor: rest.sourceAccessor,
+      targetAccessor: rest.targetAccessor,
+      colorBy,
+      colorScheme,
+      iterations: rest.iterations,
+      forceStrength: rest.forceStrength,
+      showLabels: rest.showLabels,
+      nodeLabel: rest.nodeLabel,
+      nodeSize: rest.nodeSize,
+      nodeSizeRange: rest.nodeSizeRange,
+      nodeStyle: rest.nodeStyle,
+      edgeStyle,
+      ...common,
+    }
+  },
 }
 
 // ProcessSankey is unique among network HOCs in that it doesn't use a

--- a/src/components/server/serverChartConfigs.ts
+++ b/src/components/server/serverChartConfigs.ts
@@ -691,7 +691,9 @@ const forceDirectedGraph: ChartConfig = {
       chartType: "force",
       nodes: rest.nodes,
       edges: rest.edges,
-      nodeIDAccessor: rest.nodeIDAccessor,
+      // Accept the canonical `nodeIdAccessor` (and the legacy `nodeIDAccessor`
+      // alias), matching the HOC and the other network SSR configs.
+      nodeIDAccessor: rest.nodeIdAccessor || rest.nodeIDAccessor,
       sourceAccessor: rest.sourceAccessor,
       targetAccessor: rest.targetAccessor,
       colorBy,

--- a/src/components/stream/OrdinalSVGOverlay.tsx
+++ b/src/components/stream/OrdinalSVGOverlay.tsx
@@ -230,15 +230,47 @@ export function OrdinalSVGOverlay(props: OrdinalSVGOverlayProps) {
   const isHorizontal = scales?.projection === "horizontal"
   const showCategoryTicks = showCategoryTicksProp !== false
 
-  // Category labels (band scale)
+  // Category labels (band scale). When many categories crowd the axis —
+  // the classic temporal-histogram / many-bin case — drawing every label
+  // produces an unreadable overlapping smear. Thin to evenly-spaced labels
+  // (every Nth) so the remaining set never collides. The thinning is a
+  // no-op when labels already fit (step === 1), so charts with few
+  // categories render byte-identically.
   const categoryTicks = useMemo(() => {
     if (!showAxes || !showCategoryTicks || !scales || isRadial) return []
-    return scales.o.domain().map((cat, index) => ({
+    const band = scales.o.bandwidth()
+    const all = scales.o.domain().map((cat, index) => ({
       value: cat,
-      pixel: (scales.o(cat) ?? 0) + scales.o.bandwidth() / 2,
+      pixel: (scales.o(cat) ?? 0) + band / 2,
       label: oFormat ? oFormat(cat, index) : cat
     }))
-  }, [showAxes, showCategoryTicks, scales, oFormat, isRadial])
+    if (all.length <= 2) return all
+
+    // Uniform spacing between adjacent category centers (band scale).
+    const spacing = Math.abs(all[1].pixel - all[0].pixel) || band
+    // Pixel footprint each label needs along the axis. Vertical bars lay
+    // horizontal labels along the bottom (footprint = text width); horizontal
+    // bars stack labels down the left axis (footprint = line height).
+    let needed: number
+    if (isHorizontal) {
+      needed = 16 // line height + breathing room
+    } else {
+      let maxChars = 0
+      let hasNodeLabel = false
+      for (const t of all) {
+        if (typeof t.label === "string") maxChars = Math.max(maxChars, t.label.length)
+        else if (typeof t.label === "number") maxChars = Math.max(maxChars, String(t.label).length)
+        else hasNodeLabel = true
+      }
+      // 6.5 px/char mirrors the heuristic in SVGOverlay; ReactNode labels
+      // can't be measured, so assume the 60px foreignObject width.
+      needed = Math.max(maxChars * 6.5, hasNodeLabel ? 60 : 0) + 6
+    }
+
+    const step = Math.max(1, Math.ceil(needed / spacing))
+    if (step === 1) return all
+    return all.filter((_, i) => i % step === 0)
+  }, [showAxes, showCategoryTicks, scales, oFormat, isRadial, isHorizontal])
 
   // Value ticks (linear scale) — custom rTickValues override d3 ticks
   const rTickValues = props.rTickValues

--- a/src/components/stream/OrdinalSVGOverlay.tsx
+++ b/src/components/stream/OrdinalSVGOverlay.tsx
@@ -248,20 +248,24 @@ export function OrdinalSVGOverlay(props: OrdinalSVGOverlayProps) {
 
     // Uniform spacing between adjacent category centers (band scale).
     const spacing = Math.abs(all[1].pixel - all[0].pixel) || band
+    // Measure the labels: longest string (in chars) and whether any are
+    // ReactNodes (rendered in a 60×24 foreignObject — unmeasurable text).
+    let maxChars = 0
+    let hasNodeLabel = false
+    for (const t of all) {
+      if (typeof t.label === "string") maxChars = Math.max(maxChars, t.label.length)
+      else if (typeof t.label === "number") maxChars = Math.max(maxChars, String(t.label).length)
+      else hasNodeLabel = true
+    }
     // Pixel footprint each label needs along the axis. Vertical bars lay
     // horizontal labels along the bottom (footprint = text width); horizontal
-    // bars stack labels down the left axis (footprint = line height).
+    // bars stack labels down the left axis (footprint = line height — and
+    // ReactNode labels render in a 24px-tall foreignObject, so reserve that
+    // much so the "never collides" guarantee holds for them too).
     let needed: number
     if (isHorizontal) {
-      needed = 16 // line height + breathing room
+      needed = hasNodeLabel ? 24 : 16
     } else {
-      let maxChars = 0
-      let hasNodeLabel = false
-      for (const t of all) {
-        if (typeof t.label === "string") maxChars = Math.max(maxChars, t.label.length)
-        else if (typeof t.label === "number") maxChars = Math.max(maxChars, String(t.label).length)
-        else hasNodeLabel = true
-      }
       // 6.5 px/char mirrors the heuristic in SVGOverlay; ReactNode labels
       // can't be measured, so assume the 60px foreignObject width.
       needed = Math.max(maxChars * 6.5, hasNodeLabel ? 60 : 0) + 6

--- a/src/components/stream/PipelineStore.customLayout.test.ts
+++ b/src/components/stream/PipelineStore.customLayout.test.ts
@@ -67,6 +67,55 @@ describe("PipelineStore customLayout integration", () => {
     expect(store.customLayoutOverlays).toBe(sentinel)
   })
 
+  it("re-runs the layout (regenerating overlays) on a dimension-only change", () => {
+    // Regression: a dimension-only change must NOT take computeScene's fast
+    // remap path for custom layouts. remapScene only proportionally rescales
+    // scene nodes and never regenerates customLayoutOverlays, so the overlay
+    // glyphs would freeze at the previous width while the canvas scene nodes
+    // moved — the "flowers offset from their stems until any other change"
+    // bug on the GoFish flower demo (responsive resize).
+    let invocations = 0
+    const layout = (ctx: LayoutContext) => {
+      invocations++
+      const w = ctx.dimensions.plot.width
+      const node: RectSceneNode = {
+        type: "rect",
+        // A fixed pixel offset that a proportional remap would get wrong.
+        x: w - 24,
+        y: 0,
+        w: 4,
+        h: 10,
+        style: { fill: "#0f0" },
+        datum: { tag: "stem" },
+      }
+      // Overlay encodes the width it was solved at so we can detect staleness.
+      return { nodes: [node], overlays: { _solvedWidth: w } as unknown as React.ReactNode }
+    }
+    const store = new PipelineStore({
+      chartType: "custom",
+      windowSize: 100,
+      windowMode: "sliding",
+      arrowOfTime: "right",
+      extentPadding: 0,
+      xAccessor: "x",
+      yAccessor: "y",
+      customLayout: layout,
+    })
+    store.ingest({ inserts: [{ x: 1, y: 1 }], bounded: true })
+
+    store.computeScene({ width: 200, height: 100 })
+    expect(invocations).toBe(1)
+    expect((store.customLayoutOverlays as { _solvedWidth: number })._solvedWidth).toBe(200)
+    expect((store.scene[0] as RectSceneNode).x).toBe(200 - 24)
+
+    // Dimension-only change: the layout must run again at the new width.
+    store.computeScene({ width: 400, height: 100 })
+    expect(invocations).toBe(2)
+    expect((store.customLayoutOverlays as { _solvedWidth: number })._solvedWidth).toBe(400)
+    // Scene node honors the fixed offset at the new width — not a 2× remap.
+    expect((store.scene[0] as RectSceneNode).x).toBe(400 - 24)
+  })
+
   it("warns when customLayout returns overlays without scene nodes", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
     const sentinel = { _sentinel: true } as unknown as React.ReactNode

--- a/src/components/stream/PipelineStore.customLayout.test.ts
+++ b/src/components/stream/PipelineStore.customLayout.test.ts
@@ -105,13 +105,13 @@ describe("PipelineStore customLayout integration", () => {
 
     store.computeScene({ width: 200, height: 100 })
     expect(invocations).toBe(1)
-    expect((store.customLayoutOverlays as { _solvedWidth: number })._solvedWidth).toBe(200)
+    expect((store.customLayoutOverlays as unknown as { _solvedWidth: number })._solvedWidth).toBe(200)
     expect((store.scene[0] as RectSceneNode).x).toBe(200 - 24)
 
     // Dimension-only change: the layout must run again at the new width.
     store.computeScene({ width: 400, height: 100 })
     expect(invocations).toBe(2)
-    expect((store.customLayoutOverlays as { _solvedWidth: number })._solvedWidth).toBe(400)
+    expect((store.customLayoutOverlays as unknown as { _solvedWidth: number })._solvedWidth).toBe(400)
     // Scene node honors the fixed offset at the new width — not a 2× remap.
     expect((store.scene[0] as RectSceneNode).x).toBe(400 - 24)
   })

--- a/src/components/stream/PipelineStore.ts
+++ b/src/components/stream/PipelineStore.ts
@@ -668,8 +668,20 @@ export class PipelineStore {
 
     // Fast path: if only layout dimensions changed (no data or config change),
     // remap existing scene node coordinates instead of rebuilding from scratch.
+    //
+    // Excluded for custom layouts: a custom layout positions both scene nodes
+    // AND overlays with arbitrary geometry (fixed pixel offsets, non-linear
+    // padding floors, glyph chrome), so a *proportional* coordinate remap is
+    // not equivalent to re-running the layout — and crucially `remapScene`
+    // never regenerates `customLayoutOverlays`, so the overlay glyphs would
+    // stay at the previous dimensions while the canvas scene nodes move,
+    // drifting the two apart on a responsive resize (the classic "flowers
+    // offset from their stems until any other change forces a rebuild" bug).
+    // Re-running the layout on a dimension change is the correct behavior for
+    // these and the per-resize cost is acceptable.
     if (
       !this.needsFullRebuild &&
+      !config.customLayout &&
       this.lastLayout &&
       this.scene.length > 0 &&
       this.scales &&

--- a/src/components/stream/StreamOrdinalFrame.test.tsx
+++ b/src/components/stream/StreamOrdinalFrame.test.tsx
@@ -595,6 +595,53 @@ describe("StreamOrdinalFrame", () => {
       expect(svgs.length).toBeGreaterThan(0)
     })
 
+    it("thins crowded category labels so they do not overlap", () => {
+      // 40 bins in a 400px-wide chart — the temporal-histogram case. Drawing
+      // every label overlaps; the axis should thin to a readable subset.
+      const data = Array.from({ length: 40 }, (_, i) => ({
+        category: `2026-${String(i + 1).padStart(2, "0")}`,
+        value: (i % 7) + 1,
+      }))
+      const { container } = render(
+        <StreamOrdinalFrame
+          chartType="bar"
+          data={data}
+          oAccessor="category"
+          rAccessor="value"
+          size={[400, 300]}
+          showAxes={true}
+        />
+      )
+      // Vertical bars put categories on the bottom axis.
+      const catTicks = container.querySelectorAll(
+        ".semiotic-axis-bottom .semiotic-axis-tick"
+      )
+      expect(catTicks.length).toBeGreaterThan(0)
+      expect(catTicks.length).toBeLessThan(data.length)
+    })
+
+    it("keeps every label when categories are few enough to fit", () => {
+      const data = [
+        { category: "A", value: 10 },
+        { category: "B", value: 20 },
+        { category: "C", value: 15 },
+      ]
+      const { container } = render(
+        <StreamOrdinalFrame
+          chartType="bar"
+          data={data}
+          oAccessor="category"
+          rAccessor="value"
+          size={[600, 300]}
+          showAxes={true}
+        />
+      )
+      const catTicks = container.querySelectorAll(
+        ".semiotic-axis-bottom .semiotic-axis-tick"
+      )
+      expect(catTicks.length).toBe(data.length)
+    })
+
     it("renders title in SVG overlay when title is a string", () => {
       const data = [{ category: "A", value: 10 }]
       const { container } = render(


### PR DESCRIPTION
Fix ForceDirectedGraph edgeWidth accessor to resolve against raw edge data (HOC + SSR renderChart path); add tests and server-side handling so edge weights drive stroke widths. Prevent crowded ordinal category labels from overlapping by thinning to an evenly-spaced subset when needed; add tests. Make PipelineStore re-run custom layouts on dimension-only changes so SVG overlays stay aligned with scene nodes; add tests. Enhance GoFish demo controls: expose multiple sliders (boba cup volumes edit the last cup in-place) and reset behavior. Add BarChart heuristic/caveat for temporal-like category axes and update CHANGELOG.

This pull request introduces several bug fixes and feature improvements, primarily focused on chart rendering accuracy and interactivity, as well as enhancements to the BarChart and ForceDirectedGraph components. The most significant changes include ensuring that edge widths in `ForceDirectedGraph` correctly honor data-driven values, improving category axis label handling in bar charts, and adding interactive controls to the GoFish boba demo.

### Chart Rendering and Data Handling Improvements

* **ForceDirectedGraph edge width now honors a weight field:** The `edgeWidth` accessor (string or function) is now correctly resolved against the raw edge data rather than the wrapper, ensuring edge widths reflect data values in both the interactive component and server-side rendering. Corresponding tests and SSR logic have been updated for parity. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R37) [[2]](diffhunk://#diff-e14e456257ba2c1886dff3d6b4342129d6f9f6990e7042e02e2bcf2c01416dabR201-R230) [[3]](diffhunk://#diff-352df5d3513c1a66c08cc4f267c79c03daa5fba9405142af633c6a0069c24d17L298-R320) [[4]](diffhunk://#diff-05a67eb15b462252702584f18726d7834d1b0bbd812d8b59c2b56159918cae5aR97-R112) [[5]](diffhunk://#diff-91769abee4e97bbc7334467e54d6754cc975da50a0ebae94f7770cefc79e9e9cL658-R690)
* **Crowded bar-chart category labels no longer overlap:** Ordinal category axes now automatically thin tick labels when too many bins crowd the axis, improving readability for charts with many categories.

### BarChart Category Axis Enhancements

* **BarChart suggestion caveat for temporal categories:** The BarChart capability now detects when its category axis holds time-bin labels (such as months or weeks) and surfaces a caveat suggesting a time-aware chart (e.g., LineChart or temporal histogram). This includes new heuristics and tests to avoid false positives on ordinary categories. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R37) [[2]](diffhunk://#diff-8451488d3ad96b2eccb3e0c0f6567988d45fa2765ff13f074e64cc16c14d1f41L1-R39) [[3]](diffhunk://#diff-8451488d3ad96b2eccb3e0c0f6567988d45fa2765ff13f074e64cc16c14d1f41R76-R85) [[4]](diffhunk://#diff-2be65b2629ebee4f8283782e646b6ec7dc2a03a8de5c8c85364d428c415797ccR63-R86)

### GoFish Demo Interactivity

* **Interactive sliders for boba cup volumes:** The GoFishLayoutsPage demo now features sliders that allow users to adjust the tea, boba, and ice volumes of the last cup in the menu. These controls are synchronized with the underlying data and chart rendering, ensuring real-time updates and consistent state on reset. [[1]](diffhunk://#diff-ad7cec5e3848ec58aca4dadafa1191ac277d4f64e5b2ffeeb7495436b3e9d752R46-R57) [[2]](diffhunk://#diff-ad7cec5e3848ec58aca4dadafa1191ac277d4f64e5b2ffeeb7495436b3e9d752L203-R215) [[3]](diffhunk://#diff-ad7cec5e3848ec58aca4dadafa1191ac277d4f64e5b2ffeeb7495436b3e9d752L228-R353) [[4]](diffhunk://#diff-ad7cec5e3848ec58aca4dadafa1191ac277d4f64e5b2ffeeb7495436b3e9d752R436-R444) [[5]](diffhunk://#diff-ad7cec5e3848ec58aca4dadafa1191ac277d4f64e5b2ffeeb7495436b3e9d752R495-R525) [[6]](diffhunk://#diff-ad7cec5e3848ec58aca4dadafa1191ac277d4f64e5b2ffeeb7495436b3e9d752L608-R708) [[7]](diffhunk://#diff-ad7cec5e3848ec58aca4dadafa1191ac277d4f64e5b2ffeeb7495436b3e9d752R721-R722) [[8]](diffhunk://#diff-ad7cec5e3848ec58aca4dadafa1191ac277d4f64e5b2ffeeb7495436b3e9d752L648-R750)

### Bug Fixes

* **Custom-layout overlays no longer drift on the first responsive resize:** Ensures overlays and scene nodes remain aligned during dimension-only changes in custom XY layouts.