### PR TITLE
Split nightly Cloud Run to new service

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -6,8 +6,9 @@ provenance and compatibility expectations.
 
 | Channel | Cloud Run service | Source | Deployment trigger | Intended users |
 | --- | --- | --- | --- | --- |
-| Stable | `semiotic-mcp` | Exact published npm release | Manual/tagged release | Public users and registries |
-| Nightly | `semiotic-mcp-server` | Repository `main` commit | Automatic after merge | Maintainers and live validation |
+| Stable | `semiotic-mcp-server` (`us-west1`) | Exact published npm release | Manual/tagged release | Public users and registries |
+| Nightly | `semiotic-mcp-nightly` (`us-central1`) | Repository `main` commit | Automatic after merge, after manual smoke approval | Maintainers and live validation |
+| Legacy | `semiotic-mcp` | Existing deployment | None in this workflow | Leave untouched until nightly verification completes |
 
 The stable implementation is [`cloud-run`](./cloud-run/). It is a thin,
 release-oriented wrapper: it installs an exact published `semiotic` npm
@@ -125,14 +126,15 @@ application-level substitute.
 
 To roll back **nightly**, either send all nightly traffic to a previously known
 good revision, or update only the nightly service image to a previously known
-Artifact Registry digest. These actions do not alter `semiotic-mcp`:
+Artifact Registry digest. These actions do not alter the stable
+`semiotic-mcp-server` service:
 
 ```sh
-gcloud run revisions list --project semiotic-mcp --region us-west1 \
-  --service semiotic-mcp-server
+gcloud run revisions list --project semiotic-mcp --region us-central1 \
+  --service semiotic-mcp-nightly
 
-gcloud run services update-traffic semiotic-mcp-server \
-  --project semiotic-mcp --region us-west1 \
+gcloud run services update-traffic semiotic-mcp-nightly \
+  --project semiotic-mcp --region us-central1 \
   --to-revisions=KNOWN_GOOD_REVISION=100
 ```
 
@@ -144,7 +146,7 @@ nightly deployment README has the exact image path and trigger procedure.
 To promote a validated nightly commit, make a normal stable patch release from
 that commit: tag and publish the exact npm package, update the exact
 `semiotic` version and lockfile in `deploy/cloud-run`, run the release checks,
-then manually deploy `semiotic-mcp`. Update the registry/surface manifest and
+then manually deploy `semiotic-mcp-server`. Update the registry/surface manifest and
 GitHub Release as the same release operation. Promotion is never an image copy
 from nightly and never changes stable traffic automatically.
 

--- a/deploy/cloud-run-nightly/README.md
+++ b/deploy/cloud-run-nightly/README.md
@@ -1,14 +1,26 @@
 # Semiotic nightly Cloud Run deployment
 
-This directory is the repository-built **nightly** deployment path for
-`semiotic-mcp-server` in `us-west1`. It is separate from
-[`../cloud-run`](../cloud-run), which remains the stable release wrapper around
-an exact published `semiotic` npm package. Do not repurpose that stable wrapper
-to build repository source.
+This directory deploys the repository-built **nightly** MCP service:
 
-## Image build
+| Channel | Service | Region | Source |
+| --- | --- | --- | --- |
+| Official/stable | `semiotic-mcp-server` | `us-west1` | Exact published `semiotic` npm release via [`../cloud-run`](../cloud-run) |
+| Nightly | `semiotic-mcp-nightly` | `us-central1` | Checked-out repository `main` source |
+| Legacy | `semiotic-mcp` | Existing service | Leave untouched until nightly passes hosted smoke tests |
 
-The Node 22 Dockerfile uses the repository lockfile, then runs:
+Only `semiotic-mcp-nightly` is in scope for this configuration. Never update,
+attach a trigger to, delete, or copy settings from either existing service.
+
+## Image and source-build contract
+
+The expected nightly image is:
+
+```text
+us-central1-docker.pkg.dev/semiotic-mcp/cloud-run-source-deploy/semiotic/semiotic-mcp-nightly:$COMMIT_SHA
+```
+
+The Node 22 Dockerfile builds from the repository root with an explicit source
+allow-list and runs:
 
 ```sh
 npm ci --include=dev
@@ -17,178 +29,153 @@ npm run dist:prod
 npm run build:mcp
 ```
 
-The MCP bundle externalizes `semiotic/server`, `semiotic/ai`, and
-`semiotic/geo`; it cannot render from a standalone MCP build. The surface
-check rejects stale generated MCP/widget metadata, and `verify-runtime.mjs`
-gates both the final image and Cloud Build before push.
-
-Docker always builds from the repository root through an explicit source
-allow-list, so local `node_modules`, prior output, and unrelated files cannot
-enter the image. It starts:
+The final image is runtime-verified before push. It starts the five-tool public
+MCP profile:
 
 ```sh
 node ai/dist/mcp-server.js --http --host 0.0.0.0 --port "${PORT:-8080}" --profile public
 ```
 
-No released `semiotic` package is installed as application implementation. The
-source-built image bakes `SEMIOTIC_DEPLOYMENT_CHANNEL`, `SEMIOTIC_GIT_SHA`,
-`SEMIOTIC_BUILD_ID`, and `SEMIOTIC_BUILD_TIME` into its environment.
+The immutable image bakes in the nightly build identity environment values:
+`SEMIOTIC_DEPLOYMENT_CHANNEL=nightly`, `SEMIOTIC_GIT_SHA`,
+`SEMIOTIC_BUILD_ID`, and `SEMIOTIC_BUILD_TIME`. Do not override those values
+as Cloud Run service environment variables, because later image-only updates
+must report the new commit and build identity.
 
-`cloudbuild.yaml` builds and pushes:
+## First deployment: safe two-stage service creation
 
-```text
-us-west1-docker.pkg.dev/semiotic-mcp/cloud-run-source-deploy/semiotic/semiotic-mcp-server:$COMMIT_SHA
-```
+`semiotic-mcp-nightly` is new. Its initial settings cannot be inherited from
+either existing service. Supply and review all of these values before the first
+build:
 
-This is the existing service convention: the generated trigger's former
-`$_AR_HOSTNAME/$_AR_PROJECT_ID/$_AR_REPOSITORY/$REPO_NAME/$_SERVICE_NAME`
-expands to this same repository/image path. The nightly config makes it
-explicit because it must push before updating Cloud Run; there is no image-path
-deviation.
+- public unauthenticated invocation and `ingress=all`;
+- runtime service account (the account email is required, not guessed);
+- CPU `1`, memory `1Gi`, request timeout `300s`, concurrency `80`, minimum
+  instances `0`, and maximum instances `3` (change only through a reviewed
+  substitution); and
+- `MCP_ALLOWED_HOSTS`, which must contain the generated Cloud Run hostname.
 
