### PR TITLE
Add DataPitfalls return-path helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,9 +132,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the same unit the next began).
 - **DataPitfalls and GoFish adapters remain experimental.** The DataPitfalls
   bridge is exposed from `semiotic/experimental` as
-  `unstable_toDataPitfallsChain` / `unstable_buildDataPitfallsBridge`, and the
-  GoFish DisplayList adapter remains `unstable_fromGofishIR` on the same
-  endpoint. Neither adapter is part of the stable API surface yet.
+  `unstable_toDataPitfallsChain` / `unstable_buildDataPitfallsBridge`, with
+  return-path helpers for DataPitfalls PR #35 reports:
+  `unstable_toDataPitfallsNotifications` for chart-level findings and
+  `unstable_toDataPitfallsAnnotations` for host-anchored Semiotic v3
+  annotations. The GoFish DisplayList adapter remains `unstable_fromGofishIR`
+  on the same endpoint. Neither adapter is part of the stable API surface yet.
 
 ## [3.7.5] - 2026-06-24
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,29 @@ const input = unstable_toDataPitfallsChain("LineChart", props, {
 const report = await detectPitfalls(input, { apiKey: process.env.ANTHROPIC_API_KEY })
 ```
 
+The return path stays dependency-free too. Use whole-chart findings as
+`ChartContainer` notifications, and only turn findings into annotations after
+your app can anchor them to marks or semantic positions:
+
+```tsx
+import { ChartContainer } from "semiotic"
+import { LineChart } from "semiotic/xy"
+import {
+  unstable_toDataPitfallsAnnotations,
+  unstable_toDataPitfallsNotifications,
+} from "semiotic/experimental"
+
+const notifications = unstable_toDataPitfallsNotifications(report)
+const annotations = unstable_toDataPitfallsAnnotations(report, {
+  anchorFor: (finding) =>
+    finding.ruleId === "truncated-axis" ? { x: 9, y: 9000 } : null,
+})
+
+<ChartContainer notifications={notifications}>
+  <LineChart {...props} annotations={annotations} />
+</ChartContainer>
+```
+
 ### When to use something else
 
 Need a standard bar or line chart for a dashboard you'll never need to

--- a/docs/src/pages/features/DataPitfallsBridgePage.jsx
+++ b/docs/src/pages/features/DataPitfallsBridgePage.jsx
@@ -594,7 +594,9 @@ export default function DataPitfallsBridgePage() {
         </a>
         . Semiotic contributes the chart config, JSX, reader grounding, config diagnostics,
         accessibility audit, and optional render evidence. Data Pitfalls remains the model-backed
-        detector that reviews that chain against its pitfall taxonomy.
+        detector that reviews that chain against its pitfall taxonomy. The return-path helpers map a
+        report back into chart-level notifications or Semiotic v3 annotation objects, mirroring the
+        dependency-free bridge added in DataPitfalls PR #35.
       </p>
 
       <h2 id="live-demo">Live payload builder</h2>
@@ -634,6 +636,42 @@ const report = await detectPitfalls(input, {
 console.log(formatReport(report))
 if (hasBlockingFindings(report)) process.exit(1)`}
       </CodeBlock>
+
+      <h2 id="return-path">Return path</h2>
+      <p>
+        DataPitfalls PR #35 adds <code>toSemioticAnnotations()</code> in the DataPitfalls package.
+        Semiotic also exposes structural helpers for apps that already have a report object and want
+        to keep rendering code dependency-free. Whole-chart findings fit the{" "}
+        <code>ChartContainer</code> notification stack; mark-level findings can become annotations
+        once the host app supplies coordinates or semantic anchors.
+      </p>
+
+      <CodeBlock language="tsx">{`import { ChartContainer } from "semiotic"
+import { LineChart } from "semiotic/xy"
+import {
+  unstable_toDataPitfallsAnnotations,
+  unstable_toDataPitfallsNotifications,
+} from "semiotic/experimental"
+
+const notifications = unstable_toDataPitfallsNotifications(report, { max: 3 })
+
+const annotations = unstable_toDataPitfallsAnnotations(report, {
+  anchorFor: (finding) =>
+    finding.ruleId === "truncated-axis"
+      ? { x: 9, y: 9000, anchor: "semantic" }
+      : null,
+})
+
+<ChartContainer notifications={notifications}>
+  <LineChart {...props} annotations={annotations} />
+</ChartContainer>`}
+      </CodeBlock>
+
+      <p>
+        The annotation helper deliberately does not invent <code>x</code> or <code>y</code>. An
+        unanchored Semiotic v3 annotation is dropped until the host places it, while unanchored
+        report-level findings remain visible as notifications.
+      </p>
 
       <h2 id="what-semiotic-adds">What Semiotic adds</h2>
       <ul>

--- a/src/components/ai/dataPitfallsBridge.test.ts
+++ b/src/components/ai/dataPitfallsBridge.test.ts
@@ -215,7 +215,7 @@ describe("dataPitfallsBridge", () => {
     expect(bridge.meta).toEqual({ count: 3, kind: "image" })
     expect(bridge.notifications).toEqual([
       {
-        id: "truncated-axis",
+        id: "truncated-axis:0",
         level: "error",
         title: "Truncated axis",
         message: "Start the axis at zero.",
@@ -223,13 +223,31 @@ describe("dataPitfallsBridge", () => {
         dismissible: false,
       },
       {
-        id: "missing-context",
+        id: "missing-context:1",
         level: "warning",
         title: "Missing decision context",
         message: "readers cannot tell whether the observed lift is enough",
         source: "datapitfalls · Epistemic Errors",
         dismissible: false,
       },
+    ])
+  })
+
+  it("keeps notification IDs unique when multiple findings share a rule", () => {
+    const duplicateRuleReport: DataPitfallsReport = {
+      ...pitfallReport,
+      findings: [
+        pitfallReport.findings[0],
+        {
+          ...pitfallReport.findings[0],
+          evidence: "another chart region has the same rule finding",
+        },
+      ],
+    }
+
+    expect(toDataPitfallsNotifications(duplicateRuleReport).map((n) => n.id)).toEqual([
+      "truncated-axis:0",
+      "truncated-axis:1",
     ])
   })
 
@@ -276,6 +294,41 @@ describe("dataPitfallsBridge", () => {
     expect(first).not.toHaveProperty("disable")
     expect(first).not.toHaveProperty("x")
     expect(first).not.toHaveProperty("y")
+  })
+
+  it("uses the host info palette fallback and sanitized class names for forward-compatible severities", () => {
+    const unknownSeverityReport: DataPitfallsReport = {
+      ...pitfallReport,
+      findings: [{
+        ...pitfallReport.findings[0],
+        severity: "review needed",
+      }],
+    }
+
+    const [annotation] = toDataPitfallsAnnotations(unknownSeverityReport, {
+      palette: { info: "#abcdef" },
+    })
+
+    expect(annotation.color).toBe("#abcdef")
+    expect(annotation.className).toBe("pitfall-review-needed")
+  })
+
+  it("keeps provenance stableId equal to ruleId for DataPitfalls semantic matching", () => {
+    const duplicateRuleReport: DataPitfallsReport = {
+      ...pitfallReport,
+      findings: [
+        pitfallReport.findings[0],
+        {
+          ...pitfallReport.findings[0],
+          evidence: "another chart region has the same rule finding",
+        },
+      ],
+    }
+
+    expect(toDataPitfallsAnnotations(duplicateRuleReport).map((a) => a.provenance.stableId)).toEqual([
+      "truncated-axis",
+      "truncated-axis",
+    ])
   })
 
   it("caps annotations while keeping the full finding count visible in meta", () => {

--- a/src/components/ai/dataPitfallsBridge.test.ts
+++ b/src/components/ai/dataPitfallsBridge.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest"
 import {
+  DEFAULT_DATA_PITFALLS_ANNOTATION_PALETTE,
+  buildDataPitfallsAnnotationBridge,
   buildDataPitfallsBridge,
+  buildDataPitfallsNotificationBridge,
+  toDataPitfallsAnnotations,
   toDataPitfallsChain,
+  toDataPitfallsNotifications,
   type DataPitfallsChainStage,
+  type DataPitfallsReport,
   type DataPitfallsTextInput,
 } from "./dataPitfallsBridge"
 
@@ -24,6 +30,38 @@ function textOrCodeArtifact(stage: DataPitfallsChainStage): DataPitfallsTextInpu
     throw new Error(`Expected text/code artifact, received ${artifact.kind}`)
   }
   return artifact
+}
+
+const pitfallReport: DataPitfallsReport = {
+  kind: "image",
+  model: "test-model",
+  rulesConsidered: 3,
+  findings: [
+    {
+      ruleId: "truncated-axis",
+      name: "Truncated axis",
+      domain: "Graphical Gaffes",
+      severity: "error",
+      evidence: "the y-axis starts at 90, not 0",
+      remediation: "Start the axis at zero.",
+    },
+    {
+      ruleId: "missing-context",
+      name: "Missing decision context",
+      domain: "Epistemic Errors",
+      severity: "warning",
+      evidence: "the chart does not define the decision threshold",
+      explanation: "readers cannot tell whether the observed lift is enough",
+    },
+    {
+      ruleId: "data-reality-gap",
+      name: "Data-reality gap",
+      domain: "Epistemic Errors",
+      severity: "info",
+      evidence: "survey responses are shown as population fact",
+      condition: "the metric is a sample proxy",
+    },
+  ],
 }
 
 describe("dataPitfallsBridge", () => {
@@ -166,5 +204,112 @@ describe("dataPitfallsBridge", () => {
     const configArtifact = textOrCodeArtifact(config)
     expect(configArtifact.content).toContain("\"xAccessor\": \"month\"")
     expect(configArtifact.content).not.toContain("\"data\"")
+  })
+
+  it("maps Data Pitfalls findings to ChartContainer-compatible notifications", () => {
+    const bridge = buildDataPitfallsNotificationBridge(pitfallReport, {
+      max: 2,
+      dismissible: false,
+    })
+
+    expect(bridge.meta).toEqual({ count: 3, kind: "image" })
+    expect(bridge.notifications).toEqual([
+      {
+        id: "truncated-axis",
+        level: "error",
+        title: "Truncated axis",
+        message: "Start the axis at zero.",
+        source: "datapitfalls · Graphical Gaffes",
+        dismissible: false,
+      },
+      {
+        id: "missing-context",
+        level: "warning",
+        title: "Missing decision context",
+        message: "readers cannot tell whether the observed lift is enough",
+        source: "datapitfalls · Epistemic Errors",
+        dismissible: false,
+      },
+    ])
+  })
+
+  it("supports custom notification source and message mapping", () => {
+    const notifications = toDataPitfallsNotifications(pitfallReport, {
+      sourcePrefix: "audit",
+      message: (finding, index, report) =>
+        `${index + 1}/${report.findings.length}: ${finding.ruleId}`,
+    })
+
+    expect(notifications[0]).toMatchObject({
+      source: "audit · Graphical Gaffes",
+      message: "1/3: truncated-axis",
+    })
+  })
+
+  it("emits Data Pitfalls report findings as Semiotic v3-native annotations", () => {
+    const annotations = toDataPitfallsAnnotations(pitfallReport)
+    const first = annotations[0]
+
+    expect(first).toMatchObject({
+      type: "label",
+      title: "Truncated axis",
+      label: "Start the axis at zero.",
+      wrap: 240,
+      color: DEFAULT_DATA_PITFALLS_ANNOTATION_PALETTE.error,
+      className: "pitfall-error",
+      emphasis: "primary",
+      provenance: {
+        author: "datapitfalls",
+        authorKind: "watcher",
+        source: "computed",
+        basis: "llm-inference",
+        stableId: "truncated-axis",
+      },
+      dataPitfall: {
+        ruleId: "truncated-axis",
+        domain: "Graphical Gaffes",
+        severity: "error",
+        evidence: "the y-axis starts at 90, not 0",
+      },
+    })
+    expect(first).not.toHaveProperty("note")
+    expect(first).not.toHaveProperty("disable")
+    expect(first).not.toHaveProperty("x")
+    expect(first).not.toHaveProperty("y")
+  })
+
+  it("caps annotations while keeping the full finding count visible in meta", () => {
+    const bridge = buildDataPitfallsAnnotationBridge(pitfallReport, {
+      max: 1,
+      type: "text",
+      wrap: 320,
+      palette: { error: "#111111" },
+    })
+
+    expect(bridge.meta).toEqual({ count: 3, kind: "image" })
+    expect(bridge.annotations).toHaveLength(1)
+    expect(bridge.annotations[0]).toMatchObject({
+      type: "text",
+      wrap: 320,
+      color: "#111111",
+    })
+  })
+
+  it("merges host-owned anchors into Data Pitfalls annotations without inventing coordinates", () => {
+    const annotations = toDataPitfallsAnnotations(pitfallReport, {
+      anchorFor: (finding) =>
+        finding.ruleId === "truncated-axis"
+          ? { x: 9, y: 9000, anchor: "semantic" }
+          : null,
+    })
+
+    expect(annotations[0]).toMatchObject({
+      x: 9,
+      y: 9000,
+      anchor: "semantic",
+      title: "Truncated axis",
+    })
+    expect(annotations[1]).not.toHaveProperty("x")
+    expect(annotations[1]).not.toHaveProperty("y")
   })
 })

--- a/src/components/ai/dataPitfallsBridge.ts
+++ b/src/components/ai/dataPitfallsBridge.ts
@@ -125,6 +125,136 @@ export interface DataPitfallsBridgeResult {
   accessibility?: AccessibilityAuditResult
 }
 
+export type DataPitfallsSeverity =
+  | "info"
+  | "warning"
+  | "error"
+  | (string & {})
+
+export type DataPitfallsInputKind =
+  | "text"
+  | "code"
+  | "image"
+  | "document"
+  | "slides"
+  | "chain"
+  | (string & {})
+
+export interface DataPitfallsFinding {
+  ruleId: string
+  name: string
+  domain: string
+  severity: DataPitfallsSeverity
+  evidence?: string
+  remediation?: string
+  explanation?: string
+  condition?: string
+  [key: string]: unknown
+}
+
+export interface DataPitfallsReport {
+  kind: DataPitfallsInputKind
+  findings: DataPitfallsFinding[]
+  [key: string]: unknown
+}
+
+export type DataPitfallsNotificationLevel =
+  | "info"
+  | "warning"
+  | "error"
+  | "neutral"
+
+export interface DataPitfallsChartNotification {
+  id?: string
+  level?: DataPitfallsNotificationLevel
+  title?: string
+  message: string
+  source?: string
+  dismissible?: boolean
+}
+
+export type DataPitfallsNotificationMessage =
+  (
+    finding: DataPitfallsFinding,
+    index: number,
+    report: DataPitfallsReport
+  ) => string
+
+export interface DataPitfallsNotificationBridgeOptions {
+  /** Cap emitted notifications. `meta.count` keeps the uncapped finding count. */
+  max?: number
+  /** Prefix for the source tag. Default: "datapitfalls". */
+  sourcePrefix?: string
+  /** Passed through to ChartContainer notifications when set. */
+  dismissible?: boolean
+  /** Custom message mapper. Defaults to remediation, explanation, evidence, then condition. */
+  message?: DataPitfallsNotificationMessage
+}
+
+export interface DataPitfallsNotificationBridge {
+  notifications: DataPitfallsChartNotification[]
+  meta: { count: number; kind: DataPitfallsInputKind }
+}
+
+export type DataPitfallsAnnotationType = "label" | "text"
+
+export interface DataPitfallsSemioticAnnotation {
+  type: DataPitfallsAnnotationType
+  title: string
+  label: string
+  wrap: number
+  color: string
+  className: string
+  emphasis: "primary" | "secondary"
+  provenance: {
+    author: "datapitfalls"
+    authorKind: "watcher"
+    source: "computed"
+    basis: "llm-inference"
+    stableId: string
+  }
+  dataPitfall: {
+    ruleId: string
+    domain: string
+    severity: DataPitfallsSeverity
+    evidence: string
+  }
+  [key: string]: unknown
+}
+
+export interface DataPitfallsAnnotationBridgeOptions {
+  /** Override severity colors. Merged over the defaults. */
+  palette?: Partial<Record<string, string>>
+  /** Cap emitted annotations. `meta.count` keeps the uncapped finding count. */
+  max?: number
+  /** Text wrap width passed through to Semiotic v3 annotations. Default: 240. */
+  wrap?: number
+  /** Semiotic v3 annotation type. Default: "label". */
+  type?: DataPitfallsAnnotationType
+  /**
+   * Optional host-owned anchoring. Return `{ x, y }`, data accessors, or any
+   * other Semiotic annotation fields for findings you can position.
+   */
+  anchorFor?: (
+    finding: DataPitfallsFinding,
+    index: number,
+    report: DataPitfallsReport
+  ) => Record<string, unknown> | null | undefined
+}
+
+export interface DataPitfallsAnnotationBridge {
+  annotations: DataPitfallsSemioticAnnotation[]
+  meta: { count: number; kind: DataPitfallsInputKind }
+}
+
+export const DEFAULT_DATA_PITFALLS_ANNOTATION_PALETTE = {
+  info: "#2563eb",
+  warning: "#d97706",
+  error: "#dc2626",
+} as const
+
+const DEFAULT_DATA_PITFALLS_WRAP = 240
+
 function asArray<T>(value: T | T[] | undefined): T[] {
   if (value == null) return []
   return Array.isArray(value) ? value : [value]
@@ -136,6 +266,148 @@ function stringify(value: unknown): string {
     return JSON.stringify(value, null, 2) ?? String(value)
   } catch {
     return String(value)
+  }
+}
+
+function cappedFindings(
+  report: DataPitfallsReport,
+  max: number | undefined
+): DataPitfallsFinding[] {
+  return max == null
+    ? report.findings
+    : report.findings.slice(0, Math.max(0, max))
+}
+
+function firstText(...values: Array<string | undefined>): string {
+  for (const value of values) {
+    const trimmed = value?.trim()
+    if (trimmed) return trimmed
+  }
+  return "Review this finding."
+}
+
+function findingMessage(finding: DataPitfallsFinding): string {
+  return firstText(
+    finding.remediation,
+    finding.explanation,
+    finding.evidence,
+    finding.condition
+  )
+}
+
+function findingTitle(finding: DataPitfallsFinding): string {
+  return firstText(finding.name, finding.ruleId)
+}
+
+function notificationLevel(severity: DataPitfallsSeverity): DataPitfallsNotificationLevel {
+  if (severity === "error") return "error"
+  if (severity === "warning") return "warning"
+  if (severity === "info") return "info"
+  return "neutral"
+}
+
+function findingSource(finding: DataPitfallsFinding, prefix: string): string {
+  return finding.domain ? `${prefix} · ${finding.domain}` : prefix
+}
+
+function paletteColor(
+  severity: DataPitfallsSeverity,
+  palette: Partial<Record<string, string>>
+): string {
+  return palette[severity] ?? DEFAULT_DATA_PITFALLS_ANNOTATION_PALETTE.info
+}
+
+export function dataPitfallsFindingToNotification(
+  finding: DataPitfallsFinding,
+  options: DataPitfallsNotificationBridgeOptions = {},
+  index = 0,
+  report: DataPitfallsReport = { kind: "image", findings: [finding] }
+): DataPitfallsChartNotification {
+  const prefix = options.sourcePrefix ?? "datapitfalls"
+  return {
+    id: firstText(finding.ruleId, finding.name),
+    level: notificationLevel(finding.severity),
+    title: findingTitle(finding),
+    message: options.message
+      ? options.message(finding, index, report)
+      : findingMessage(finding),
+    source: findingSource(finding, prefix),
+    ...(options.dismissible === undefined ? {} : { dismissible: options.dismissible }),
+  }
+}
+
+export function toDataPitfallsNotifications(
+  report: DataPitfallsReport,
+  options: DataPitfallsNotificationBridgeOptions = {}
+): DataPitfallsChartNotification[] {
+  return cappedFindings(report, options.max).map((finding, index) =>
+    dataPitfallsFindingToNotification(finding, options, index, report)
+  )
+}
+
+export function buildDataPitfallsNotificationBridge(
+  report: DataPitfallsReport,
+  options: DataPitfallsNotificationBridgeOptions = {}
+): DataPitfallsNotificationBridge {
+  return {
+    notifications: toDataPitfallsNotifications(report, options),
+    meta: { count: report.findings.length, kind: report.kind },
+  }
+}
+
+export function dataPitfallsFindingToAnnotation(
+  finding: DataPitfallsFinding,
+  options: DataPitfallsAnnotationBridgeOptions = {},
+  index = 0,
+  report: DataPitfallsReport = { kind: "image", findings: [finding] }
+): DataPitfallsSemioticAnnotation {
+  const palette = {
+    ...DEFAULT_DATA_PITFALLS_ANNOTATION_PALETTE,
+    ...options.palette,
+  }
+  const anchor = options.anchorFor?.(finding, index, report)
+
+  return {
+    ...(anchor ?? {}),
+    type: options.type ?? "label",
+    title: findingTitle(finding),
+    label: findingMessage(finding),
+    wrap: options.wrap ?? DEFAULT_DATA_PITFALLS_WRAP,
+    color: paletteColor(finding.severity, palette),
+    className: `pitfall-${finding.severity}`,
+    emphasis: finding.severity === "error" ? "primary" : "secondary",
+    provenance: {
+      author: "datapitfalls",
+      authorKind: "watcher",
+      source: "computed",
+      basis: "llm-inference",
+      stableId: finding.ruleId,
+    },
+    dataPitfall: {
+      ruleId: finding.ruleId,
+      domain: finding.domain,
+      severity: finding.severity,
+      evidence: finding.evidence ?? "",
+    },
+  }
+}
+
+export function toDataPitfallsAnnotations(
+  report: DataPitfallsReport,
+  options: DataPitfallsAnnotationBridgeOptions = {}
+): DataPitfallsSemioticAnnotation[] {
+  return cappedFindings(report, options.max).map((finding, index) =>
+    dataPitfallsFindingToAnnotation(finding, options, index, report)
+  )
+}
+
+export function buildDataPitfallsAnnotationBridge(
+  report: DataPitfallsReport,
+  options: DataPitfallsAnnotationBridgeOptions = {}
+): DataPitfallsAnnotationBridge {
+  return {
+    annotations: toDataPitfallsAnnotations(report, options),
+    meta: { count: report.findings.length, kind: report.kind },
   }
 }
 

--- a/src/components/ai/dataPitfallsBridge.ts
+++ b/src/components/ai/dataPitfallsBridge.ts
@@ -314,7 +314,19 @@ function paletteColor(
   severity: DataPitfallsSeverity,
   palette: Partial<Record<string, string>>
 ): string {
-  return palette[severity] ?? DEFAULT_DATA_PITFALLS_ANNOTATION_PALETTE.info
+  return palette[severity] ?? palette.info ?? DEFAULT_DATA_PITFALLS_ANNOTATION_PALETTE.info
+}
+
+function findingId(finding: DataPitfallsFinding): string {
+  return firstText(finding.ruleId, finding.name)
+}
+
+function indexedFindingId(finding: DataPitfallsFinding, index: number): string {
+  return `${findingId(finding)}:${index}`
+}
+
+function severityClassName(severity: DataPitfallsSeverity): string {
+  return `pitfall-${String(severity).toLowerCase().replace(/[^a-z0-9_-]/g, "-")}`
 }
 
 export function dataPitfallsFindingToNotification(
@@ -325,7 +337,7 @@ export function dataPitfallsFindingToNotification(
 ): DataPitfallsChartNotification {
   const prefix = options.sourcePrefix ?? "datapitfalls"
   return {
-    id: firstText(finding.ruleId, finding.name),
+    id: indexedFindingId(finding, index),
     level: notificationLevel(finding.severity),
     title: findingTitle(finding),
     message: options.message
@@ -374,7 +386,7 @@ export function dataPitfallsFindingToAnnotation(
     label: findingMessage(finding),
     wrap: options.wrap ?? DEFAULT_DATA_PITFALLS_WRAP,
     color: paletteColor(finding.severity, palette),
-    className: `pitfall-${finding.severity}`,
+    className: severityClassName(finding.severity),
     emphasis: finding.severity === "error" ? "primary" : "secondary",
     provenance: {
       author: "datapitfalls",

--- a/src/components/semiotic-experimental.ts
+++ b/src/components/semiotic-experimental.ts
@@ -35,21 +35,43 @@ export type { GofishIRExample as UnstableGofishIRExample } from "./recipes/gofis
 // DataPitfalls bridge (§8.x). This packages Semiotic config, JSX, reader
 // grounding, diagnostics, accessibility audit output, and optional render
 // evidence into the chain input consumed by the external `datapitfalls`
-// package. Kept experimental while that package's input contract settles.
+// package, and maps returned pitfall reports into chart-level notifications or
+// Semiotic v3-native annotation specs. Kept experimental while that package's
+// bridge contracts settle.
 export {
+  DEFAULT_DATA_PITFALLS_ANNOTATION_PALETTE as unstable_DEFAULT_DATA_PITFALLS_ANNOTATION_PALETTE,
+  buildDataPitfallsAnnotationBridge as unstable_buildDataPitfallsAnnotationBridge,
   buildDataPitfallsBridge as unstable_buildDataPitfallsBridge,
-  toDataPitfallsChain as unstable_toDataPitfallsChain
+  buildDataPitfallsNotificationBridge as unstable_buildDataPitfallsNotificationBridge,
+  dataPitfallsFindingToAnnotation as unstable_dataPitfallsFindingToAnnotation,
+  dataPitfallsFindingToNotification as unstable_dataPitfallsFindingToNotification,
+  toDataPitfallsAnnotations as unstable_toDataPitfallsAnnotations,
+  toDataPitfallsChain as unstable_toDataPitfallsChain,
+  toDataPitfallsNotifications as unstable_toDataPitfallsNotifications
 } from "./ai/dataPitfallsBridge"
 export type {
+  DataPitfallsAnnotationBridge as UnstableDataPitfallsAnnotationBridge,
+  DataPitfallsAnnotationBridgeOptions as UnstableDataPitfallsAnnotationBridgeOptions,
+  DataPitfallsAnnotationType as UnstableDataPitfallsAnnotationType,
   DataPitfallsBridgeOptions as UnstableDataPitfallsBridgeOptions,
   DataPitfallsBridgeResult as UnstableDataPitfallsBridgeResult,
   DataPitfallsChainInput as UnstableDataPitfallsChainInput,
   DataPitfallsChainStage as UnstableDataPitfallsChainStage,
+  DataPitfallsChartNotification as UnstableDataPitfallsChartNotification,
   DataPitfallsDocumentInput as UnstableDataPitfallsDocumentInput,
+  DataPitfallsFinding as UnstableDataPitfallsFinding,
   DataPitfallsImageInput as UnstableDataPitfallsImageInput,
   DataPitfallsImageMediaType as UnstableDataPitfallsImageMediaType,
   DataPitfallsImageSource as UnstableDataPitfallsImageSource,
+  DataPitfallsInputKind as UnstableDataPitfallsInputKind,
+  DataPitfallsNotificationBridge as UnstableDataPitfallsNotificationBridge,
+  DataPitfallsNotificationBridgeOptions as UnstableDataPitfallsNotificationBridgeOptions,
+  DataPitfallsNotificationLevel as UnstableDataPitfallsNotificationLevel,
+  DataPitfallsNotificationMessage as UnstableDataPitfallsNotificationMessage,
   DataPitfallsRenderedChart as UnstableDataPitfallsRenderedChart,
+  DataPitfallsReport as UnstableDataPitfallsReport,
+  DataPitfallsSemioticAnnotation as UnstableDataPitfallsSemioticAnnotation,
+  DataPitfallsSeverity as UnstableDataPitfallsSeverity,
   DataPitfallsSlideContent as UnstableDataPitfallsSlideContent,
   DataPitfallsSlidesInput as UnstableDataPitfallsSlidesInput,
   DataPitfallsSingleArtifactInput as UnstableDataPitfallsSingleArtifactInput,


### PR DESCRIPTION
Adds `toDataPitfallsNotifications` and `toDataPitfallsAnnotations` (plus lower-level `buildDataPitfalls*Bridge` and per-finding helpers) to the DataPitfalls bridge. These map a DataPitfalls PR #35 report back into `ChartContainer` notifications and Semiotic v3 annotation objects without introducing new dependencies. Exports exposed via `semiotic/experimental` with `unstable_` prefix. Docs and CHANGELOG updated.
