### PR TITLE
Add HRA/WPP pilot and upgrade MCP to 3.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The HRA/WPP typology pilot now runs on the real kidney ASCT+B v1.6
+  digital object.** A pinned generator produces a checked-in, workshop-ready
+  artifact for the observed direct children of kidney, with ontology IDs kept
+  as semantic keys, provisional cell-type review signals kept separate from
+  measured counts, and a public `/interoperability/hra-wpp` walkthrough. The
+  actual data exposed the pilot's first failure case: distinct ontology concepts
+  share labels, while mixing parent and descendant rows turns hierarchy into a
+  misleading rank. A focused regression test pins both corrections.
+- **MCP `3.8.6` distribution is verified end to end.** The official
+  `io.github.nteract/semiotic` Registry entry marks `3.8.6` latest, and stable
+  Cloud Run revision `semiotic-mcp-server-00071-2rw` now serves the exact
+  release with commit/build identity. The production smoke passes health,
+  initialize, public tools, resources/build-info, render evidence, and schema
+  retrieval. Its initialize assertion is now channel-aware: stable requires
+  `semiotic` plus the exact package version, while nightly retains the
+  commit-qualified `semiotic-nightly` contract.
 - **MCP Registry publication now follows every release instead of one pinned
   version.** The reusable publisher derives the exact version from the checked-out
   package manifest, runs only after npm publication, and remains manually

--- a/MCP_DISTRIBUTION.md
+++ b/MCP_DISTRIBUTION.md
@@ -8,14 +8,28 @@ from third-party directory cards that may cache or rewrite project metadata.
 | Path | Status | Source of truth | Freshness mechanism |
 | --- | --- | --- | --- |
 | npm stdio | `npx semiotic-mcp` from the `semiotic` package | `package.json` and the published npm artifact | The release workflow publishes and smoke-tests the exact immutable tarball. |
-| Stable Streamable HTTP | `https://semiotic-mcp-server-481507046413.us-west1.run.app/mcp` | `server.json` and `deploy/cloud-run` | Hosted smoke tests cover initialize, tools, resources, prompts, limits, and response headers. |
+| Stable Streamable HTTP | `https://semiotic-mcp-server-481507046413.us-west1.run.app/mcp` serves verified `3.8.6` | `server.json` and `deploy/cloud-run` | Hosted smoke tests cover initialize, tools, resources, prompts, limits, and response headers. |
 | Official MCP Registry | `io.github.nteract/semiotic` | `server.json` | After npm publication, the release workflow validates and publishes the exact `package.json` / `server.json` version, then verifies the active Registry entry. Manual dispatch remains available for backfill. |
 
-At this audit, the Official Registry returned active entries for `3.4.2` and
-`3.8.1`, with `3.8.1` marked latest. Source and npm are currently `3.8.6`; the
-release-called workflow removes the former one-off `3.8.1` pin. A manual
-workflow dispatch after this change lands can backfill `3.8.6`; subsequent
-releases publish their exact manifest version automatically.
+The Registry metadata backfill is complete. At
+`2026-07-26T06:07:39.980185Z`
+(`2026-07-25` in the project timezone), the Official Registry returned active
+entries for `3.4.2`, `3.8.1`, and `3.8.6`, with `3.8.6` marked latest. Its
+package is the exact immutable npm release `semiotic@3.8.6`, and its remote is
+the canonical Streamable HTTP endpoint above.
+
+An end-to-end production smoke immediately after that verification found and
+closed a separate deployment drift: the remote still served `3.8.1` and omitted
+required build identity. Stable revision `semiotic-mcp-server-00071-2rw` now
+serves `3.8.6` with release commit
+`315d9b43169391b66fe26510c6460d147fe7e3ea`, and the full smoke passes health,
+MCP GET, initialize, tools, resources, build-info, render evidence, and schema
+retrieval. The smoke runner is channel-aware so stable requires the exact
+published version while nightly still requires its commit-qualified version.
+The revision labels carry the same release commit/version and remove stale
+prior-trigger provenance.
+Subsequent releases publish their exact Registry manifest version
+automatically; manual Registry dispatch remains a recovery path.
 
 Run the local cross-reference gate before a release:
 

--- a/deploy/cloud-run/README.md
+++ b/deploy/cloud-run/README.md
@@ -38,7 +38,7 @@ arbitrary commits from `main`.
 
 ### Lockfile status
 
-The wrapper pins the published `semiotic@3.8.1` release and includes a generated
+The wrapper pins the published `semiotic@3.8.6` release and includes a generated
 `package-lock.json`. Cloud Buildpacks receives that lockfile because `.gcloudignore` excludes
 only `node_modules`.
 
@@ -86,18 +86,30 @@ git status --short
 cd deploy/cloud-run
 npm ci --ignore-scripts
 npm pkg get dependencies.semiotic
+SEMIOTIC_RELEASE_SHA="$(git rev-list -n 1 vX.Y.Z)"
+SEMIOTIC_RELEASE_BUILT_AT="$(node -e 'process.stdout.write(new Date(process.argv[1]).toISOString())' "$(git show -s --format=%cI vX.Y.Z)")"
 gcloud run deploy semiotic-mcp-server --source . --region us-west1 \
   --allow-unauthenticated --memory 1Gi \