-It updates only the nightly image and identity labels
-(`commit-sha`, `gcb-build-id`, `gcb-trigger-id`) plus
-`deployment-channel=nightly` and `deployment-source=repository-main`.
-It does not replace service environment variables, secrets, IAM, ingress,
-resources, scaling, concurrency, request timeout, or custom domains.
+The build solves the hostname bootstrap without ever serving a revision with
+host validation disabled:
 
-## Change the existing trigger after review
+1. It creates a no-traffic revision with
+   `MCP_ALLOWED_HOSTS=bootstrap.invalid`, public invocation, and the explicit
+   initial service settings.
+2. It reads the generated `status.url`, creates a second revision with that
+   hostname as `MCP_ALLOWED_HOSTS`, then sends traffic to that revision.
 
-| Field | Value |
-| --- | --- |
-| Trigger name | `rmgpgab-semiotic-mcp-server-us-west1-nteract-semiotic--mafcz` |
-| Trigger ID | `36c05cdd-221d-4c1b-a383-a8117cea4556` |
-| Location | `global` — omit `--region` |
-| Repository / branch | Existing GitHub `nteract/semiotic` connection, `^main$` |
-| Build service account | `projects/semiotic-mcp/serviceAccounts/481507046413-compute@developer.gserviceaccount.com` |
-| New config path | `deploy/cloud-run-nightly/cloudbuild.yaml` |
-
-The current trigger stores a generated inline **Buildpacks** build whose Pack
-step uses `--path=deploy/cloud-run`. Replace only that inline build with the
-checked-in YAML. Do not set `deploy/cloud-run-nightly` as a source directory:
-the YAML deliberately runs `docker build ... .` from the repository root.
+For a first manual build, work from the reviewed repository commit. Substitute
+the approved runtime service-account email; do not use either existing
+service's account without an IAM review.
 
 ```sh
 PROJECT_ID=semiotic-mcp
-TRIGGER_NAME=rmgpgab-semiotic-mcp-server-us-west1-nteract-semiotic--mafcz
-TRIGGER_ID=36c05cdd-221d-4c1b-a383-a8117cea4556
-BUILD_CONFIG=deploy/cloud-run-nightly/cloudbuild.yaml
+GIT_SHA="$(git rev-parse HEAD)"
+RUNTIME_SERVICE_ACCOUNT=APPROVED_RUNTIME_SERVICE_ACCOUNT
 
-gcloud builds triggers describe "$TRIGGER_NAME" --project="$PROJECT_ID" \
-  --format='yaml(name,id,github,serviceAccount,substitutions,filename,build)'
+gcloud builds submit . \
+  --project="$PROJECT_ID" \
+  --config=deploy/cloud-run-nightly/cloudbuild.yaml \
+  --substitutions="COMMIT_SHA=$GIT_SHA,_TRIGGER_ID=manual,_NIGHTLY_RUNTIME_SERVICE_ACCOUNT=$RUNTIME_SERVICE_ACCOUNT,_NIGHTLY_CPU=1,_NIGHTLY_MEMORY=1Gi,_NIGHTLY_TIMEOUT=300s,_NIGHTLY_CONCURRENCY=80,_NIGHTLY_MIN_INSTANCES=0,_NIGHTLY_MAX_INSTANCES=3,_NIGHTLY_BOOTSTRAP_HOST=bootstrap.invalid"
 ```
 
-The describe command confirms the exact existing build service account. Preserve
-that account, GitHub connection, `^main$` rule, and substitutions.
-
-To stage safely, pause only this nightly trigger with a non-matching branch:
+The create/update step in that build runs the following update for an existing
+nightly service; it changes only the image and nightly identity labels:
 
 ```sh
-gcloud builds triggers update github "$TRIGGER_NAME" --project="$PROJECT_ID" \
-  --branch-pattern='^__semiotic_nightly_paused__$'
+gcloud run services update semiotic-mcp-nightly \
+  --project=semiotic-mcp \
+  --region=us-central1 \
+  --image=us-central1-docker.pkg.dev/semiotic-mcp/cloud-run-source-deploy/semiotic/semiotic-mcp-nightly:$COMMIT_SHA \
+  --update-labels=commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=${_TRIGGER_ID},deployment-channel=nightly,deployment-source=repository-main \
+  --quiet
 ```
 
-After the reviewed repository files are on `main`, replace the generated
-Buildpacks configuration. `_TRIGGER_ID` already exists on the trigger; retain
-the actual UUID rather than the checked-in `manual` default:
+Do not run either command as part of this repository change.
+
+### Find and confirm the generated hostname
+
+After the first build succeeds, retrieve the URL and host explicitly:
 
 ```sh
-gcloud builds triggers update github "$TRIGGER_NAME" --project="$PROJECT_ID" \
-  --build-config="$BUILD_CONFIG" \
-  --branch-pattern='^__semiotic_nightly_paused__$' \
-  --update-substitutions="_TRIGGER_ID=$TRIGGER_ID"
-
-gcloud builds triggers describe "$TRIGGER_NAME" --project="$PROJECT_ID" \
-  --format='yaml(filename,github.push.branch,serviceAccount,substitutions)'
+NIGHTLY_URL="$(gcloud run services describe semiotic-mcp-nightly \
+  --project=semiotic-mcp --region=us-central1 --format='value(status.url)')"
+NIGHTLY_HOST="${NIGHTLY_URL#https://}"
+printf '%s\n%s\n' "$NIGHTLY_URL" "$NIGHTLY_HOST"
 ```
 
-Do not pass `--repo-owner`, `--repo-name`, `--repository`,
-`--service-account`, `--clear-substitutions`, or Dockerfile/Buildpacks flags
-to that update: omitting them preserves the existing connection and unrelated
-settings.
-
-Run one manual test from the checked-out `main` while automatic matching is
-still paused. It uses the existing trigger service account and runs the
-post-deployment smoke test:
+The build already creates the host-validated revision. If a manual recovery is
+needed before traffic is enabled, use only the new service:
 
 ```sh
-gcloud builds triggers run "$TRIGGER_NAME" --project="$PROJECT_ID" --branch=main
-
-gcloud builds list --project="$PROJECT_ID" \
-  --filter="buildTriggerId=$TRIGGER_ID" --sort-by='~createTime' --limit=1
-
-gcloud run services describe semiotic-mcp-server --project="$PROJECT_ID" \
-  --region=us-west1 \
-  --format='yaml(status.latestReadyRevisionName,spec.template.spec.containers[0].image,spec.template.metadata.labels)'
+gcloud run services update semiotic-mcp-nightly \
+  --project=semiotic-mcp --region=us-central1 \
+  --update-env-vars="MCP_ALLOWED_HOSTS=$NIGHTLY_HOST"
+gcloud run services update-traffic semiotic-mcp-nightly \
+  --project=semiotic-mcp --region=us-central1 --to-latest
 ```
 
