### PR TITLE
Seed selection resolution, add streamStoreSync

### DIFF
--- a/src/components/LinkedCharts.test.tsx
+++ b/src/components/LinkedCharts.test.tsx
@@ -85,6 +85,29 @@ describe("LinkedCharts", () => {
     expect(container.textContent).toContain("Charts")
   })
 
+  it("seeds the configured resolution mode at construction", () => {
+    // Proves the resolution is actually applied (not just accepted): in
+    // crossfilter mode a client's own clause is excluded from its own
+    // predicate, so with no other clauses it matches everything — including a
+    // row its own clause would otherwise filter out. Under the default "union"
+    // mode this would be false, so this distinguishes a live seed from a no-op.
+    let predicate: (d: Datum) => boolean = () => true
+    function CrossfilterConsumer() {
+      const sel = useSelection({ name: "cf", fields: ["region"], clientId: "chart-1" })
+      predicate = sel.predicate
+      return <button data-testid="select" onClick={() => sel.selectPoints({ region: ["East"] })}>select</button>
+    }
+
+    const { getByTestId } = render(
+      <LinkedCharts selections={{ cf: { resolution: "crossfilter" } }}>
+        <CrossfilterConsumer />
+      </LinkedCharts>
+    )
+
+    act(() => { getByTestId("select").click() })
+    expect(predicate({ region: "West" })).toBe(true)
+  })
+
   it("useLinkedHover produces selections consumed by useSelection", () => {
     let consumerActive = false
 

--- a/src/components/LinkedCharts.test.tsx
+++ b/src/components/LinkedCharts.test.tsx
@@ -85,12 +85,13 @@ describe("LinkedCharts", () => {
     expect(container.textContent).toContain("Charts")
   })
 
-  it("seeds the configured resolution mode at construction", () => {
+  it("applies the configured resolution mode", () => {
     // Proves the resolution is actually applied (not just accepted): in
     // crossfilter mode a client's own clause is excluded from its own
     // predicate, so with no other clauses it matches everything — including a
     // row its own clause would otherwise filter out. Under the default "union"
-    // mode this would be false, so this distinguishes a live seed from a no-op.
+    // mode this would be false, so this distinguishes an applied resolution
+    // from a no-op.
     let predicate: (d: Datum) => boolean = () => true
     function CrossfilterConsumer() {
       const sel = useSelection({ name: "cf", fields: ["region"], clientId: "chart-1" })

--- a/src/components/LinkedCharts.tsx
+++ b/src/components/LinkedCharts.tsx
@@ -136,6 +136,11 @@ export interface LinkedChartsProps {
 
 // ── Interactive unified legend ─────────────────────────────────────────────
 
+// Stable clientIds for the unified legend's own selection clauses. Module
+// scope so they're not reactive inputs to the legend's hooks.
+const ISOLATE_CLIENT = "__linked-legend-isolate__"
+const HIGHLIGHT_CLIENT = "__linked-legend-highlight__"
+
 /**
  * Inner component rendered inside SelectionProvider so it can use selection hooks.
  * Handles highlight (hover) and isolate (click) interactions on the unified legend,
@@ -175,9 +180,6 @@ function LinkedLegend({
   // React state and synced back with an effect. The legend's own swatch
   // emphasis is *derived* from the store below, so there is exactly one
   // place this state lives.
-  const ISOLATE_CLIENT = "__linked-legend-isolate__"
-  const HIGHLIGHT_CLIENT = "__linked-legend-highlight__"
-
   // Isolate mode: click toggles point selections.
   const { selectPoints: selectIsolate, clear: clearIsolate } = useSelection({
     name: selectionName,

--- a/src/components/LinkedCharts.tsx
+++ b/src/components/LinkedCharts.tsx
@@ -2,9 +2,9 @@
 import * as React from "react"
 import { createContext, useContext, useEffect, useId, useLayoutEffect, useMemo, useRef, useState, useCallback } from "react"
 import { SelectionProvider, useSelectionSelector } from "./store/SelectionStore"
-import type { ResolutionMode, SelectionStoreState } from "./store/SelectionStore"
+import type { ResolutionMode, Selection, SelectionStoreState } from "./store/SelectionStore"
 import { ObservationProvider } from "./store/ObservationStore"
-import { useLinkedHover, useSelection } from "./store/useSelection"
+import { useSelection } from "./store/useSelection"
 import { CategoryColorProvider, useCategoryColors } from "./CategoryColors"
 import { DEFAULT_COLORS } from "./charts/shared/colorUtils"
 import Legend from "./Legend"
@@ -134,22 +134,6 @@ export interface LinkedChartsProps {
   legendField?: string
 }
 
-// ── Resolution initializer ─────────────────────────────────────────────────
-
-function ResolutionInit({ selections }: { selections: Record<string, { resolution?: ResolutionMode }> }) {
-  const setResolution = useSelectionSelector((state: SelectionStoreState) => state.setResolution)
-
-  useEffect(() => {
-    for (const [name, config] of Object.entries(selections)) {
-      if (config.resolution) {
-        setResolution(name, config.resolution)
-      }
-    }
-  }, [selections, setResolution])
-
-  return null
-}
-
 // ── Interactive unified legend ─────────────────────────────────────────────
 
 /**
@@ -185,71 +169,80 @@ function LinkedLegend({
     label: ""
   }]
 
-  // Highlight mode: hover produces a linkedHover selection
-  const linkedHoverHook = useLinkedHover({
+  // The selection store is the single source of truth for both the
+  // highlight (hover) and isolate (click) interactions. Each writes its
+  // own clause directly from the event handler; nothing is mirrored into
+  // React state and synced back with an effect. The legend's own swatch
+  // emphasis is *derived* from the store below, so there is exactly one
+  // place this state lives.
+  const ISOLATE_CLIENT = "__linked-legend-isolate__"
+  const HIGHLIGHT_CLIENT = "__linked-legend-highlight__"
+
+  // Isolate mode: click toggles point selections.
+  const { selectPoints: selectIsolate, clear: clearIsolate } = useSelection({
     name: selectionName,
     fields: [field],
+    clientId: ISOLATE_CLIENT,
   })
-
-  // Isolate mode: click toggles point selections
-  const selectionHook = useSelection({
+  // Highlight mode: hover produces a transient point selection.
+  const { selectPoints: selectHighlight, clear: clearHighlight } = useSelection({
     name: selectionName,
     fields: [field],
-    clientId: "__linked-legend-isolate__",
+    clientId: HIGHLIGHT_CLIENT,
   })
 
-  const [isolatedCategories, setIsolatedCategories] = useState<Set<string>>(new Set())
-  const [highlightedCategory, setHighlightedCategory] = useState<string | null>(null)
-
-  // Use refs for store methods to avoid infinite effect loops
-  // (selectPoints/clear change identity when selection state changes)
-  const selectPointsRef = useRef(selectionHook.selectPoints)
-  selectPointsRef.current = selectionHook.selectPoints
-  const clearRef = useRef(selectionHook.clear)
-  clearRef.current = selectionHook.clear
-
-  // Sync isolatedCategories → selection store via effect to avoid setState-during-render
-  useEffect(() => {
-    if (interaction !== "isolate") return
-    if (isolatedCategories.size > 0) {
-      selectPointsRef.current({ [field]: Array.from(isolatedCategories) })
-    } else {
-      clearRef.current()
+  // Read the legend's emphasis straight back from the store rather than
+  // keeping a parallel React-state copy. `selections.get` returns a stable
+  // reference until *this* selection changes, so the subscription only
+  // re-renders the legend on its own updates.
+  const selection = useSelectionSelector(
+    (state: SelectionStoreState) => state.selections.get(selectionName)
+  )
+  const { isolatedCategories, highlightedCategory } = useMemo(() => {
+    const isolated = new Set<string>()
+    let highlighted: string | null = null
+    const isolateField = selection?.clauses.get(ISOLATE_CLIENT)?.fields[field]
+    if (isolateField?.type === "point") {
+      for (const v of isolateField.values) isolated.add(String(v))
     }
-  }, [interaction, isolatedCategories, field])
+    const highlightField = selection?.clauses.get(HIGHLIGHT_CLIENT)?.fields[field]
+    if (highlightField?.type === "point") {
+      const first = highlightField.values.values().next().value
+      if (first != null) highlighted = String(first)
+    }
+    return { isolatedCategories: isolated, highlightedCategory: highlighted }
+  }, [selection, field])
 
   const handleHover = useCallback(
     (item: { label: string } | null) => {
       if (interaction !== "highlight") return
       if (item) {
-        setHighlightedCategory(item.label)
-        linkedHoverHook.onHover({ [field]: item.label })
+        selectHighlight({ [field]: [item.label] })
       } else {
-        setHighlightedCategory(null)
-        linkedHoverHook.onHover(null)
+        clearHighlight()
       }
     },
-    [interaction, field, linkedHoverHook]
+    [interaction, field, selectHighlight, clearHighlight]
   )
 
   const handleClick = useCallback(
     (item: { label: string }) => {
       if (interaction !== "isolate") return
-      setIsolatedCategories(prev => {
-        const next = new Set(prev)
-        if (next.has(item.label)) {
-          next.delete(item.label)
-        } else {
-          next.add(item.label)
-        }
-        // If all categories selected, reset (Carbon behavior)
-        if (next.size === allCategories.length) {
-          return new Set()
-        }
-        return next
-      })
+      const next = new Set(isolatedCategories)
+      if (next.has(item.label)) {
+        next.delete(item.label)
+      } else {
+        next.add(item.label)
+      }
+      // Empty, or all categories selected (Carbon behavior): clear the
+      // isolate clause so every category shows.
+      if (next.size === 0 || next.size === allCategories.length) {
+        clearIsolate()
+      } else {
+        selectIsolate({ [field]: Array.from(next) })
+      }
     },
-    [interaction, allCategories.length]
+    [interaction, field, isolatedCategories, allCategories.length, selectIsolate, clearIsolate]
   )
 
   // Measure the container's actual laid-out width so we can tell <Legend>
@@ -365,6 +358,22 @@ export function LinkedCharts({
   legendSelectionName = "legend",
   legendField = "category",
 }: LinkedChartsProps) {
+  // Seed configured resolution modes at store construction rather than
+  // mirroring them in with a mount effect — the resolution is initial
+  // config, so it belongs in `initialState`, not a synchronize-after-commit
+  // pass. createStore builds the source once with this, then ignores later
+  // identity changes (resolution isn't a runtime-dynamic input).
+  const initialSelectionState = useMemo(() => {
+    if (!selections) return undefined
+    const seeded = new Map<string, Selection>()
+    for (const [name, config] of Object.entries(selections)) {
+      if (config.resolution) {
+        seeded.set(name, { name, resolution: config.resolution, clauses: new Map() })
+      }
+    }
+    return seeded.size > 0 ? { selections: seeded } : undefined
+  }, [selections])
+
   const parentCategoryColors = useCategoryColors()
   const [registeredCategories, setRegisteredCategories] = useState<Record<string, string[]>>({})
   const generatedCategoryColorsRef = useRef<Record<string, string>>({})
@@ -427,9 +436,8 @@ export function LinkedCharts({
   const suppressChildLegends = shouldShowLegend && hasCategories
 
   return (
-    <SelectionProvider>
+    <SelectionProvider initialState={initialSelectionState}>
       <ObservationProvider>
-        {selections && <ResolutionInit selections={selections} />}
         <LinkedCategoryRegistryContext.Provider value={registry}>
           <CategoryColorProvider colors={categoryColors}>
             <LinkedLegendContext.Provider value={suppressChildLegends}>

--- a/src/components/stream/StreamGeoFrame.tsx
+++ b/src/components/stream/StreamGeoFrame.tsx
@@ -25,6 +25,7 @@ import { GeoPipelineStore } from "./GeoPipelineStore"
 import type { GeoPipelineConfig } from "./geoTypes"
 import { findNearestGeoNode } from "./GeoCanvasHitTester"
 import { useFrame } from "./useFrame"
+import { useConfigSync } from "./streamStoreSync"
 import { resolveThemeSemanticColors } from "../store/ThemeStore"
 import { useStalenessCheck } from "./useStalenessCheck"
 import { StalenessBadge } from "./StalenessBadge"
@@ -438,11 +439,7 @@ const StreamGeoFrame = forwardRef<StreamGeoFrameHandle, StreamGeoFrameProps>(
 
     // ── Sync config ───────────────────────────────────────────────────
 
-    useEffect(() => {
-      storeRef.current?.updateConfig(stablePipelineConfig)
-      dirtyRef.current = true
-      scheduleRender()
-    }, [stablePipelineConfig, scheduleRender])
+    useConfigSync(storeRef, stablePipelineConfig, dirtyRef, scheduleRender)
 
     // ── Sync bounded data ─────────────────────────────────────────────
 

--- a/src/components/stream/StreamNetworkFrame.tsx
+++ b/src/components/stream/StreamNetworkFrame.tsx
@@ -26,6 +26,7 @@ import { DEFAULT_TENSION_CONFIG, DEFAULT_PARTICLE_STYLE } from "./networkTypes"
 import { NetworkPipelineStore } from "./NetworkPipelineStore"
 import { composeOverlays } from "./composeOverlays"
 import { wrapWithCustomLayoutSelection } from "./customLayoutSelection"
+import { useConfigSync, useLayoutSelectionSync } from "./streamStoreSync"
 import { findNearestNetworkNode } from "./NetworkCanvasHitTester"
 import {
   extractNetworkNavPoints,
@@ -766,37 +767,15 @@ const StreamNetworkFrame = forwardRef<
   // So no separate React state / per-change setState is needed (and can't
   // compound with a per-frame morph into a "Maximum update depth" storm).
 
-  // Update config when props change. A render-only config change (e.g. the
-  // resolved selection predicate driving dim/highlight) flows through here
-  // too: updateConfig → dirty → render-loop buildScene re-emits the overlays
-  // → setAnnotationFrame re-render reads them.
-  useEffect(() => {
-    storeRef.current?.updateConfig(stablePipelineConfig)
-    dirtyRef.current = true
-    scheduleRender()
-  }, [stablePipelineConfig, scheduleRender])
+  // A render-only config change (e.g. the resolved selection predicate driving
+  // dim/highlight) flows through here too: updateConfig → dirty → render-loop
+  // buildScene re-emits the overlays → setAnnotationFrame re-render reads them.
+  useConfigSync(storeRef, stablePipelineConfig, dirtyRef, scheduleRender)
 
-  // Selection / hover channel for custom layouts — kept OFF the rebuild path.
-  // When the layout supplied `restyle`/`restyleEdge`, a selection change only
-  // re-applies styles to the existing scene + repaints (no relayout, no quadtree
-  // rebuild); otherwise it falls back to the rebuild path so `ctx.selection`
-  // reaches the layout. Either way the overlay subtree re-renders against the
-  // new selection via CustomLayoutSelectionProvider below.
-  const lastLayoutSelectionRef = useRef<unknown>(null)
-  useEffect(() => {
-    const store = storeRef.current
-    if (!store) return
-    const sel = layoutSelection ?? null
-    if (lastLayoutSelectionRef.current === sel) return
-    lastLayoutSelectionRef.current = sel
-    store.setLayoutSelection(sel)
-    if (store.hasCustomRestyle) {
-      store.restyleScene(sel)
-    } else {
-      dirtyRef.current = true
-    }
-    scheduleRender()
-  }, [layoutSelection, scheduleRender])
+  // Bridge the resolved custom-layout selection into the scene store +
+  // repaint. See useLayoutSelectionSync for why this is a legitimate
+  // React→canvas sync (selection is React-assembled), not a store relay.
+  useLayoutSelectionSync(storeRef, layoutSelection, dirtyRef, scheduleRender)
 
   // Theme-change repaint (clearCSSColorCache + dirty + scheduleRender)
   // is handled by useFrame above when themeDirtyRef is provided. But there's

--- a/src/components/stream/StreamOrdinalFrame.tsx
+++ b/src/components/stream/StreamOrdinalFrame.tsx
@@ -45,6 +45,7 @@ import { DataSourceAdapter } from "./DataSourceAdapter"
 import { OrdinalPipelineStore } from "./OrdinalPipelineStore"
 import { composeOverlays } from "./composeOverlays"
 import { wrapWithCustomLayoutSelection } from "./customLayoutSelection"
+import { useConfigSync, useLayoutSelectionSync } from "./streamStoreSync"
 import { findNearestOrdinalNode } from "./OrdinalCanvasHitTester"
 import { extractOrdinalNavPoints, buildNavGraph, resolvePosition, nextGraphIndex, navPointToHover, type NavGraph } from "./keyboardNav"
 import { useStalenessCheck } from "./useStalenessCheck"
@@ -512,32 +513,12 @@ const StreamOrdinalFrame = forwardRef<StreamOrdinalFrameHandle, StreamOrdinalFra
       onChange(categories)
     }, [])
 
-    // Update config when it changes
-    useEffect(() => {
-      storeRef.current?.updateConfig(stablePipelineConfig)
-      dirtyRef.current = true
-      scheduleRender()
-    }, [stablePipelineConfig, scheduleRender])
+    useConfigSync(storeRef, stablePipelineConfig, dirtyRef, scheduleRender)
 
-    // Custom-layout selection channel — off the rebuild path. With a `restyle`
-    // callback a selection change re-applies styles + repaints (no relayout);
-    // otherwise it rebuilds so `ctx.selection` reaches the layout. Overlays
-    // re-render via CustomLayoutSelectionProvider below.
-    const lastLayoutSelectionRef = useRef<unknown>(null)
-    useEffect(() => {
-      const store = storeRef.current
-      if (!store) return
-      const sel = layoutSelection ?? null
-      if (lastLayoutSelectionRef.current === sel) return
-      lastLayoutSelectionRef.current = sel
-      store.setLayoutSelection(sel)
-      if (store.hasCustomRestyle) {
-        store.restyleScene(sel)
-      } else {
-        dirtyRef.current = true
-      }
-      scheduleRender()
-    }, [layoutSelection, scheduleRender])
+    // Bridge the resolved custom-layout selection into the scene store +
+    // repaint. See useLayoutSelectionSync for why this is a legitimate
+    // React→canvas sync (selection is React-assembled), not a store relay.
+    useLayoutSelectionSync(storeRef, layoutSelection, dirtyRef, scheduleRender)
 
     // Theme-change repaint (clearCSSColorCache + dirty + scheduleRender)
     // is handled by useFrame above when themeDirtyRef is provided.

--- a/src/components/stream/StreamXYFrame.tsx
+++ b/src/components/stream/StreamXYFrame.tsx
@@ -27,6 +27,7 @@ import { resolveThemeSemanticColors } from "../store/ThemeStore"
 import { PipelineStore, type PipelineConfig } from "./PipelineStore"
 import { composeOverlays } from "./composeOverlays"
 import { wrapWithCustomLayoutSelection } from "./customLayoutSelection"
+import { useConfigSync, useLayoutSelectionSync } from "./streamStoreSync"
 import { findNearestNode, findAllNodesAtX } from "./CanvasHitTester"
 import { enrichDatumWithBand } from "./xySceneBuilders/ribbonScene"
 import { extractXYNavPoints, buildNavGraph, resolvePosition, nextGraphIndex, navPointToHover, type NavGraph } from "./keyboardNav"
@@ -749,33 +750,12 @@ const StreamXYFrame = forwardRef<StreamXYFrameHandle, StreamXYFrameProps>(
       onChange(categories)
     }, [])
 
-    // Update config when it changes — also schedule re-render since style
-    // callbacks (pointStyle, areaStyle, etc.) may have changed.
-    useEffect(() => {
-      storeRef.current?.updateConfig(stablePipelineConfig)
-      dirtyRef.current = true
-      scheduleRender()
-    }, [stablePipelineConfig, scheduleRender])
+    useConfigSync(storeRef, stablePipelineConfig, dirtyRef, scheduleRender)
 
-    // Custom-layout selection channel — off the rebuild path. When the layout
-    // returned a `restyle`, a selection change re-applies styles + repaints (no
-    // relayout / quadtree rebuild); otherwise it rebuilds so `ctx.selection`
-    // reaches the layout. Overlays re-render via CustomLayoutSelectionProvider.
-    const lastLayoutSelectionRef = useRef<unknown>(null)
-    useEffect(() => {
-      const store = storeRef.current
-      if (!store) return
-      const sel = layoutSelection ?? null
-      if (lastLayoutSelectionRef.current === sel) return
-      lastLayoutSelectionRef.current = sel
-      store.setLayoutSelection(sel)
-      if (store.hasCustomRestyle) {
-        store.restyleScene(sel)
-      } else {
-        dirtyRef.current = true
-      }
-      scheduleRender()
-    }, [layoutSelection, scheduleRender])
+    // Bridge the resolved custom-layout selection into the scene store +
+    // repaint. See useLayoutSelectionSync for why this is a legitimate
+    // React→canvas sync (selection is React-assembled), not a store relay.
+    useLayoutSelectionSync(storeRef, layoutSelection, dirtyRef, scheduleRender)
 
     // Theme-change repaint (clearCSSColorCache + dirty + scheduleRender)
     // is handled by useFrame above when themeDirtyRef is provided.

--- a/src/components/stream/streamStoreSync.ts
+++ b/src/components/stream/streamStoreSync.ts
@@ -1,0 +1,81 @@
+"use client"
+import { useEffect, useRef, type MutableRefObject } from "react"
+
+// Bridges that push a React-owned value into the imperative scene store and
+// repaint. These are NOT "mirror a store value into another store" relays: the
+// values they carry (the memoized pipeline config; the resolved custom-layout
+// selection) are owned/assembled in React, and the canvas/scene store is
+// imperative and must be told to repaint when they change. That is the
+// legitimate "synchronize an external imperative system with React-owned state"
+// use of an effect — note neither hook calls `setState`, so they cannot cascade
+// React re-renders. All three stream stores (`PipelineStore`,
+// `OrdinalPipelineStore`, `NetworkPipelineStore`) plus the geo store structurally
+// satisfy the minimal store slices below.
+
+/**
+ * Push the memoized pipeline config into the scene store and repaint.
+ *
+ * `config` is memoized upstream (the frames' `stablePipelineConfig`), so this
+ * fires only on a real config change, never per render. Marks the scene dirty
+ * and repaints because style callbacks (pointStyle, areaStyle, …) carried in
+ * the config may have changed even when geometry did not.
+ */
+export function useConfigSync<C>(
+  storeRef: MutableRefObject<{ updateConfig(config: C): void } | null>,
+  config: C,
+  dirtyRef: MutableRefObject<boolean>,
+  scheduleRender: () => void
+): void {
+  useEffect(() => {
+    storeRef.current?.updateConfig(config)
+    dirtyRef.current = true
+    scheduleRender()
+  }, [config, scheduleRender, storeRef, dirtyRef])
+}
+
+/**
+ * Bridge a custom layout's resolved selection (`layoutSelection`) into the
+ * scene store and repaint.
+ *
+ * `layoutSelection` has no single home in a store: the custom-chart HOCs
+ * assemble it in React by merging local component state (hover-highlight,
+ * legend interaction) with the cross-chart selection store
+ * (`effectiveSelectionHook = hover ?? legend ?? activeSelection`). React owns
+ * that blended value.
+ *
+ * Kept OFF the rebuild path: when the layout returned a `restyle` callback a
+ * selection change re-applies styles to the existing scene and repaints (no
+ * relayout, no quadtree rebuild); otherwise it marks the scene dirty so a
+ * rebuild lets `ctx.selection` reach the layout. Either way the overlay subtree
+ * re-renders against the new selection via `CustomLayoutSelectionProvider`.
+ *
+ * The `lastSelectionRef` guard makes the write fire only on a real selection
+ * change (the HOCs already memoize `layoutSelection` on its `isActive`/
+ * `predicate` identity), never per render.
+ */
+export function useLayoutSelectionSync<S>(
+  storeRef: MutableRefObject<{
+    setLayoutSelection(selection: S | null): void
+    hasCustomRestyle: boolean
+    restyleScene(selection: S | null): void
+  } | null>,
+  layoutSelection: S | null | undefined,
+  dirtyRef: MutableRefObject<boolean>,
+  scheduleRender: () => void
+): void {
+  const lastSelectionRef = useRef<S | null>(null)
+  useEffect(() => {
+    const store = storeRef.current
+    if (!store) return
+    const sel = layoutSelection ?? null
+    if (lastSelectionRef.current === sel) return
+    lastSelectionRef.current = sel
+    store.setLayoutSelection(sel)
+    if (store.hasCustomRestyle) {
+      store.restyleScene(sel)
+    } else {
+      dirtyRef.current = true
+    }
+    scheduleRender()
+  }, [layoutSelection, scheduleRender, storeRef, dirtyRef])
+}


### PR DESCRIPTION
Seed configured selection resolution in LinkedCharts at store construction (via SelectionProvider initialState) and remove the mount-effect ResolutionInit. Refactor the legend selection handling to use the selection store as the single source of truth (dedicated isolate/highlight client IDs, derive isolated/highlighted categories from the store, and write selections directly from handlers). Add a unit test to verify resolution is applied at construction. Introduce streamStoreSync with useConfigSync and useLayoutSelectionSync to centralize the imperative sync logic for pipeline config and custom-layout selection; update StreamGeoFrame, StreamNetworkFrame, StreamOrdinalFrame and StreamXYFrame to use these hooks and remove duplicated useEffect blocks. Also update imports/types accordingly.

This pull request introduces two main improvements: it refactors the synchronization between React state and imperative scene stores in all stream frame components, and it simplifies and improves the handling of selection resolution and legend interaction in `LinkedCharts`. The changes make the code more robust, reduce unnecessary React state, and centralize imperative updates to the scene stores.

**Stream frame synchronization refactor:**

* Introduced a new module `streamStoreSync.ts` that exports `useConfigSync` and `useLayoutSelectionSync` hooks, which handle pushing React-owned state (pipeline config and custom layout selection) into the imperative scene stores and triggering repaints. This eliminates repeated effect boilerplate and ensures updates only occur on real changes.
* Updated all stream frame components (`StreamGeoFrame`, `StreamNetworkFrame`, `StreamOrdinalFrame`, `StreamXYFrame`) to use these new hooks instead of inline `useEffect` blocks for config and layout selection synchronization. [[1]](diffhunk://#diff-5a9dd56b677cc6742d662964a1a27cb3a8ee6a185808fcdb4f97b9647e26ae7eL441-R442) [[2]](diffhunk://#diff-8841643e6efc8308d2cfe4c7d8b4a88fd25e75683b27f766828c7eea6ba31cbfL769-R778) [[3]](diffhunk://#diff-f6c9def3d978faa0130aedb448891335cc96127aa2d1a7e32bf98772e1ada6d7L515-R521) [[4]](diffhunk://#diff-20b8116eeccbf51ba294c34db387ada382100f96a8ee11959997b3894dcbd446L752-R758)

**LinkedCharts selection and legend improvements:**

* The initial selection resolution mode is now seeded directly into the selection store at construction via the `initialState` prop, rather than being mirrored in with a mount effect. This ensures the correct resolution is applied from the start and avoids unnecessary synchronization logic. [[1]](diffhunk://#diff-d4c73adb258921e8b75be29d84f5a14c6f1e2e16c99654888f266b20053d1051R361-R376) [[2]](diffhunk://#diff-d4c73adb258921e8b75be29d84f5a14c6f1e2e16c99654888f266b20053d1051L137-L152) [[3]](diffhunk://#diff-d4c73adb258921e8b75be29d84f5a14c6f1e2e16c99654888f266b20053d1051L430-L432)
* Refactored the legend interaction logic in `LinkedCharts` to use the selection store as the single source of truth, removing parallel React state for isolated and highlighted categories. Legend emphasis is now derived directly from the store, and legend event handlers write directly to the store, ensuring a single, consistent state.
* Added a test to verify that the configured resolution mode is correctly seeded and affects selection behavior as intended.