-  --set-env-vars "MCP_ALLOWED_HOSTS=YOUR_STABLE_HOST"
+  --update-labels "commit-sha=${SEMIOTIC_RELEASE_SHA},managed-by=manual-stable-release,release-version=X-Y-Z" \
+  --remove-labels "gcb-build-id,gcb-trigger-id,gcb-trigger-region" \
+  --update-env-vars "MCP_ALLOWED_HOSTS=YOUR_STABLE_HOST,SEMIOTIC_DEPLOYMENT_CHANNEL=stable,SEMIOTIC_GIT_SHA=${SEMIOTIC_RELEASE_SHA},SEMIOTIC_BUILD_ID=release-vX.Y.Z,SEMIOTIC_BUILD_TIME=${SEMIOTIC_RELEASE_BUILT_AT}"
+
+node ../../scripts/smoke-hosted-mcp.mjs \
+  --endpoint https://YOUR_STABLE_HOST \
+  --expected-channel stable \
+  --expected-sha "${SEMIOTIC_RELEASE_SHA}" \
+  --expected-build-id release-vX.Y.Z
 ```
 
 `git status --short` must be empty, and `npm pkg get dependencies.semiotic` must
 print the exact published release version represented by the tag (for example,
-`"3.8.1"`, never a range). If deploying from a reviewed release commit instead
+`"3.8.6"`, never a range). If deploying from a reviewed release commit instead
 of a tag, substitute that full commit SHA for `vX.Y.Z` only after confirming
 that the wrapper's exact dependency and lockfile match the intended published
 npm artifact. This keeps npm, the stable Cloud Run revision, registry metadata,
-the surface manifest, and GitHub Release on one release identity.
+the surface manifest, and GitHub Release on one release identity. The Node
+one-liner normalizes the tag timestamp to the ISO UTC form required by the
+hosted smoke.
 
 ### Why these flags
 
@@ -219,7 +231,6 @@ ChatGPT: add it as a connector / app using the `/mcp` URL.
 When a new `semiotic` is published, bump the pinned `semiotic` version in `package.json`,
 generate and verify the lockfile as above, then re-run the same `gcloud run deploy` command.
 Cloud Buildpacks will receive the committed lockfile and install the exact dependency graph.
-If release provenance is available, set the `SEMIOTIC_*` build-identity variables with an
-additive `gcloud run services update --update-env-vars ...` command after the manual stable
-release deploy; this does not require building repository source and should never make the
-stable service track `main`.
+Release provenance is required for the post-deploy smoke: set the `SEMIOTIC_*`
+build-identity variables with additive `--update-env-vars` during the manual
+stable deploy. The stable service must never track arbitrary `main` commits.

--- a/deploy/cloud-run/package-lock.json
+++ b/deploy/cloud-run/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "react": "19.2.0",
         "react-dom": "19.2.0",
-        "semiotic": "3.8.1"
+        "semiotic": "3.8.6"
       },
       "engines": {
         "node": "22"
@@ -1268,12 +1268,6 @@
         "react": "^19.2.0"
       }
     },
-    "node_modules/regression": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/regression/-/regression-2.0.1.tgz",
-      "integrity": "sha512-A4XYsc37dsBaNOgEjkJKzfJlE394IMmUPlI/p3TTI9u3T+2a+eox5Pr/CPUqF0eszeWZJPAc6QkroAhuUpWDJQ==",
-      "license": "MIT"
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -1304,9 +1298,9 @@
       "license": "MIT"
     },
     "node_modules/semiotic": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/semiotic/-/semiotic-3.8.1.tgz",
-      "integrity": "sha512-jwp0UB4heXuDGAoOlLHeDqTkE3J81PpLAzmh/5ElLnW3LSXAsHoq6TAmX+RPi/ei2h090o8lprLZLF/Cwx68wg==",
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/semiotic/-/semiotic-3.8.6.tgz",
+      "integrity": "sha512-BULIYds1fobntFf+hIzKADpkfZ567VugJG3adsppk2worWdqdYl+L6HyR/Y/spGBZJn1tHWkqyfP3uIVq1HktA==",
       "license": "Apache-2.0",
       "dependencies": {
         "d3-array": "^3.2.4",
@@ -1321,7 +1315,6 @@
         "d3-selection": "^3.0.0",
         "d3-shape": "^3.2.0",
         "d3-zoom": "^3.0.0",
-        "regression": "^2.0.1",
         "topojson-client": "^3.1.0"
       },
       "bin": {
@@ -1341,6 +1334,7 @@
         "matter-js": "^0.20.0",
         "react": "^18.1.0 || ^19.0.0",
         "react-dom": "^18.1.0 || ^19.0.0",
+        "roughjs": "^4.6.6",
         "world-atlas": "^2.0.2"
       },
       "peerDependenciesMeta": {
@@ -1348,6 +1342,9 @@
           "optional": true
         },
         "matter-js": {
+          "optional": true
+        },
+        "roughjs": {
           "optional": true
         },
         "world-atlas": {

--- a/deploy/cloud-run/package.json
+++ b/deploy/cloud-run/package.json
@@ -12,6 +12,6 @@
   "dependencies": {
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "semiotic": "3.8.1"
+    "semiotic": "3.8.6"
   }
 }

--- a/docs/src/App.jsx
+++ b/docs/src/App.jsx
@@ -152,6 +152,7 @@ const ConferenceDemoPage = lazy(() => import("./pages/features/ConferenceDemoPag
 const TemporalLifecyclePage = lazy(() => import("./pages/features/TemporalLifecyclePage"))
 const PortabilitySpecPage = lazy(() => import("./pages/features/PortabilitySpecPage"))
 const VACPPage = lazy(() => import("./pages/features/VACPPage"))
+const HraWppPilotPage = lazy(() => import("./pages/features/HraWppPilotPage"))
 const DataQualityBridgePage = lazy(() => import("./pages/features/DataQualityBridgePage"))
 const GenerativeUIPage = lazy(() => import("./pages/features/GenerativeUIPage"))
 const ObservablePlotPage = lazy(() => import("./pages/features/ObservablePlotPage"))
@@ -830,6 +831,7 @@ export default function DocsApp() {
                 <Route path="overview" element={<InteroperabilityPage />} />
                 <Route path="portability-spec" element={<PortabilitySpecPage />} />
                 <Route path="vacp" element={<VACPPage />} />
+                <Route path="hra-wpp" element={<HraWppPilotPage />} />
                 <Route path="vega-lite" element={<VegaLiteTranslatorPage />} />
                 <Route path="observable-plot" element={<ObservablePlotPage />} />
                 <Route path="flint-chart" element={<FlintChartAdapterPage />} />

--- a/docs/src/components/navData.js
+++ b/docs/src/components/navData.js
@@ -265,6 +265,7 @@ const navData = [
       { title: "Overview", path: "/interoperability/overview" },
       { title: "Portability Spec", path: "/interoperability/portability-spec" },
       { title: "VACP Bridge", path: "/interoperability/vacp" },
+      { title: "HRA/WPP Typology Pilot", path: "/interoperability/hra-wpp" },
       { title: "Vega-Lite", path: "/interoperability/vega-lite" },
       { title: "Observable Plot", path: "/interoperability/observable-plot" },
       { title: "Flint Chart", path: "/interoperability/flint-chart" },

--- a/docs/src/data/hra-wpp-kidney-v1.6-pilot.json
+++ b/docs/src/data/hra-wpp-kidney-v1.6-pilot.json
@@ -1,0 +1,162 @@
+{
+  "kind": "semiotic-hra-wpp-kidney-pilot",
+  "schemaVersion": 1,
+  "source": {
+    "purl": "https://purl.humanatlas.io/asct-b/kidney/v1.6",
+    "version": "v1.6",
+    "creationDate": "2026-06-08",
+    "publisher": "HuBMAP",
+    "license": "https://creativecommons.org/licenses/by/4.0/",
+    "seeAlso": "https://lod.humanatlas.io/asct-b/kidney/v1.6",
+    "derivedFrom": "https://lod.humanatlas.io/asct-b/kidney/v1.6#raw-data"
+  },
+  "methodology": {
+    "scope": "Observed direct children of kidney (UBERON:0002113)",
+    "identity": "Ontology identifiers are semantic keys; labels are display text only.",
+    "aggregation": "For each ASCT+B record, distinct cell types are associated with every anatomical structure in that record's path, then deduplicated per structure.",
+    "caveats": [
+      "Counts are set memberships and are not additive across anatomical structures.",
+      "A record can contribute to more than one hierarchy path.",
+      "Parent and descendant rows must not be ranked together as independent categories."
+    ]
+  },
+  "summary": {
+    "recordCount": 78,
+    "declaredAnatomicalStructureCount": 67,
+    "observedAnatomicalStructureCount": 61,
+    "declaredCellTypeCount": 72,
+    "observedCellTypeCount": 70,
+    "provisionalAnatomicalStructureCount": 2,
+    "provisionalCellTypeCount": 3
+  },
+  "chartRows": [
+    {
+      "anatomicalStructureId": "UBERON:0001285",
+      "anatomicalStructureLabel": "nephron",
+      "displayLabel": "nephron · UBERON:0001285",
+      "cellTypeCount": 25,
+      "temporaryCellTypeCount": 0,
+      "recordCount": 25,
+      "structureIsProvisional": false
+    },
+    {
+      "anatomicalStructureId": "UBERON:0005215",
+      "anatomicalStructureLabel": "Interstitium",
+      "displayLabel": "Interstitium · UBERON:0005215",
+      "cellTypeCount": 22,
+      "temporaryCellTypeCount": 1,
+      "recordCount": 21,
+      "structureIsProvisional": false
+    },
+    {
+      "anatomicalStructureId": "UBERON:0004100",
+      "anatomicalStructureLabel": "renal collecting system",
+      "displayLabel": "renal collecting system · UBERON:0004100",
+      "cellTypeCount": 11,
+      "temporaryCellTypeCount": 1,
+      "recordCount": 12,
+      "structureIsProvisional": false
+    },
+    {
+      "anatomicalStructureId": "UBERON:0006544",
+      "anatomicalStructureLabel": "Vessels",
+      "displayLabel": "Vessels · UBERON:0006544",
+      "cellTypeCount": 10,
+      "temporaryCellTypeCount": 0,
+      "recordCount": 10,
+      "structureIsProvisional": false
+    },
+    {
+      "anatomicalStructureId": "UBERON:0000362",
+      "anatomicalStructureLabel": "renal medulla",
+      "displayLabel": "renal medulla · UBERON:0000362",
+      "cellTypeCount": 4,
+      "temporaryCellTypeCount": 0,
+      "recordCount": 5,
+      "structureIsProvisional": false
+    },
+    {
+      "anatomicalStructureId": "UBERON:0001225",
+      "anatomicalStructureLabel": "cortex of kidney",
+      "displayLabel": "cortex of kidney · UBERON:0001225",
+      "cellTypeCount": 2,
+      "temporaryCellTypeCount": 0,
+      "recordCount": 4,
+      "structureIsProvisional": false
+    },
+    {
+      "anatomicalStructureId": "UBERON:0001228",
+      "anatomicalStructureLabel": "renal papilla",
+      "displayLabel": "renal papilla · UBERON:0001228",
+      "cellTypeCount": 2,
+      "temporaryCellTypeCount": 0,
+      "recordCount": 2,
+      "structureIsProvisional": false
+    },
+    {
+      "anatomicalStructureId": "UBERON:0002015",
+      "anatomicalStructureLabel": "kidney capsule",
+      "displayLabel": "kidney capsule · UBERON:0002015",
+      "cellTypeCount": 2,
+      "temporaryCellTypeCount": 1,
+      "recordCount": 1,
+      "structureIsProvisional": false
+    }
+  ],
+  "reviewRows": [
+    {
+      "anatomicalStructureId": "UBERON:0005215",
+      "anatomicalStructureLabel": "Interstitium",
+      "displayLabel": "Interstitium · UBERON:0005215",
+      "cellTypeCount": 22,
+      "temporaryCellTypeCount": 1,
+      "recordCount": 21,
+      "structureIsProvisional": false
+    },
+    {
+      "anatomicalStructureId": "UBERON:0004100",
+      "anatomicalStructureLabel": "renal collecting system",
+      "displayLabel": "renal collecting system · UBERON:0004100",
+      "cellTypeCount": 11,
+      "temporaryCellTypeCount": 1,
+      "recordCount": 12,
+      "structureIsProvisional": false
+    },
+    {
+      "anatomicalStructureId": "UBERON:0002015",
+      "anatomicalStructureLabel": "kidney capsule",
+      "displayLabel": "kidney capsule · UBERON:0002015",
+      "cellTypeCount": 2,
+      "temporaryCellTypeCount": 1,
+      "recordCount": 1,
+      "structureIsProvisional": false
+    }
+  ],
+  "findings": {
+    "observedLabelCollisions": [
+      {
+        "label": "Endothelium (non glomerular)",
+        "ids": [
+          "UBERON:0001986",
+          "UBERON:0002042",
+          "UBERON:0012441"
+        ]
+      },
+      {
+        "label": "Loop of Henle (Thin Limb)",
+        "ids": [
+          "UBERON:0001289",
+          "UBERON:0004193"
+        ]
+      },
+      {
+        "label": "Tubules",
+        "ids": [
+          "UBERON:0001231",
+          "UBERON:0001232"
+        ]
+      }
+    ],
+    "hierarchyFailure": "Ranking the kidney root beside descendants makes the largest bar a hierarchy artifact and implies independent categories. The pilot therefore limits the chart to one explicit sibling scope."
+  }
+}

--- a/docs/src/pages/features/HraWppPilotPage.jsx
+++ b/docs/src/pages/features/HraWppPilotPage.jsx
@@ -53,7 +53,7 @@ const sourceCode = `import { BarChart } from "semiotic/ordinal"
 
 function ExternalLink({ href, children }) {
   return (
-    <a href={href} target="_blank" rel="noreferrer">
+    <a href={href} target="_blank" rel="noreferrer noopener">
       {children}
     </a>
   )

--- a/docs/src/pages/features/HraWppPilotPage.jsx
+++ b/docs/src/pages/features/HraWppPilotPage.jsx
@@ -35,15 +35,19 @@ const tableCellStyle = {
 
 const sourceCode = `import { BarChart } from "semiotic/ordinal"
 
-<BarChart
-  data={kidneyDirectChildren}
-  categoryAccessor="displayLabel"
-  valueAccessor="cellTypeCount"
-  colorBy={row =>
+const chartRows = kidneyDirectChildren.map(row => ({
+  ...row,
+  reviewStatus:
     row.temporaryCellTypeCount > 0
       ? "Contains provisional cell type"
-      : "No provisional cell type"
-  }
+      : "No provisional cell type",
+}))
+
+<BarChart
+  data={chartRows}
+  categoryAccessor="displayLabel"
+  valueAccessor="cellTypeCount"
+  colorBy="reviewStatus"
   orientation="horizontal"
   sort={false}
   categoryLabel="Anatomical structure · ontology ID"

--- a/docs/src/pages/features/HraWppPilotPage.jsx
+++ b/docs/src/pages/features/HraWppPilotPage.jsx
@@ -1,0 +1,218 @@
+import React from "react"
+import { BarChart } from "semiotic/ordinal"
+
+import CodeBlock from "../../components/CodeBlock"
+import PageLayout from "../../components/PageLayout"
+import pilot from "../../data/hra-wpp-kidney-v1.6-pilot.json"
+
+const chartRows = pilot.chartRows.map((row) => ({
+  ...row,
+  reviewStatus:
+    row.temporaryCellTypeCount > 0
+      ? "Contains provisional cell type"
+      : "No provisional cell type",
+}))
+
+const panelStyle = {
+  border: "1px solid var(--surface-3)",
+  borderRadius: 10,
+  background: "var(--surface-1)",
+  padding: 16,
+  margin: "20px 0",
+}
+
+const warningStyle = {
+  ...panelStyle,
+  borderLeft: "4px solid var(--warning, #b26a00)",
+}
+
+const tableCellStyle = {
+  padding: "8px 10px",
+  borderBottom: "1px solid var(--surface-3)",
+  textAlign: "left",
+  whiteSpace: "nowrap",
+}
+
+const sourceCode = `import { BarChart } from "semiotic/ordinal"
+
+<BarChart
+  data={kidneyDirectChildren}
+  categoryAccessor="displayLabel"
+  valueAccessor="cellTypeCount"
+  colorBy={row =>
+    row.temporaryCellTypeCount > 0
+      ? "Contains provisional cell type"
+      : "No provisional cell type"
+  }
+  orientation="horizontal"
+  sort={false}
+  categoryLabel="Anatomical structure · ontology ID"
+  valueLabel="Distinct cell types"
+  description="Distinct cell-type coverage for observed direct children of kidney in HRA ASCT+B kidney v1.6. Counts are set memberships and are not additive."
+/>`
+
+function ExternalLink({ href, children }) {
+  return (
+    <a href={href} target="_blank" rel="noreferrer">
+      {children}
+    </a>
+  )
+}
+
+export default function HraWppPilotPage() {
+  return (
+    <PageLayout
+      title="HRA/WPP Typology Pilot"
+      breadcrumbs={[
+        { label: "Interoperability", path: "/interoperability" },
+        {
+          label: "HRA/WPP Typology Pilot",
+          path: "/interoperability/hra-wpp",
+        },
+      ]}
+      prevPage={{ title: "VACP Bridge", path: "/interoperability/vacp" }}
+      nextPage={{ title: "Vega-Lite", path: "/interoperability/vega-lite" }}
+    >
+      <p>
+        This pre-workshop artifact tests whether Semiotic&apos;s portable IDID
+        metadata can carry an expert biomedical typology without flattening it.
+        It is generated from the versioned{" "}
+        <ExternalLink href={pilot.source.purl}>
+          HRA kidney ASCT+B {pilot.source.version} digital object
+        </ExternalLink>
+        , not illustrative rows.
+      </p>
+
+      <div style={panelStyle}>
+        <strong>Evidence snapshot</strong>
+        <p style={{ marginBottom: 0 }}>
+          {pilot.summary.recordCount} ASCT+B records;{" "}
+          {pilot.summary.observedAnatomicalStructureCount} observed anatomical
+          structures; {pilot.summary.observedCellTypeCount} observed cell
+          types. The chart uses the {pilot.chartRows.length} observed direct
+          children of <code>kidney (UBERON:0002113)</code>. Source created{" "}
+          {pilot.source.creationDate} by {pilot.source.publisher}.
+        </p>
+      </div>
+
+      <h2 id="actual-query-result">Actual query result</h2>
+
+      <BarChart
+        data={chartRows}
+        categoryAccessor="displayLabel"
+        valueAccessor="cellTypeCount"
+        colorBy="reviewStatus"
+        colorScheme={{
+          "Contains provisional cell type": "var(--warning, #b26a00)",
+          "No provisional cell type": "var(--accent, #4c78a8)",
+        }}
+        orientation="horizontal"
+        sort={false}
+        width={900}
+        responsiveWidth
+        height={430}
+        margin={{ left: 285, top: 30, right: 35, bottom: 65 }}
+        categoryLabel="Anatomical structure · ontology ID"
+        valueLabel="Distinct cell types"
+        title="Cell-type coverage for observed direct children of kidney"
+        description="Distinct cell-type coverage for observed direct children of kidney in HRA ASCT+B kidney v1.6. Orange bars include at least one provisional cell-type term. Counts are set memberships and are not additive."
+      />
+
+      <div style={warningStyle}>
+        <strong>Review signal</strong>
+        <p style={{ marginBottom: 0 }}>
+          Interstitium, renal collecting system, and kidney capsule each include
+          one provisional cell-type term. That status is an editorial claim
+          derived from <code>ccf_is_provisional</code>, separate from the
+          measured bar height.
+        </p>
+      </div>
+
+      <div style={{ overflowX: "auto", margin: "20px 0" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead>
+            <tr>
+              <th style={tableCellStyle}>Anatomical structure</th>
+              <th style={tableCellStyle}>Ontology ID</th>
+              <th style={tableCellStyle}>Cell types</th>
+              <th style={tableCellStyle}>Records</th>
+              <th style={tableCellStyle}>Provisional cell types</th>
+            </tr>
+          </thead>
+          <tbody>
+            {pilot.chartRows.map((row) => (
+              <tr key={row.anatomicalStructureId}>
+                <td style={tableCellStyle}>
+                  {row.anatomicalStructureLabel}
+                </td>
+                <td style={tableCellStyle}>
+                  <code>{row.anatomicalStructureId}</code>
+                </td>
+                <td style={tableCellStyle}>{row.cellTypeCount}</td>
+                <td style={tableCellStyle}>{row.recordCount}</td>
+                <td style={tableCellStyle}>
+                  {row.temporaryCellTypeCount}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h2 id="failure-found">A real failure found before the workshop</h2>
+
+      <p>
+        The first candidate ranked every anatomical-structure path by its
+        display label. The real data shows why that is unsafe: a parent count
+        includes cell types associated with descendant records, and distinct
+        ontology identifiers can share the same label. The kidney root would
+        dominate simply because it is the root, while a label-keyed chart would
+        merge different concepts.
+      </p>
+
+      <ul>
+        {pilot.findings.observedLabelCollisions.map((collision) => (
+          <li key={collision.label}>
+            <strong>{collision.label}</strong>:{" "}
+            {collision.ids.map((id) => (
+              <code key={id} style={{ marginRight: 8 }}>
+                {id}
+              </code>
+            ))}
+          </li>
+        ))}
+      </ul>
+
+      <p>
+        The corrected artifact uses ontology IDs as semantic keys, renders IDs
+        beside labels, and compares one explicit sibling scope. It still does
+        not claim the sibling counts are additive: a record can participate in
+        more than one hierarchy path.
+      </p>
+
+      <CodeBlock code={sourceCode} />
+
+      <h2 id="workshop-question">Workshop question</h2>
+
+      <blockquote>
+        Where does this typology mapping break for WPP? In particular, which
+        facts must be typed and acted on across tools rather than merely
+        preserved as ontology-linked extension metadata?
+      </blockquote>
+
+      <p>
+        The remaining human validation is deliberately narrow: review the
+        role/domain-literacy terms, identify one case where the corrected chart
+        or reader-grounding envelope still miscommunicates the task, and decide
+        whether that case justifies a typed <code>ContextProfile</code>. Until
+        then, context remains namespaced <code>x-hra</code> metadata.
+      </p>
+
+      <p>
+        Rebuild the pinned fixture with{" "}
+        <code>npm run generate:hra-wpp-pilot</code>; the aggregator and its
+        ontology-identity regression test live in <code>scripts/</code>.
+      </p>
+    </PageLayout>
+  )
+}

--- a/docs/src/pages/features/InteroperabilityPage.jsx
+++ b/docs/src/pages/features/InteroperabilityPage.jsx
@@ -30,6 +30,18 @@ const GROUPS = [
     ],
   },
   {
+    heading: "Domain typology pilot — expert vocabulary stays identifiable",
+    blurb:
+      "Test portable audience, intent, provenance, and extension metadata against a real versioned domain object before promoting a new core schema.",
+    items: [
+      {
+        title: "HRA/WPP Typology Pilot",
+        path: "/interoperability/hra-wpp",
+        what: "A reproducible kidney ASCT+B v1.6 query artifact, ontology-identity failure case, and bounded workshop question.",
+      },
+    ],
+  },
+  {
     heading: "Inbound spec adapters — a format becomes a chart",
     blurb:
       "Parse another tool's chart description and compile it to a Semiotic ChartConfig. The chart arrives with the accessibility, navigation, theming, and provenance the source never had.",

--- a/docs/src/pages/features/VACPPage.jsx
+++ b/docs/src/pages/features/VACPPage.jsx
@@ -411,7 +411,10 @@ export default function VACPPage() {
         title: "Portability Spec",
         path: "/interoperability/portability-spec",
       }}
-      nextPage={{ title: "Vega-Lite", path: "/interoperability/vega-lite" }}
+      nextPage={{
+        title: "HRA/WPP Typology Pilot",
+        path: "/interoperability/hra-wpp",
+      }}
     >
       <p>
         The{" "}

--- a/package.json
+++ b/package.json
@@ -273,6 +273,8 @@
     "generate:gofish-fixtures": "node --experimental-strip-types scripts/gen-gofish-fixtures.ts --write",
     "generate:demo-gifs": "node -e \"try{require.resolve('sharp');require.resolve('gifenc')}catch{console.log('Skipping GIF generation (sharp/gifenc not installed)');process.exit(0)}\" && npx tsx scripts/generate-demo-gifs.ts",
     "generate:weather-baselines": "npx tsx scripts/generate-open-meteo-preset-baselines.mjs",
+    "generate:hra-wpp-pilot": "node scripts/build-hra-wpp-kidney-pilot.mjs --write",
+    "test:hra-wpp-pilot": "node --test scripts/build-hra-wpp-kidney-pilot.test.mjs",
     "generate:blog-og-cards": "node scripts/generate-blog-og-cards.mjs",
     "generate:example-og-cards": "node scripts/generate-example-og-cards.mjs",
     "generate:blog-rss": "node scripts/generate-blog-rss.mjs",

--- a/scripts/build-hra-wpp-kidney-pilot.mjs
+++ b/scripts/build-hra-wpp-kidney-pilot.mjs
@@ -70,7 +70,8 @@ function aggregateObservedStructures(records) {
           aggregate.cellTypeIds.add(cellType.source_concept)
         }
       }
-      aggregate.recordIds.add(record.id || String(record.record_number))
+      const recordKey = record.id ?? record.record_number
+      if (recordKey != null) aggregate.recordIds.add(String(recordKey))
       structures.set(id, aggregate)
     }
   }

--- a/scripts/build-hra-wpp-kidney-pilot.mjs
+++ b/scripts/build-hra-wpp-kidney-pilot.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from "node:fs/promises"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+export const KIDNEY_PURL =
+  "https://purl.humanatlas.io/asct-b/kidney/v1.6"
+export const KIDNEY_ROOT_ID = "UBERON:0002113"
+export const DEFAULT_OUTPUT = resolve(
+  "docs/src/data/hra-wpp-kidney-v1.6-pilot.json",
+)
+
+const uniqueBy = (items, accessor) => {
+  const seen = new Set()
+  return items.filter((item) => {
+    const key = accessor(item)
+    if (!key || seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+const shortId = (id) => String(id).split(/[\/#]/).filter(Boolean).at(-1)
+
+function validateSource(source) {
+  const data = source?.data
+  if (source?.metadata?.version !== "v1.6") {
+    throw new Error(
+      `Expected kidney v1.6, received ${source?.metadata?.version || "no version"}`,
+    )
+  }
+  for (const field of [
+    "anatomical_structures",
+    "cell_types",
+    "asctb_record",
+  ]) {
+    if (!Array.isArray(data?.[field])) {
+      throw new Error(`HRA source is missing data.${field}`)
+    }
+  }
+}
+
+function aggregateObservedStructures(records) {
+  const structures = new Map()
+
+  for (const record of records) {
+    const cellTypes = uniqueBy(
+      record.cell_type_list || [],
+      (cellType) => cellType.source_concept,
+    )
+
+    for (const structure of uniqueBy(
+      record.anatomical_structure_list || [],
+      (item) => item.source_concept,
+    )) {
+      const id = structure.source_concept
+      if (!id) continue
+      const aggregate = structures.get(id) || {
+        id,
+        labels: new Set(),
+        cellTypeIds: new Set(),
+        recordIds: new Set(),
+      }
+      if (structure.ccf_pref_label) {
+        aggregate.labels.add(structure.ccf_pref_label)
+      }
+      for (const cellType of cellTypes) {
+        if (cellType.source_concept) {
+          aggregate.cellTypeIds.add(cellType.source_concept)
+        }
+      }
+      aggregate.recordIds.add(record.id || String(record.record_number))
+      structures.set(id, aggregate)
+    }
+  }
+
+  return structures
+}
+
+function findObservedLabelCollisions(observedStructures, definitions) {
+  const byLabel = new Map()
+
+  for (const [id, aggregate] of observedStructures) {
+    const label =
+      definitions.get(id)?.ccf_pref_label || [...aggregate.labels][0] || id
+    const ids = byLabel.get(label) || []
+    ids.push(id)
+    byLabel.set(label, ids)
+  }
+
+  return [...byLabel]
+    .filter(([, ids]) => new Set(ids).size > 1)
+    .map(([label, ids]) => ({ label, ids: [...new Set(ids)].sort() }))
+    .sort((a, b) => a.label.localeCompare(b.label))
+}
+
+export function buildKidneyPilot(source) {
+  validateSource(source)
+
+  const { metadata, data } = source
+  const definitions = new Map(
+    data.anatomical_structures.map((structure) => [structure.id, structure]),
+  )
+  const cellTypeDefinitions = new Map(
+    data.cell_types.map((cellType) => [cellType.id, cellType]),
+  )
+  const observedStructures = aggregateObservedStructures(data.asctb_record)
+  const directChildIds = new Set(
+    data.anatomical_structures
+      .filter((structure) =>
+        (structure.ccf_part_of || []).includes(KIDNEY_ROOT_ID),
+      )
+      .map((structure) => structure.id),
+  )
+
+  const chartRows = [...observedStructures]
+    .filter(([id]) => directChildIds.has(id))
+    .map(([id, aggregate]) => {
+      const definition = definitions.get(id)
+      const label =
+        definition?.ccf_pref_label || [...aggregate.labels][0] || id
+      const temporaryCellTypeCount = [...aggregate.cellTypeIds].filter(
+        (cellTypeId) =>
+          cellTypeDefinitions.get(cellTypeId)?.ccf_is_provisional === true,
+      ).length
+
+      return {
+        anatomicalStructureId: id,
+        anatomicalStructureLabel: label,
+        displayLabel: `${label} · ${shortId(id)}`,
+        cellTypeCount: aggregate.cellTypeIds.size,
+        temporaryCellTypeCount,
+        recordCount: aggregate.recordIds.size,
+        structureIsProvisional:
+          definition?.ccf_is_provisional === true,
+      }
+    })
+    .sort(
+      (a, b) =>
+        b.cellTypeCount - a.cellTypeCount ||
+        a.anatomicalStructureId.localeCompare(b.anatomicalStructureId),
+    )
+
+  const observedCellTypeIds = new Set(
+    data.asctb_record.flatMap((record) =>
+      (record.cell_type_list || [])
+        .map((cellType) => cellType.source_concept)
+        .filter(Boolean),
+    ),
+  )
+
+  return {
+    kind: "semiotic-hra-wpp-kidney-pilot",
+    schemaVersion: 1,
+    source: {
+      purl: KIDNEY_PURL,
+      version: metadata.version,
+      creationDate: metadata.creation_date,
+      publisher: metadata.publisher,
+      license: metadata.license,
+      seeAlso: metadata.see_also,
+      derivedFrom: metadata.derived_from,
+    },
+    methodology: {
+      scope: `Observed direct children of kidney (${KIDNEY_ROOT_ID})`,
+      identity:
+        "Ontology identifiers are semantic keys; labels are display text only.",
+      aggregation:
+        "For each ASCT+B record, distinct cell types are associated with every anatomical structure in that record's path, then deduplicated per structure.",
+      caveats: [
+        "Counts are set memberships and are not additive across anatomical structures.",
+        "A record can contribute to more than one hierarchy path.",
+        "Parent and descendant rows must not be ranked together as independent categories.",
+      ],
+    },
+    summary: {
+      recordCount: data.asctb_record.length,
+      declaredAnatomicalStructureCount: data.anatomical_structures.length,
+      observedAnatomicalStructureCount: observedStructures.size,
+      declaredCellTypeCount: data.cell_types.length,
+      observedCellTypeCount: observedCellTypeIds.size,
+      provisionalAnatomicalStructureCount: data.anatomical_structures.filter(
+        (structure) => structure.ccf_is_provisional === true,
+      ).length,
+      provisionalCellTypeCount: data.cell_types.filter(
+        (cellType) => cellType.ccf_is_provisional === true,
+      ).length,
+    },
+    chartRows,
+    reviewRows: chartRows.filter(
+      (row) =>
+        row.structureIsProvisional || row.temporaryCellTypeCount > 0,
+    ),
+    findings: {
+      observedLabelCollisions: findObservedLabelCollisions(
+        observedStructures,
+        definitions,
+      ),
+      hierarchyFailure:
+        "Ranking the kidney root beside descendants makes the largest bar a hierarchy artifact and implies independent categories. The pilot therefore limits the chart to one explicit sibling scope.",
+    },
+  }
+}
+
+export async function fetchKidneySource() {
+  const response = await fetch(KIDNEY_PURL, {
+    headers: { Accept: "application/json" },
+    redirect: "follow",
+  })
+  if (!response.ok) {
+    throw new Error(`HRA request failed with HTTP ${response.status}`)
+  }
+  return response.json()
+}
+
+async function main() {
+  const output = process.argv.includes("--write")
+    ? DEFAULT_OUTPUT
+    : process.argv.find((argument) => argument.startsWith("--output="))?.slice(9)
+  const artifact = buildKidneyPilot(await fetchKidneySource())
+  const serialized = `${JSON.stringify(artifact, null, 2)}\n`
+
+  if (output) {
+    await mkdir(dirname(output), { recursive: true })
+    await writeFile(output, serialized)
+    console.log(`Wrote ${output}`)
+  } else {
+    process.stdout.write(serialized)
+  }
+}
+
+const isMain =
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1])
+
+if (isMain) {
+  await main()
+}

--- a/scripts/build-hra-wpp-kidney-pilot.test.mjs
+++ b/scripts/build-hra-wpp-kidney-pilot.test.mjs
@@ -108,6 +108,26 @@ test("buildKidneyPilot is deterministic and validates the pinned version", () =>
   )
 })
 
+test("records without an identifier do not create an undefined record key", () => {
+  const sourceWithMissingRecordId = {
+    ...source,
+    data: {
+      ...source.data,
+      asctb_record: [
+        {
+          anatomical_structure_list: [
+            { source_concept: "AS:A", ccf_pref_label: "Shared label" },
+          ],
+          cell_type_list: [{ source_concept: "CT:CURATED" }],
+        },
+      ],
+    },
+  }
+
+  const artifact = buildKidneyPilot(sourceWithMissingRecordId)
+  assert.equal(artifact.chartRows[0].recordCount, 0)
+})
+
 test("the checked-in kidney v1.6 fixture pins the reviewed workshop evidence", () => {
   const artifact = JSON.parse(
     readFileSync(

--- a/scripts/build-hra-wpp-kidney-pilot.test.mjs
+++ b/scripts/build-hra-wpp-kidney-pilot.test.mjs
@@ -1,0 +1,137 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import {
+  buildKidneyPilot,
+  KIDNEY_ROOT_ID,
+} from "./build-hra-wpp-kidney-pilot.mjs"
+
+const source = {
+  metadata: {
+    version: "v1.6",
+    creation_date: "2026-06-08",
+    publisher: "HuBMAP",
+    license: "https://creativecommons.org/licenses/by/4.0/",
+    see_also: "https://example.test/kidney",
+    derived_from: "https://example.test/kidney#raw-data",
+  },
+  data: {
+    anatomical_structures: [
+      {
+        id: "AS:A",
+        ccf_pref_label: "Shared label",
+        ccf_part_of: [KIDNEY_ROOT_ID],
+        ccf_is_provisional: false,
+      },
+      {
+        id: "AS:B",
+        ccf_pref_label: "Shared label",
+        ccf_part_of: [KIDNEY_ROOT_ID],
+        ccf_is_provisional: false,
+      },
+      {
+        id: "AS:GRANDCHILD",
+        ccf_pref_label: "Nested structure",
+        ccf_part_of: ["AS:A"],
+        ccf_is_provisional: false,
+      },
+    ],
+    cell_types: [
+      {
+        id: "CT:CURATED",
+        ccf_pref_label: "Curated cell",
+        ccf_is_provisional: false,
+      },
+      {
+        id: "CT:TEMP",
+        ccf_pref_label: "Temporary cell",
+        ccf_is_provisional: true,
+      },
+    ],
+    asctb_record: [
+      {
+        id: "R1",
+        anatomical_structure_list: [
+          { source_concept: "AS:A", ccf_pref_label: "Shared label" },
+          {
+            source_concept: "AS:GRANDCHILD",
+            ccf_pref_label: "Nested structure",
+          },
+        ],
+        cell_type_list: [
+          { source_concept: "CT:CURATED" },
+          { source_concept: "CT:TEMP" },
+          { source_concept: "CT:TEMP" },
+        ],
+      },
+      {
+        id: "R2",
+        anatomical_structure_list: [
+          { source_concept: "AS:B", ccf_pref_label: "Shared label" },
+        ],
+        cell_type_list: [{ source_concept: "CT:CURATED" }],
+      },
+    ],
+  },
+}
+
+test("buildKidneyPilot preserves ontology identity and one hierarchy level", () => {
+  const artifact = buildKidneyPilot(source)
+
+  assert.deepEqual(
+    artifact.chartRows.map((row) => row.anatomicalStructureId),
+    ["AS:A", "AS:B"],
+  )
+  assert.equal(artifact.chartRows[0].cellTypeCount, 2)
+  assert.equal(artifact.chartRows[0].temporaryCellTypeCount, 1)
+  assert.equal(artifact.chartRows[1].cellTypeCount, 1)
+  assert.notEqual(
+    artifact.chartRows[0].displayLabel,
+    artifact.chartRows[1].displayLabel,
+  )
+  assert.deepEqual(artifact.findings.observedLabelCollisions, [
+    { label: "Shared label", ids: ["AS:A", "AS:B"] },
+  ])
+})
+
+test("buildKidneyPilot is deterministic and validates the pinned version", () => {
+  assert.deepEqual(buildKidneyPilot(source), buildKidneyPilot(source))
+  assert.throws(
+    () =>
+      buildKidneyPilot({
+        ...source,
+        metadata: { ...source.metadata, version: "v1.7" },
+      }),
+    /Expected kidney v1\.6/,
+  )
+})
+
+test("the checked-in kidney v1.6 fixture pins the reviewed workshop evidence", () => {
+  const artifact = JSON.parse(
+    readFileSync(
+      resolve("docs/src/data/hra-wpp-kidney-v1.6-pilot.json"),
+      "utf8",
+    ),
+  )
+
+  assert.deepEqual(artifact.summary, {
+    recordCount: 78,
+    declaredAnatomicalStructureCount: 67,
+    observedAnatomicalStructureCount: 61,
+    declaredCellTypeCount: 72,
+    observedCellTypeCount: 70,
+    provisionalAnatomicalStructureCount: 2,
+    provisionalCellTypeCount: 3,
+  })
+  assert.deepEqual(
+    artifact.reviewRows.map((row) => row.anatomicalStructureId),
+    ["UBERON:0005215", "UBERON:0004100", "UBERON:0002015"],
+  )
+  assert.ok(
+    artifact.findings.observedLabelCollisions.some(
+      ({ label, ids }) => label === "Tubules" && ids.length === 2,
+    ),
+  )
+})

--- a/scripts/smoke-hosted-mcp.mjs
+++ b/scripts/smoke-hosted-mcp.mjs
@@ -420,7 +420,13 @@ function parseBuildInfoResource(step, result) {
   }
 }
 
-function assertNightlyInitialize(step, result, identity, requestedProtocolVersion) {
+function assertInitialize(
+  step,
+  result,
+  identity,
+  expectedChannel,
+  requestedProtocolVersion,
+) {
   const protocolVersion = requireString(step, result.protocolVersion, "protocolVersion")
   if (!/^\d{4}-\d{2}-\d{2}$/.test(protocolVersion)) {
     throw new SmokeFailure(step, `${step} returned an unsupported protocol version format`)
@@ -435,11 +441,22 @@ function assertNightlyInitialize(step, result, identity, requestedProtocolVersio
     "protocolVersion",
   )
   const serverInfo = requireRecord(step, result.serverInfo, "serverInfo")
-  requireExactString(step, serverInfo.name, "semiotic-nightly", "serverInfo.name")
+  const expectedName =
+    expectedChannel === "nightly" ? "semiotic-nightly" : "semiotic"
+  requireExactString(step, serverInfo.name, expectedName, "serverInfo.name")
   const version = requireString(step, serverInfo.version, "serverInfo.version")
-  const expectedSuffix = `-nightly+${identity.commitSha.slice(0, 7)}`
-  if (!new RegExp(`^\\d+\\.\\d+\\.\\d+${escapeRegex(expectedSuffix)}$`, "i").test(version)) {
-    throw new SmokeFailure(step, `${step} serverInfo.version did not identify the nightly commit`)
+  if (expectedChannel === "nightly") {
+    const expectedSuffix = `-nightly+${identity.commitSha.slice(0, 7)}`
+    if (!new RegExp(`^\\d+\\.\\d+\\.\\d+${escapeRegex(expectedSuffix)}$`, "i").test(version)) {
+      throw new SmokeFailure(step, `${step} serverInfo.version did not identify the nightly commit`)
+    }
+  } else {
+    requireExactString(
+      step,
+      version,
+      identity.packageVersion,
+      "serverInfo.version",
+    )
   }
   return protocolVersion
 }
@@ -475,10 +492,11 @@ export async function runHostedMcpSmoke(options) {
     options.protocolVersion,
     deadline,
   )
-  const protocolVersion = assertNightlyInitialize(
+  const protocolVersion = assertInitialize(
     "initialize",
     initialized.result,
     health.identity,
+    options.expectedChannel,
     options.protocolVersion,
   )
   checks.push("initialize")

--- a/scripts/smoke-hosted-mcp.test.mjs
+++ b/scripts/smoke-hosted-mcp.test.mjs
@@ -280,6 +280,7 @@ describe("smoke-hosted-mcp", () => {
       const result = await runSmoke(fixture.endpoint, [], "stable")
       assert.equal(result.code, 0, `${result.stdout}\n${result.stderr}`)
       assert.match(result.stdout, /hosted MCP smoke passed/)
+      assert.equal(result.stderr, "")
     })
   })
 

--- a/scripts/smoke-hosted-mcp.test.mjs
+++ b/scripts/smoke-hosted-mcp.test.mjs
@@ -28,8 +28,13 @@ function json(res, status, body, headers = {}) {
 
 function fixtureIdentity(options) {
   const commitSha = options.commitSha ?? (options.wrongSha ? OTHER_SHA : COMMIT_SHA)
+  const expectedChannel = options.channel ?? "nightly"
   return {
-    channel: options.wrongChannel ? "stable" : "nightly",
+    channel: options.wrongChannel
+      ? expectedChannel === "nightly"
+        ? "stable"
+        : "nightly"
+      : expectedChannel,
     packageVersion: "3.8.3",
     surfaceVersion: "3.8.3-ai",
     commitSha,
@@ -208,12 +213,12 @@ async function createFixture(options = {}) {
   }
 }
 
-function runSmoke(endpoint, args = []) {
+function runSmoke(endpoint, args = [], expectedChannel = "nightly") {
   return new Promise((resolveRun, reject) => {
     const child = spawn(process.execPath, [
       smokeScript,
       "--endpoint", endpoint,
-      "--expected-channel", "nightly",
+      "--expected-channel", expectedChannel,
       "--expected-sha", COMMIT_SHA,
       "--expected-build-id", BUILD_ID,
       "--timeout-ms", "300",
@@ -267,6 +272,14 @@ describe("smoke-hosted-mcp", () => {
       assert.match(result.stdout, /createChart/)
       assert.doesNotMatch(result.stdout, /<svg/i)
       assert.equal(result.stderr, "")
+    })
+  })
+
+  it("accepts the stable server name and exact published package version", async () => {
+    await withFixture({ channel: "stable" }, async (fixture) => {
+      const result = await runSmoke(fixture.endpoint, [], "stable")
+      assert.equal(result.code, 0, `${result.stdout}\n${result.stderr}`)
+      assert.match(result.stdout, /hosted MCP smoke passed/)
     })
   })
 


### PR DESCRIPTION
Adds the HRA/WPP kidney typology pilot as a new interoperability feature, using real kidney ASCT+B v1.6 data with ontology-identity regression testing. Upgrades the Cloud Run MCP deployment from 3.8.1 to 3.8.6, with verified end-to-end smoke tests. Makes smoke tests channel-aware to distinguish stable (exact version) from nightly (commit-qualified) assertions. Adds build identity tracking (commit SHA, build ID, timestamp) to deployment labels and environment variables for production release audits.

This pull request updates the MCP deployment and documentation to use the latest `semiotic@3.8.6` release, and introduces a new, workshop-ready pilot artifact for the HRA/WPP typology, based on the real kidney ASCT+B v1.6 digital object. It also adds a new public walkthrough page and supporting data for this pilot, and improves deployment and verification instructions to ensure provenance and registry consistency.

The most important changes are:

**HRA/WPP Typology Pilot and Documentation**
* Added a new pilot artifact for the HRA/WPP typology, using the real kidney ASCT+B v1.6 digital object, with a pinned, checked-in generator output and a public `/interoperability/hra-wpp` walkthrough page (`docs/src/data/hra-wpp-kidney-v1.6-pilot.json`, `docs/src/App.jsx`, `docs/src/components/navData.js`). [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12-R27) [[2]](diffhunk://#diff-c5c4afe490aeef52dbdafb2c06ab62442cc3ae7f33be856f900f034c4561277aR1-R162) [[3]](diffhunk://#diff-c296d5ff577e4d07e0070d757fea11d7b7bf757caed70cc2f82ab83912def97dR155) [[4]](diffhunk://#diff-c296d5ff577e4d07e0070d757fea11d7b7bf757caed70cc2f82ab83912def97dR834) [[5]](diffhunk://#diff-0e9b4495873193679d9f273691fe01757f807fcafbf78074bdb2c758b56986a1R268)
* The pilot highlights a real-world failure case (label collisions, hierarchy artifacts) and includes a focused regression test for these issues. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12-R27) [[2]](diffhunk://#diff-c5c4afe490aeef52dbdafb2c06ab62442cc3ae7f33be856f900f034c4561277aR1-R162)

**MCP Distribution and Registry Verification**
* Upgraded all MCP deployment and documentation references from `semiotic@3.8.1` to `semiotic@3.8.6`, including `package.json` and `package-lock.json`, and verified the stable Cloud Run revision serves the exact release with full build identity. [[1]](diffhunk://#diff-121fe1bb522ebd71ee45c0f0c2b05a6450bba798bba9b9ea3dfa8937bb4533c6L13-R13) [[2]](diffhunk://#diff-121fe1bb522ebd71ee45c0f0c2b05a6450bba798bba9b9ea3dfa8937bb4533c6L1307-R1303) [[3]](diffhunk://#diff-121fe1bb522ebd71ee45c0f0c2b05a6450bba798bba9b9ea3dfa8937bb4533c6R1337) [[4]](diffhunk://#diff-121fe1bb522ebd71ee45c0f0c2b05a6450bba798bba9b9ea3dfa8937bb4533c6R1347-R1349) [[5]](diffhunk://#diff-9d12b69e8bc53a96ed760079e0dbd17e2a7fca197a919a7a9184dbc6e53e7345L15-R15) [[6]](diffhunk://#diff-6e1d2248081a13668d3a9a486da0c0590415c93b379282119ff327092b939e43L41-R41)
* Updated MCP distribution documentation to reflect the completed registry metadata backfill, the new stable verification flow, and the requirement for release provenance and build identity variables during deploy. [[1]](diffhunk://#diff-b9c9fa0b45e00e9087ff7d411f4178aee2526ce28457c5025aeba79640b47a60L11-R32) [[2]](diffhunk://#diff-6e1d2248081a13668d3a9a486da0c0590415c93b379282119ff327092b939e43R89-R112) [[3]](diffhunk://#diff-6e1d2248081a13668d3a9a486da0c0590415c93b379282119ff327092b939e43L222-R236)

**Dependency and Lockfile Updates**
* Updated the `package-lock.json` to remove the unused `regression` dependency and add `roughjs` as an optional peer dependency, matching the new `semiotic@3.8.6` requirements. [[1]](diffhunk://#diff-121fe1bb522ebd71ee45c0f0c2b05a6450bba798bba9b9ea3dfa8937bb4533c6L1271-L1276) [[2]](diffhunk://#diff-121fe1bb522ebd71ee45c0f0c2b05a6450bba798bba9b9ea3dfa8937bb4533c6L1324) [[3]](diffhunk://#diff-121fe1bb522ebd71ee45c0f0c2b05a6450bba798bba9b9ea3dfa8937bb4533c6R1337) [[4]](diffhunk://#diff-121fe1bb522ebd71ee45c0f0c2b05a6450bba798bba9b9ea3dfa8937bb4533c6R1347-R1349)

These changes ensure the MCP deployment is fully up-to-date, reproducible, and verified end-to-end, while introducing a robust and documented pilot for the HRA/WPP typology using real data.