-The image must end in the tested commit SHA. Labels must include
-`commit-sha`, `gcb-build-id`, `gcb-trigger-id`,
-`deployment-channel=nightly`, and `deployment-source=repository-main`.
-Use the hosted smoke script to inspect `/health`, `/healthz`, initialize
-metadata, and `semiotic://build-info`. Its default canonical `status.url`
-host must remain allowed by `MCP_ALLOWED_HOSTS`; for a future
-custom-domain-only allowlist, smoke an allowed public endpoint instead of
-changing that environment variable in this deployment.
+Never leave `MCP_ALLOWED_HOSTS` unset, and never set it to a stable or legacy
+service hostname.
 
-Re-enable only after the test is accepted:
+## Verify the manually deployed service
+
+The post-deployment smoke test exercises `/health`, `/healthz`, `GET /mcp`
+(405), `initialize`, `tools/list`, `resources/list`,
+`resources/read` for `semiotic://build-info`, and a `createChart` render:
 
 ```sh
-gcloud builds triggers update github "$TRIGGER_NAME" --project="$PROJECT_ID" \
-  --branch-pattern='^main$'
+node scripts/smoke-hosted-mcp.mjs \
+  --endpoint "$NIGHTLY_URL" \
+  --expected-channel nightly \
+  --expected-sha "$GIT_SHA" \
+  --expected-build-id CLOUD_BUILD_ID
 ```
 
-To disable nightly later, restore the no-match branch pattern above. It affects
-only this trigger, does not delete either service, and does not change stable
-traffic.
+Use the Cloud Build ID printed by the first-build output. The Cloud Build
+configuration runs this same smoke test automatically after every deployment.
+Do not enable automatic deployment until this manual smoke passes.
 
-## IAM, logging, and rollback
+## Enable automation only after validation
 
-Retrieve the trigger's build identity locally:
+Repository files do not establish whether a Cloud Build trigger already exists
+for `semiotic-mcp-nightly`. Before creating or updating one, inspect the
+following Google Cloud state read-only:
 
 ```sh
-BUILD_SERVICE_ACCOUNT="$(gcloud builds triggers describe "$TRIGGER_NAME" \
-  --project="$PROJECT_ID" --format='value(serviceAccount)')"
-printf '%s\n' "$BUILD_SERVICE_ACCOUNT"
+gcloud builds triggers list --project=semiotic-mcp \
+  --format='table(name,id,github.push.branch,filename,serviceAccount,disabled)'
+
+gcloud run services describe semiotic-mcp-nightly --project=semiotic-mcp \
+  --region=us-central1 \
+  --format='yaml(metadata.labels,status.url,spec.template.spec.serviceAccountName,spec.template.spec.containers[0].resources)'
+
+gcloud artifacts repositories describe cloud-run-source-deploy \
+  --project=semiotic-mcp --location=us-central1 \
+  --format='yaml(name,format,location)'
 ```
 
-For least privilege, give that account `roles/artifactregistry.writer` on the
-existing `us-west1` `cloud-run-source-deploy` repository (it also supplies the
-image-read permission), `roles/run.developer` on `semiotic-mcp-server`, and
-`roles/iam.serviceAccountUser` on the service's runtime identity. The developer
-role supplies the service update/read permissions used by deployment and smoke
-endpoint discovery. The Cloud Run service agent must retain Artifact Registry
-Reader access to the same repository (normally already present for a same-
-project service). `CLOUD_LOGGING_ONLY` also needs `roles/logging.logWriter`
-when it is not already supplied by the build role. `roles/run.admin` works but
-is broader than needed. The human making these changes needs the corresponding
-Cloud Build trigger-update/run permissions.
+Confirm the trigger's exact name/ID, location, GitHub connection and repository,
+`^main$` push rule, enabled state, repository-root config filename, build
+service account, substitutions, and approval/filter settings. Confirm that the
+build account can write the `us-central1` Artifact Registry repository, update
+only `semiotic-mcp-nightly`, impersonate the approved runtime service account,
+and write Cloud Logging.
 
-For a nightly rollback, prefer earlier revision traffic so its baked identity
-stays coherent:
+If no such trigger exists, create a new clearly named one for
+`semiotic-mcp-nightly` only after the manual smoke passes. It must use
+`deploy/cloud-run-nightly/cloudbuild.yaml`, pass its real trigger ID as
+`_TRIGGER_ID`, and supply the reviewed initial-service substitutions above.
+Do not repurpose a stable or legacy trigger.
 
-```sh
-gcloud run revisions list --service=semiotic-mcp-server --project="$PROJECT_ID" \
-  --region=us-west1 --sort-by='~metadata.creationTimestamp'
+## Rollback and legacy retirement
 
-gcloud run services update-traffic semiotic-mcp-server --project="$PROJECT_ID" \
-  --region=us-west1 --to-revisions=EARLIER_READY_REVISION=100
-```
+Roll back only `semiotic-mcp-nightly` in `us-central1`, either to a known-good
+revision or an immutable image digest with matching nightly labels. The archived
+[`historical-stable-buildpacks-cloudbuild.yaml`](./historical-stable-buildpacks-cloudbuild.yaml)
+targets the stable service and is never a nightly rollback option.
 
-If a new revision is required, retrieve the earlier immutable image digest, then
-use `gcloud run services update` with only `--image=IMAGE@sha256:...` and
-matching identity labels. Never use `--set-env-vars`, `--clear-env-vars`,
-`--clear-labels`, or resource flags for this rollback.
-
-`legacy-buildpacks-cloudbuild.yaml` is the exact prior generated Buildpacks
-configuration, retained only for trigger rollback. Restore it with:
-
-```sh
-gcloud builds triggers update github "$TRIGGER_NAME" --project="$PROJECT_ID" \
-  --inline-config=deploy/cloud-run-nightly/legacy-buildpacks-cloudbuild.yaml \
-  --branch-pattern='^main$' \
-  --update-substitutions="_TRIGGER_ID=$TRIGGER_ID"
-```
-
-That restores the old Pack Buildpacks path at `deploy/cloud-run`; it does not
-change the stable Cloud Run service.
+Leave `semiotic-mcp` running and untouched until `semiotic-mcp-nightly` passes
+the hosted smoke test and its public endpoint has been accepted. Deleting the
+legacy service, if desired, is a separate manual follow-up and is not part of
+this deployment or trigger workflow.

--- a/deploy/cloud-run-nightly/cloudbuild.yaml
+++ b/deploy/cloud-run-nightly/cloudbuild.yaml
@@ -1,12 +1,24 @@
-# Repository-built nightly deployment for the existing us-west1 Cloud Run
-# service. The trigger must use this file with the repository root as its build
-# context; do not point it at deploy/cloud-run-nightly.
+# Repository-built nightly deployment for the us-central1 Cloud Run service
+# `semiotic-mcp-nightly`. The trigger must use this file with the repository
+# root as its build context; do not point it at deploy/cloud-run-nightly.
 #
-# The stable published-release wrapper deliberately remains at deploy/cloud-run.
+# The stable published-release wrapper at deploy/cloud-run targets the separate
+# `semiotic-mcp-server` service in us-west1 and must not use this configuration.
+# The existing `semiotic-mcp` service is legacy and must not use it either.
 substitutions:
-  # The existing trigger supplies its actual identifier here. Keeping a safe
-  # manual default makes an intentional local/manual build label truthful.
+  # A provisioned nightly trigger supplies its actual identifier here. Keeping
+  # a safe manual default makes an intentional local/manual build label truthful.
   _TRIGGER_ID: manual
+  # These service-creation settings must be supplied deliberately for a new
+  # nightly service. Existing service updates do not change them.
+  _NIGHTLY_RUNTIME_SERVICE_ACCOUNT: REQUIRED
+  _NIGHTLY_CPU: "1"
+  _NIGHTLY_MEMORY: 1Gi
+  _NIGHTLY_TIMEOUT: 300s
+  _NIGHTLY_CONCURRENCY: "80"
+  _NIGHTLY_MIN_INSTANCES: "0"
+  _NIGHTLY_MAX_INSTANCES: "3"
+  _NIGHTLY_BOOTSTRAP_HOST: bootstrap.invalid
 
 steps:
   - id: build-nightly-image
@@ -18,7 +30,7 @@ steps:
         build_time="$$(date -u +%Y-%m-%dT%H:%M:%SZ)"
         docker build \
           --file deploy/cloud-run-nightly/Dockerfile \
-          --tag us-west1-docker.pkg.dev/semiotic-mcp/cloud-run-source-deploy/semiotic/semiotic-mcp-server:$COMMIT_SHA \
+          --tag us-central1-docker.pkg.dev/semiotic-mcp/cloud-run-source-deploy/semiotic/semiotic-mcp-nightly:$COMMIT_SHA \
           --build-arg SEMIOTIC_DEPLOYMENT_CHANNEL=nightly \
           --build-arg SEMIOTIC_GIT_SHA=$COMMIT_SHA \
           --build-arg SEMIOTIC_BUILD_ID=$BUILD_ID \
@@ -35,7 +47,7 @@ steps:
       - --rm
       - --entrypoint
       - node
-      - us-west1-docker.pkg.dev/semiotic-mcp/cloud-run-source-deploy/semiotic/semiotic-mcp-server:$COMMIT_SHA
+      - us-central1-docker.pkg.dev/semiotic-mcp/cloud-run-source-deploy/semiotic/semiotic-mcp-nightly:$COMMIT_SHA
       - deploy/cloud-run-nightly/verify-runtime.mjs
       - --require-nightly-build-info
 
@@ -43,24 +55,67 @@ steps:
     name: gcr.io/cloud-builders/docker
     args:
       - push
-      - us-west1-docker.pkg.dev/semiotic-mcp/cloud-run-source-deploy/semiotic/semiotic-mcp-server:$COMMIT_SHA
+      - us-central1-docker.pkg.dev/semiotic-mcp/cloud-run-source-deploy/semiotic/semiotic-mcp-nightly:$COMMIT_SHA
 
-  # `services update` changes only the image and explicitly named labels. It
-  # does not use --set-env-vars, --clear-labels, or service-shaping flags, so
-  # existing MCP_ALLOWED_HOSTS, secrets, IAM, ingress, scaling, resources,
-  # concurrency, timeout, and custom-domain configuration remain intact.
-  - id: deploy-nightly-revision
+  # Existing services receive only an image/label update. On first creation,
+  # a no-traffic revision keeps host validation enabled with a non-routable
+  # bootstrap host; a second revision adds the generated run.app hostname
+  # before traffic is enabled.
+  - id: create-or-update-nightly-revision
     name: gcr.io/cloud-builders/gcloud
+    entrypoint: bash
     args:
-      - run
-      - services
-      - update
-      - semiotic-mcp-server
-      - --project=semiotic-mcp
-      - --region=us-west1
-      - --image=us-west1-docker.pkg.dev/semiotic-mcp/cloud-run-source-deploy/semiotic/semiotic-mcp-server:$COMMIT_SHA
-      - --update-labels=commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=${_TRIGGER_ID},deployment-channel=nightly,deployment-source=repository-main
-      - --quiet
+      - -ceu
+      - |
+        service=semiotic-mcp-nightly
+        region=us-central1
+        image=us-central1-docker.pkg.dev/semiotic-mcp/cloud-run-source-deploy/semiotic/semiotic-mcp-nightly:$COMMIT_SHA
+        labels=commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=${_TRIGGER_ID},deployment-channel=nightly,deployment-source=repository-main
+
+        if gcloud run services describe "$$service" --project=semiotic-mcp --region="$$region" >/dev/null 2>&1; then
+          gcloud run services update "$$service" \
+            --project=semiotic-mcp \
+            --region="$$region" \
+            --image="$$image" \
+            --update-labels="$$labels" \
+            --quiet
+          exit 0
+        fi
+
+        test "${_NIGHTLY_RUNTIME_SERVICE_ACCOUNT}" != REQUIRED
+        gcloud run deploy "$$service" \
+          --project=semiotic-mcp \
+          --region="$$region" \
+          --image="$$image" \
+          --service-account="${_NIGHTLY_RUNTIME_SERVICE_ACCOUNT}" \
+          --allow-unauthenticated \
+          --ingress=all \
+          --cpu="${_NIGHTLY_CPU}" \
+          --memory="${_NIGHTLY_MEMORY}" \
+          --timeout="${_NIGHTLY_TIMEOUT}" \
+          --concurrency="${_NIGHTLY_CONCURRENCY}" \
+          --min-instances="${_NIGHTLY_MIN_INSTANCES}" \
+          --max-instances="${_NIGHTLY_MAX_INSTANCES}" \
+          --set-env-vars="MCP_ALLOWED_HOSTS=${_NIGHTLY_BOOTSTRAP_HOST}" \
+          --update-labels="$$labels" \
+          --no-traffic \
+          --quiet
+
+        endpoint="$$(gcloud run services describe "$$service" \
+          --project=semiotic-mcp --region="$$region" --format='value(status.url)')"
+        hostname="$${endpoint#https://}"
+        test -n "$$hostname"
+        gcloud run services update "$$service" \
+          --project=semiotic-mcp \
+          --region="$$region" \
+          --update-env-vars="MCP_ALLOWED_HOSTS=$$hostname" \
+          --update-labels="$$labels" \
+          --quiet
+        gcloud run services update-traffic "$$service" \
+          --project=semiotic-mcp \
+          --region="$$region" \
+          --to-latest \
+          --quiet
 
   # Resolve the configured service URL without echoing configuration values.
   # /workspace persists across Cloud Build steps but is discarded afterward.
@@ -70,9 +125,9 @@ steps:
     args:
       - -ceu
       - |
-        gcloud run services describe semiotic-mcp-server \
+        gcloud run services describe semiotic-mcp-nightly \
           --project=semiotic-mcp \
-          --region=us-west1 \
+          --region=us-central1 \
           --format='value(status.url)' > /workspace/semiotic-nightly-endpoint
         test -s /workspace/semiotic-nightly-endpoint
 

--- a/deploy/cloud-run-nightly/historical-stable-buildpacks-cloudbuild.yaml
+++ b/deploy/cloud-run-nightly/historical-stable-buildpacks-cloudbuild.yaml
@@ -1,10 +1,10 @@
-# Exact inline-build rollback payload for the existing nightly trigger
-# `rmgpgab-semiotic-mcp-server-us-west1-nteract-semiotic--mafcz`.
+# HISTORICAL STABLE TRIGGER PAYLOAD — NEVER USE FOR NIGHTLY.
 #
-# This is not a stable deployment path. It is retained solely so an operator
-# can restore the trigger's prior generated Buildpacks behavior with
-# `gcloud builds triggers update github ... --inline-config=...` if the checked
-# in repository-built nightly configuration must be rolled back.
+# This archived generated Buildpacks configuration belongs to the stable
+# `semiotic-mcp-server` service in us-west1 and its former Cloud Build trigger.
+# It is kept only as historical evidence for the stable deployment owner. Do
+# not attach it to, use it to roll back, or otherwise apply it to the nightly
+# `semiotic-mcp-nightly` service in us-central1.
 steps:
   - id: Build
     name: gcr.io/k8s-skaffold/pack

--- a/deploy/cloud-run/README.md
+++ b/deploy/cloud-run/README.md
@@ -4,7 +4,7 @@ A thin wrapper that runs the published `semiotic-mcp` server in HTTP (Streamable
 mode as a public, remote MCP server — consumable by ChatGPT, Claude connectors, and any
 MCP client.
 
-This is the **stable release channel** (`semiotic-mcp`). It is the official endpoint
+This is the **stable release channel** (`semiotic-mcp-server` in `us-west1`). It is the official endpoint
 for public users, registries, documentation, and app directories. See
 [`../README.md`](../README.md) for the stable/nightly channel boundary.
 
@@ -62,9 +62,9 @@ fails until a fully resolved lockfile is present.
 
 ```sh
 cd deploy/cloud-run
-gcloud run deploy semiotic-mcp --source . --region us-central1 \
+gcloud run deploy semiotic-mcp-server --source . --region us-west1 \
   --allow-unauthenticated --memory 1Gi \
-  --set-env-vars "MCP_ALLOWED_HOSTS=semiotic-mcp-481507046413.us-central1.run.app"
+  --set-env-vars "MCP_ALLOWED_HOSTS=semiotic-mcp-server-481507046413.us-west1.run.app"
 ```
 
 First run will prompt to enable the Cloud Run / Cloud Build / Artifact Registry APIs —
@@ -83,7 +83,7 @@ git status --short
 cd deploy/cloud-run
 npm ci --ignore-scripts
 npm pkg get dependencies.semiotic
-gcloud run deploy semiotic-mcp --source . --region us-central1 \
+gcloud run deploy semiotic-mcp-server --source . --region us-west1 \
   --allow-unauthenticated --memory 1Gi \
   --set-env-vars "MCP_ALLOWED_HOSTS=YOUR_STABLE_HOST"
 ```
@@ -111,13 +111,14 @@ add `--max-instances N` as a cost ceiling, or `--min-instances 1` to keep it alw
 
 ## Separate nightly deployment
 
-`semiotic-mcp-server` in `us-west1` is the separate **nightly** channel. It is not
-this wrapper and must not share this Buildpacks configuration. Nightly now builds the
+`semiotic-mcp-nightly` in `us-central1` is the separate **nightly** channel. It is not
+this wrapper and must not share this Buildpacks configuration. Nightly builds the
 checked-out repository root with the deterministic Dockerfile and Cloud Build YAML in
 [`../cloud-run-nightly`](../cloud-run-nightly), then updates only the image and
-deployment labels on its existing service.
+deployment labels on that new service. The existing `semiotic-mcp` service is
+legacy and remains untouched until the nightly service passes hosted smoke tests.
 
-The stable `semiotic-mcp` service remains manual/tagged-release only. Its deployment
+The stable `semiotic-mcp-server` service remains manual/tagged-release only. Its deployment
 path stays suitable for exact version parity between npm, the MCP Registry, the Cloud
 Run stable endpoint, the surface manifest, and GitHub Releases.
 
@@ -185,13 +186,13 @@ In the OpenAI domain verification dialog, use the Cloud Run origin as the Challe
 URL, not the MCP path:
 
 ```
-https://semiotic-mcp-481507046413.us-central1.run.app
+https://semiotic-mcp-server-481507046413.us-west1.run.app
 ```
 
 Then put the dialog's token into Cloud Run without committing it:
 
 ```sh
-gcloud run services update semiotic-mcp --region us-central1 \
+gcloud run services update semiotic-mcp-server --region us-west1 \
   --update-env-vars "OPENAI_APPS_CHALLENGE_TOKEN=PASTE_TOKEN_HERE"
 ```
 

--- a/scripts/check-cloud-run-nightly.mjs
+++ b/scripts/check-cloud-run-nightly.mjs
@@ -16,7 +16,9 @@ try {
     dockerfile: read("deploy/cloud-run-nightly/Dockerfile"),
     cloudbuild: read("deploy/cloud-run-nightly/cloudbuild.yaml"),
     verifier: read("deploy/cloud-run-nightly/verify-runtime.mjs"),
-    legacyBuildpacks: read("deploy/cloud-run-nightly/legacy-buildpacks-cloudbuild.yaml"),
+    historicalStableBuildpacks: read(
+      "deploy/cloud-run-nightly/historical-stable-buildpacks-cloudbuild.yaml"
+    )
   })
 
   if (report.errors.length > 0) {
@@ -24,7 +26,9 @@ try {
     process.exitCode = 1
   } else {
     console.log("✓ Nightly Cloud Run deployment configuration passed")
-    console.log(`  service: ${report.manifest.service} (${report.manifest.region})`)
+    console.log(
+      `  service: ${report.manifest.service} (${report.manifest.region})`
+    )
     console.log(`  image: ${report.manifest.image}`)
   }
 } catch (error) {

--- a/scripts/cloud-run-nightly-manifest.test.mjs
+++ b/scripts/cloud-run-nightly-manifest.test.mjs
@@ -15,8 +15,10 @@ function deployment(overrides = {}) {
     dockerfile: read("deploy/cloud-run-nightly/Dockerfile"),
     cloudbuild: read("deploy/cloud-run-nightly/cloudbuild.yaml"),
     verifier: read("deploy/cloud-run-nightly/verify-runtime.mjs"),
-    legacyBuildpacks: read("deploy/cloud-run-nightly/legacy-buildpacks-cloudbuild.yaml"),
-    ...overrides,
+    historicalStableBuildpacks: read(
+      "deploy/cloud-run-nightly/historical-stable-buildpacks-cloudbuild.yaml"
+    ),
+    ...overrides
   }
 }
 
@@ -24,35 +26,97 @@ describe("nightly Cloud Run deployment configuration", () => {
   it("keeps a repository-built Node 22 nightly image and image-only service update", () => {
     const report = validateNightlyCloudRunDeployment(deployment())
     assert.deepEqual(report.errors, [])
-    assert.equal(report.manifest.service, "semiotic-mcp-server")
-    assert.equal(report.manifest.region, "us-west1")
-    assert.match(report.manifest.image, /semiotic-mcp-server:\$COMMIT_SHA$/)
+    assert.equal(report.manifest.service, "semiotic-mcp-nightly")
+    assert.equal(report.manifest.region, "us-central1")
+    assert.equal(
+      report.manifest.image,
+      "us-central1-docker.pkg.dev/semiotic-mcp/cloud-run-source-deploy/semiotic/semiotic-mcp-nightly:$COMMIT_SHA"
+    )
   })
 
   it("rejects a Dockerfile that skips the repository runtime or MCP build", () => {
-    const dockerfile = deployment().dockerfile.replace("  && npm run build:mcp", "")
+    const dockerfile = deployment().dockerfile.replace(
+      "  && npm run build:mcp",
+      ""
+    )
     const report = validateNightlyCloudRunDeployment(deployment({ dockerfile }))
-    assert.equal(report.errors.some((error) => error.includes("build the MCP executable")), true)
+    assert.equal(
+      report.errors.some((error) => error.includes("build the MCP executable")),
+      true
+    )
   })
 
   it("rejects a deployment that would overwrite Cloud Run environment settings", () => {
     const cloudbuild = deployment().cloudbuild.replace(
-      "- --quiet",
-      "- --update-env-vars=MCP_ALLOWED_HOSTS=wrong.example\n      - --quiet",
+      '--update-labels="$$labels"',
+      '--update-env-vars="MCP_ALLOWED_HOSTS=wrong.example" --update-labels="$$labels"'
     )
     const report = validateNightlyCloudRunDeployment(deployment({ cloudbuild }))
-    assert.equal(report.errors.some((error) => error.includes("--update-env-vars")), true)
+    assert.equal(
+      report.errors.some((error) => error.includes("--update-env-vars")),
+      true
+    )
+  })
+
+  it("rejects a deployment that changes the existing request timeout", () => {
+    const cloudbuild = deployment().cloudbuild.replace(
+      '--update-labels="$$labels"',
+      '--timeout=900 --update-labels="$$labels"'
+    )
+    const report = validateNightlyCloudRunDeployment(deployment({ cloudbuild }))
+    assert.equal(
+      report.errors.some((error) => error.includes("--timeout=")),
+      true
+    )
   })
 
   it("rejects replacing all service labels instead of updating provenance labels", () => {
-    const cloudbuild = deployment().cloudbuild.replace("--update-labels=commit-sha", "--labels=commit-sha")
+    const cloudbuild = deployment().cloudbuild.replace(
+      '--update-labels="$$labels"',
+      '--labels="$$labels"'
+    )
     const report = validateNightlyCloudRunDeployment(deployment({ cloudbuild }))
-    assert.equal(report.errors.some((error) => error.includes("identity labels")), true)
+    assert.equal(
+      report.errors.some((error) => error.includes("--labels=")),
+      true
+    )
+  })
+
+  it("rejects a deployment that points the nightly config at the stable service", () => {
+    const cloudbuild = deployment().cloudbuild.replace(
+      "service=semiotic-mcp-nightly",
+      "service=semiotic-mcp-server"
+    )
+    const report = validateNightlyCloudRunDeployment(deployment({ cloudbuild }))
+    assert.equal(
+      report.errors.some((error) => error.includes("stable service")),
+      true
+    )
+  })
+
+  it("rejects a deployment that points the nightly config at the legacy service", () => {
+    const cloudbuild = deployment().cloudbuild.replace(
+      "service=semiotic-mcp-nightly",
+      "service=semiotic-mcp\n"
+    )
+    const report = validateNightlyCloudRunDeployment(deployment({ cloudbuild }))
+    assert.equal(
+      report.errors.some((error) => error.includes("legacy service")),
+      true
+    )
   })
 
   it("rejects an artifact verifier that would permit the published package implementation", () => {
-    const verifier = deployment().verifier.replace('"unexpected-published-semiotic-package"', '"published-package-allowed"')
+    const verifier = deployment().verifier.replace(
+      '"unexpected-published-semiotic-package"',
+      '"published-package-allowed"'
+    )
     const report = validateNightlyCloudRunDeployment(deployment({ verifier }))
-    assert.equal(report.errors.some((error) => error.includes("unexpected-published-semiotic-package")), true)
+    assert.equal(
+      report.errors.some((error) =>
+        error.includes("unexpected-published-semiotic-package")
+      ),
+      true
+    )
   })
 })

--- a/scripts/lib/cloud-run-nightly-manifest.mjs
+++ b/scripts/lib/cloud-run-nightly-manifest.mjs
@@ -7,9 +7,10 @@
  * this repository and updates only the existing nightly service image/labels.
  */
 
-export const NIGHTLY_IMAGE = "us-west1-docker.pkg.dev/semiotic-mcp/cloud-run-source-deploy/semiotic/semiotic-mcp-server:$COMMIT_SHA"
-export const NIGHTLY_SERVICE = "semiotic-mcp-server"
-export const NIGHTLY_REGION = "us-west1"
+export const NIGHTLY_IMAGE =
+  "us-central1-docker.pkg.dev/semiotic-mcp/cloud-run-source-deploy/semiotic/semiotic-mcp-nightly:$COMMIT_SHA"
+export const NIGHTLY_SERVICE = "semiotic-mcp-nightly"
+export const NIGHTLY_REGION = "us-central1"
 
 function has(source, fragment) {
   return typeof source === "string" && source.includes(fragment)
@@ -17,13 +18,6 @@ function has(source, fragment) {
 
 function requireFragment(errors, source, fragment, message) {
   if (!has(source, fragment)) errors.push(message)
-}
-
-function forbidYamlArgument(errors, source, argument, message) {
-  const escaped = argument.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-  if (new RegExp(`^\\s*-\\s+${escaped}(?:=|\\s|$)`, "m").test(source)) {
-    errors.push(message)
-  }
 }
 
 function inOrder(source, fragments) {
@@ -35,37 +29,48 @@ function inOrder(source, fragments) {
   return true
 }
 
+function between(source, start, end) {
+  const startIndex = source.indexOf(start)
+  if (startIndex === -1) return ""
+  const endIndex = source.indexOf(end, startIndex)
+  return endIndex === -1 ? "" : source.slice(startIndex, endIndex)
+}
+
 /**
  * Validate the checked-in Dockerfile, Cloud Build configuration, final-image
- * verifier, and rollback payload. Inputs are strings to make regression tests
- * safe and completely independent of Google Cloud access.
+ * verifier, and archived stable Buildpacks payload. Inputs are strings to
+ * make regression tests safe and completely independent of Google Cloud
+ * access.
  */
 export function validateNightlyCloudRunDeployment({
   dockerfile,
   cloudbuild,
   verifier,
-  legacyBuildpacks,
+  historicalStableBuildpacks
 }) {
   const errors = []
 
   if (typeof dockerfile !== "string") {
     errors.push("deploy/cloud-run-nightly/Dockerfile must be readable")
   } else {
-    const node22Stages = dockerfile.match(/FROM node:22-bookworm-slim AS /g) ?? []
+    const node22Stages =
+      dockerfile.match(/FROM node:22-bookworm-slim AS /g) ?? []
     if (node22Stages.length < 2) {
-      errors.push("nightly Dockerfile must use Node.js 22 for both build and runtime stages")
+      errors.push(
+        "nightly Dockerfile must use Node.js 22 for both build and runtime stages"
+      )
     }
     requireFragment(
       errors,
       dockerfile,
       "COPY package.json package-lock.json .npmrc ./",
-      "nightly Dockerfile must copy the repository package manifest, lockfile, and npm configuration before install",
+      "nightly Dockerfile must copy the repository package manifest, lockfile, and npm configuration before install"
     )
     requireFragment(
       errors,
       dockerfile,
       "RUN npm ci --include=dev",
-      "nightly Dockerfile must install exact lockfile dependencies with npm ci",
+      "nightly Dockerfile must install exact lockfile dependencies with npm ci"
     )
     for (const fragment of [
       "COPY src ./src",
@@ -73,17 +78,25 @@ export function validateNightlyCloudRunDeployment({
       "scripts/build.mjs",
       "scripts/build-mcp.mjs",
       "scripts/generate-ai-surface-manifest.mjs",
-      "COPY tsconfig.json tsconfig.declarations.json ./",
+      "COPY tsconfig.json tsconfig.declarations.json ./"
     ]) {
       requireFragment(
         errors,
         dockerfile,
         fragment,
-        `nightly Dockerfile is missing required repository build input: ${fragment}`,
+        `nightly Dockerfile is missing required repository build input: ${fragment}`
       )
     }
-    if (!inOrder(dockerfile, ["npm run check:ai-surface", "npm run dist:prod", "npm run build:mcp"])) {
-      errors.push("nightly Dockerfile must check the generated AI surface, build package runtime artifacts, then build the MCP executable")
+    if (
+      !inOrder(dockerfile, [
+        "npm run check:ai-surface",
+        "npm run dist:prod",
+        "npm run build:mcp"
+      ])
+    ) {
+      errors.push(
+        "nightly Dockerfile must check the generated AI surface, build package runtime artifacts, then build the MCP executable"
+      )
     }
     for (const fragment of [
       "COPY --from=build /app/node_modules ./node_modules",
@@ -93,22 +106,24 @@ export function validateNightlyCloudRunDeployment({
       "ARG SEMIOTIC_GIT_SHA",
       "ARG SEMIOTIC_BUILD_ID",
       "ARG SEMIOTIC_BUILD_TIME",
-      "SEMIOTIC_DEPLOYMENT_CHANNEL=\"${SEMIOTIC_DEPLOYMENT_CHANNEL}\"",
-      "SEMIOTIC_GIT_SHA=\"${SEMIOTIC_GIT_SHA}\"",
-      "SEMIOTIC_BUILD_ID=\"${SEMIOTIC_BUILD_ID}\"",
-      "SEMIOTIC_BUILD_TIME=\"${SEMIOTIC_BUILD_TIME}\"",
+      'SEMIOTIC_DEPLOYMENT_CHANNEL="${SEMIOTIC_DEPLOYMENT_CHANNEL}"',
+      'SEMIOTIC_GIT_SHA="${SEMIOTIC_GIT_SHA}"',
+      'SEMIOTIC_BUILD_ID="${SEMIOTIC_BUILD_ID}"',
+      'SEMIOTIC_BUILD_TIME="${SEMIOTIC_BUILD_TIME}"',
       "RUN node deploy/cloud-run-nightly/verify-runtime.mjs --require-nightly-build-info",
-      "node ai/dist/mcp-server.js --http --host 0.0.0.0 --port \\\"${PORT:-8080}\\\" --profile public",
+      'node ai/dist/mcp-server.js --http --host 0.0.0.0 --port \\"${PORT:-8080}\\" --profile public'
     ]) {
       requireFragment(
         errors,
         dockerfile,
         fragment,
-        `nightly Dockerfile is missing required runtime contract: ${fragment}`,
+        `nightly Dockerfile is missing required runtime contract: ${fragment}`
       )
     }
     if (/npm\s+(?:install|i)\s+[^\n]*\bsemiotic\b/.test(dockerfile)) {
-      errors.push("nightly Dockerfile must not install a published semiotic package as its application implementation")
+      errors.push(
+        "nightly Dockerfile must not install a published semiotic package as its application implementation"
+      )
     }
   }
 
@@ -127,13 +142,13 @@ export function validateNightlyCloudRunDeployment({
       'requireFromRoot("semiotic/server")',
       'requireFromRoot("semiotic/ai")',
       'requireFromRoot("semiotic/geo")',
-      '"--require-nightly-build-info"',
+      '"--require-nightly-build-info"'
     ]) {
       requireFragment(
         errors,
         verifier,
         fragment,
-        `nightly runtime verifier is missing required artifact/self-import check: ${fragment}`,
+        `nightly runtime verifier is missing required artifact/self-import check: ${fragment}`
       )
     }
   }
@@ -143,6 +158,8 @@ export function validateNightlyCloudRunDeployment({
   } else {
     for (const fragment of [
       "_TRIGGER_ID: manual",
+      "_NIGHTLY_RUNTIME_SERVICE_ACCOUNT: REQUIRED",
+      "_NIGHTLY_BOOTSTRAP_HOST: bootstrap.invalid",
       "id: build-nightly-image",
       "docker build \\",
       "--file deploy/cloud-run-nightly/Dockerfile",
@@ -155,79 +172,122 @@ export function validateNightlyCloudRunDeployment({
       "--require-nightly-build-info",
       "id: push-nightly-image",
       "- push",
-      "id: deploy-nightly-revision",
-      "- run",
-      "- services",
-      "- update",
-      `- ${NIGHTLY_IMAGE}`,
-      `--image=${NIGHTLY_IMAGE}`,
-      `- ${NIGHTLY_SERVICE}`,
-      `- --region=${NIGHTLY_REGION}`,
-      "--update-labels=commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=${_TRIGGER_ID},deployment-channel=nightly,deployment-source=repository-main",
+      "id: create-or-update-nightly-revision",
+      `service=${NIGHTLY_SERVICE}`,
+      `region=${NIGHTLY_REGION}`,
+      `image=${NIGHTLY_IMAGE}`,
+      'gcloud run services update "$$service"',
+      'gcloud run deploy "$$service"',
+      '--service-account="${_NIGHTLY_RUNTIME_SERVICE_ACCOUNT}"',
+      "--allow-unauthenticated",
+      "--ingress=all",
+      '--set-env-vars="MCP_ALLOWED_HOSTS=${_NIGHTLY_BOOTSTRAP_HOST}"',
+      "--no-traffic",
+      'hostname="$${endpoint#https://}"',
+      '--update-env-vars="MCP_ALLOWED_HOSTS=$$hostname"',
+      'gcloud run services update-traffic "$$service"',
+      "--to-latest",
+      "labels=commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=${_TRIGGER_ID},deployment-channel=nightly,deployment-source=repository-main",
+      '--update-labels="$$labels"',
       "node scripts/smoke-hosted-mcp.mjs",
       "--expected-channel nightly",
       '--expected-sha "$COMMIT_SHA"',
       '--expected-build-id "$BUILD_ID"',
       "timeout: 1800s",
-      "logging: CLOUD_LOGGING_ONLY",
+      "logging: CLOUD_LOGGING_ONLY"
     ]) {
       requireFragment(
         errors,
         cloudbuild,
         fragment,
-        `nightly Cloud Build configuration is missing required deployment contract: ${fragment}`,
+        `nightly Cloud Build configuration is missing required deployment contract: ${fragment}`
       )
     }
-    if (!inOrder(cloudbuild, [
-      "id: build-nightly-image",
-      "id: verify-nightly-runtime-image",
-      "id: push-nightly-image",
-      "id: deploy-nightly-revision",
-      "id: smoke-nightly-deployment",
-    ])) {
-      errors.push("nightly Cloud Build steps must build, verify, push, deploy, then smoke test in that order")
-    }
-    for (const fragment of [
-      "deploy",
-      "--set-env-vars",
-      "--update-env-vars",
-      "--clear-env-vars",
-      "--set-secrets",
-      "--update-secrets",
-      "--clear-secrets",
-      "--clear-labels",
-      "--memory=",
-      "--cpu=",
-      "--concurrency=",
-      "--ingress=",
-      "--allow-unauthenticated",
-    ]) {
-      forbidYamlArgument(
-        errors,
-        cloudbuild,
-        fragment,
-        `nightly Cloud Build must preserve existing service settings and may not use ${fragment}`,
+    if (
+      !inOrder(cloudbuild, [
+        "id: build-nightly-image",
+        "id: verify-nightly-runtime-image",
+        "id: push-nightly-image",
+        "id: create-or-update-nightly-revision",
+        "id: smoke-nightly-deployment"
+      ])
+    ) {
+      errors.push(
+        "nightly Cloud Build steps must build, verify, push, deploy, then smoke test in that order"
       )
     }
-    if (/^\s*-\s+--labels=/m.test(cloudbuild)) {
-      errors.push("nightly Cloud Build must add/update identity labels instead of replacing all service labels")
+    const existingServiceUpdate = between(
+      cloudbuild,
+      'if gcloud run services describe "$$service"',
+      "exit 0"
+    )
+    if (!existingServiceUpdate) {
+      errors.push(
+        "nightly Cloud Build must retain an existing-service image-only update branch"
+      )
+    } else {
+      for (const forbidden of [
+        "--set-env-vars",
+        "--update-env-vars",
+        "--clear-env-vars",
+        "--set-secrets",
+        "--update-secrets",
+        "--clear-secrets",
+        "--clear-labels",
+        "--labels=",
+        "--memory=",
+        "--cpu=",
+        "--concurrency=",
+        "--timeout=",
+        "--min-instances=",
+        "--max-instances=",
+        "--service-account=",
+        "--ingress=",
+        "--allow-unauthenticated"
+      ]) {
+        if (has(existingServiceUpdate, forbidden)) {
+          errors.push(
+            `nightly existing-service update must preserve settings and may not use ${forbidden}`
+          )
+        }
+      }
+    }
+    if (has(cloudbuild, "service=semiotic-mcp-server")) {
+      errors.push("nightly Cloud Build must not target the stable service")
+    }
+    if (
+      has(cloudbuild, "service=semiotic-mcp\n") ||
+      has(cloudbuild, "/semiotic-mcp:$COMMIT_SHA")
+    ) {
+      errors.push("nightly Cloud Build must not target the legacy service")
+    }
+    if (
+      has(cloudbuild, "us-west1-docker.pkg.dev") ||
+      has(cloudbuild, "region=us-west1")
+    ) {
+      errors.push("nightly Cloud Build must not target the stable region")
     }
   }
 
-  if (typeof legacyBuildpacks !== "string") {
-    errors.push("deploy/cloud-run-nightly/legacy-buildpacks-cloudbuild.yaml must be readable")
+  if (typeof historicalStableBuildpacks !== "string") {
+    errors.push(
+      "deploy/cloud-run-nightly/historical-stable-buildpacks-cloudbuild.yaml must be readable"
+    )
   } else {
     for (const fragment of [
+      "HISTORICAL STABLE TRIGGER PAYLOAD — NEVER USE FOR NIGHTLY",
       "gcr.io/k8s-skaffold/pack",
       "--builder=gcr.io/buildpacks/builder:google-22",
       "--path=deploy/cloud-run",
-      "_TRIGGER_ID: 36c05cdd-221d-4c1b-a383-a8117cea4556",
+      "_SERVICE_NAME: semiotic-mcp-server",
+      "_DEPLOY_REGION: us-west1",
+      "_TRIGGER_ID: 36c05cdd-221d-4c1b-a383-a8117cea4556"
     ]) {
       requireFragment(
         errors,
-        legacyBuildpacks,
+        historicalStableBuildpacks,
         fragment,
-        `nightly legacy trigger rollback payload is missing: ${fragment}`,
+        `historical stable trigger payload is missing: ${fragment}`
       )
     }
   }
@@ -237,7 +297,7 @@ export function validateNightlyCloudRunDeployment({
     manifest: {
       image: NIGHTLY_IMAGE,
       service: NIGHTLY_SERVICE,
-      region: NIGHTLY_REGION,
-    },
+      region: NIGHTLY_REGION
+    }
   }
 }


### PR DESCRIPTION
Reworks nightly deployment to target a dedicated `semiotic-mcp-nightly` service in `us-central1`, including a safer first-deploy flow that bootstraps `MCP_ALLOWED_HOSTS` with no-traffic creation before enabling traffic. Updates deployment docs and stable/nightly channel boundaries, renames the old Buildpacks file to a historical stable artifact, and expands nightly manifest validation/tests to enforce image/service/region contracts and prevent accidental stable or legacy service mutation.
