### PR TITLE
eval: publish repeated post-merge evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **A high-touch evaluation example makes the prove track inspectable.**
   `/examples/the-benchmark-is-a-chart-too` turns the completed 516-request
-  GPT-5.6 compatibility run into an evidence-first reading room. It separates
-  answerable questions from correct abstentions, preserves the first-attempt
-  failure matrix and cost/latency context, documents the scorer audit, and links
-  the aggregate back to its checked-in reports and methods.
+  GPT-5.6 compatibility baseline and its 603-request repeated follow-up into an
+  evidence-first reading room. It separates answerable questions from correct
+  abstentions, preserves the first-attempt failure matrix and cost/latency
+  context, documents the scorer audit, and shows where the revised grounding
+  payload and generation contracts held across repeated trials. Targeted result
+  scoring now reports only submitted fixtures while retaining the available
+  corpus size, so omitted cases no longer appear as failures.
 - **The HRA/WPP typology pilot now runs on the real kidney ASCT+B v1.6
   digital object.** A pinned generator produces a checked-in, workshop-ready
   artifact for the observed direct children of kidney, with ontology IDs kept

--- a/docs/src/pages/examples/ModelEvaluationExamplePage.jsx
+++ b/docs/src/pages/examples/ModelEvaluationExamplePage.jsx
@@ -5,6 +5,9 @@ import useResponsiveWidth from "../../hooks/useResponsiveWidth"
 import ExamplePageLayout from "./ExamplePageLayout"
 import {
   CONDITION_COLORS,
+  FOLLOW_UP_FIRST_TRY_FIXTURES,
+  FOLLOW_UP_FIRST_TRY_MODELS,
+  FOLLOW_UP_RUN,
   FIRST_TRY_FAILURES,
   FIRST_TRY_MODELS,
   GROUNDING_METRICS,
@@ -12,7 +15,10 @@ import {
   MODEL_EVALUATION_RUN,
   MODEL_ORDER,
   SCORER_AUDIT_CASES,
+  TOTAL_ESTIMATED_USD,
+  TOTAL_RECORDED_REQUESTS,
   combinedGroundingDeltas,
+  followUpGroundingRows,
   groundingRowsForMetric,
 } from "./data/modelEvaluationRun"
 import "./ModelEvaluationExamplePage.css"
@@ -55,22 +61,22 @@ function ScoreTooltip({ datum }) {
 
 function RunLedger() {
   const rows = [
-    ["Requests", INTEGER.format(MODEL_EVALUATION_RUN.requestCount), "across three models"],
     [
-      "Grounding",
-      `${MODEL_EVALUATION_RUN.groundingRequestsPerModel}/model`,
-      "50 questions × 3 evidence conditions",
+      "Complete baseline",
+      INTEGER.format(MODEL_EVALUATION_RUN.requestCount),
+      "one response per case",
     ],
     [
-      "First try",
-      `${MODEL_EVALUATION_RUN.firstTryRequestsPerModel}/model`,
-      "one proposal, no repair pass",
+      "Repeated follow-up",
+      INTEGER.format(FOLLOW_UP_RUN.requestCount),
+      `${FOLLOW_UP_RUN.trialCount} targeted trials`,
     ],
     [
-      "Run cost",
-      USD.format(MODEL_EVALUATION_RUN.estimatedUsd),
-      `${MODEL_EVALUATION_RUN.durationMinutes} minutes`,
+      "Repeated scope",
+      `${FOLLOW_UP_RUN.answerableQuestions} + ${FOLLOW_UP_RUN.firstTryFixtures}`,
+      "answerable questions + generation fixtures",
     ],
+    ["Recorded cost", USD.format(TOTAL_ESTIMATED_USD), "baseline plus follow-up"],
   ]
   return (
     <dl className="benchmark-chart__ledger">
@@ -89,49 +95,143 @@ function RunLedger() {
 
 export function ModelEvaluationReadingRoom() {
   const [metricId, setMetricId] = useState("overall")
+  const [followUpWidth, followUpRef] = useResponsiveWidth(320, 920)
   const [groundingWidth, groundingRef] = useResponsiveWidth(320, 920)
   const [firstTryWidth, firstTryRef] = useResponsiveWidth(320, 760)
 
   const metric =
-    GROUNDING_METRICS.find((candidate) => candidate.id === metricId) ??
-    GROUNDING_METRICS[0]
+    GROUNDING_METRICS.find((candidate) => candidate.id === metricId) ?? GROUNDING_METRICS[0]
   const groundingRows = useMemo(() => groundingRowsForMetric(metric.id), [metric.id])
-  const deltas = useMemo(
-    () => MODEL_ORDER.map((model) => combinedGroundingDeltas(model)),
-    [],
-  )
+  const repeatedGroundingRows = useMemo(() => followUpGroundingRows(), [])
+  const deltas = useMemo(() => MODEL_ORDER.map((model) => combinedGroundingDeltas(model)), [])
   const maximumCost = Math.max(...FIRST_TRY_MODELS.map((row) => row.estimatedUsd))
+  const perfectFollowUpFixtures = FOLLOW_UP_FIRST_TRY_FIXTURES.filter(
+    (row) => row.passed === row.attempted,
+  ).length
+  const gaugeFollowUp = FOLLOW_UP_FIRST_TRY_FIXTURES.find((row) => row.fixtureId === "gauge-static")
 
   return (
     <div className="benchmark-chart">
       <header className="benchmark-chart__masthead">
         <div>
           <p className="benchmark-chart__eyebrow">
-            OpenAI GPT-5.6 compatibility run · snapshot 2026-07-27
+            OpenAI GPT-5.6 compatibility evidence · snapshot 2026-07-27
           </p>
           <h2>The benchmark is a chart, too.</h2>
           <p>
-            A scorecard has encodings, denominators, and failure modes—just like
-            the charts it judges. This one asks two different questions: can a
-            model read what is there, and can it stop when the evidence runs out?
+            A scorecard has encodings, denominators, and failure modes—just like the charts it
+            judges. This one asks two different questions: can a model read what is there, and can
+            it stop when the evidence runs out?
           </p>
         </div>
         <div className="benchmark-chart__stamp" aria-label="Run completed">
           <span>COMPLETE</span>
-          <strong>516</strong>
-          <small>requests</small>
+          <strong>{INTEGER.format(TOTAL_RECORDED_REQUESTS)}</strong>
+          <small>recorded requests</small>
         </div>
       </header>
 
       <RunLedger />
 
+      <section className="benchmark-chart__chapter" aria-labelledby="follow-up-heading">
+        <div className="benchmark-chart__chapter-heading">
+          <p>Post-merge repeated trials</p>
+          <h3 id="follow-up-heading">The revised payload recovered the answerable lookups.</h3>
+          <span>
+            Twenty answerable questions and seven generation fixtures were repeated across every
+            model. PNG-only stayed in the run as a control.
+          </span>
+        </div>
+
+        <div className="benchmark-chart__chart-shell" ref={followUpRef}>
+          <GroupedBarChart
+            data={repeatedGroundingRows}
+            categoryAccessor="model"
+            groupBy="conditionLabel"
+            valueAccessor="passed"
+            colorBy="conditionLabel"
+            colorScheme={CONDITION_COLORS}
+            valueExtent={[0, 60]}
+            sort={false}
+            width={followUpWidth}
+            height={360}
+            showGrid
+            showLegend
+            legendPosition="bottom"
+            legendInteraction="isolate"
+            enableHover
+            tooltip={(datum) => <ScoreTooltip datum={datum} />}
+            categoryLabel="Model"
+            valueLabel="Correct answerable outcomes (of 60)"
+            title="Repeated answerable outcomes"
+            description="Across three targeted trials, PNG plus grounding and grounding-only each passed all 180 answerable outcomes. PNG-only passed 139 of 180."
+            summary="The revised source-fact payload recovered every targeted answerable lookup across Sol, Terra, and Luna. This follow-up did not repeat the unanswerable questions."
+            accessibleTable
+          />
+        </div>
+
+        <div className="benchmark-chart__first-try-grid">
+          <div className="benchmark-chart__finding">
+            <span>First-attempt generation</span>
+            <strong>{perfectFollowUpFixtures} fixtures held across every model and trial.</strong>
+            <p>
+              The remaining fixture, <code>gauge-static</code>, passed {gaugeFollowUp?.passed}/
+              {gaugeFollowUp?.attempted}. Luna twice added an unsupported HOC prop to an otherwise
+              valid BigNumber proposal.
+            </p>
+          </div>
+          <div className="benchmark-chart__cost-strip" aria-label="Repeated generation by model">
+            {FOLLOW_UP_FIRST_TRY_MODELS.map((row) => (
+              <article key={row.model}>
+                <header>
+                  <strong>{row.model}</strong>
+                  <span>{row.modelId}</span>
+                </header>
+                <div
+                  className="benchmark-chart__cost-meter"
+                  aria-label={`${row.model} passed ${row.passed} of ${row.attempted}`}
+                >
+                  <i
+                    style={{
+                      width: `${(row.passed / row.attempted) * 100}%`,
+                      background: MODEL_COLORS[row.model],
+                    }}
+                  />
+                </div>
+                <dl>
+                  <div>
+                    <dt>Passing proposals</dt>
+                    <dd>
+                      {row.passed}/{row.attempted}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>Pass rate</dt>
+                    <dd>{Math.round((row.passed / row.attempted) * 100)}%</dd>
+                  </div>
+                </dl>
+              </article>
+            ))}
+          </div>
+        </div>
+
+        <aside className="benchmark-chart__margin-note">
+          <strong>What the repeat establishes</strong>
+          <p>
+            The source-fact revision fixed the tested value, hierarchy, geo, and physics lookups. It
+            does not update the baseline’s abstention result, because the thirty unanswerable
+            questions were outside this targeted run.
+          </p>
+        </aside>
+      </section>
+
       <section className="benchmark-chart__chapter" aria-labelledby="grounding-heading">
         <div className="benchmark-chart__chapter-heading">
-          <p>Reader grounding</p>
+          <p>Original baseline · reader grounding</p>
           <h3 id="grounding-heading">Grounding improved restraint, not chart reading.</h3>
           <span>
-            Compare correct answers with correct restraint instead of
-            compressing both into the same bar.
+            Compare correct answers with correct restraint instead of compressing both into the same
+            bar.
           </span>
         </div>
 
@@ -204,25 +304,27 @@ export function ModelEvaluationReadingRoom() {
         <aside className="benchmark-chart__margin-note">
           <strong>What survived the comparison</strong>
           <p>
-            Structured grounding can help a model refuse unsupported claims.
-            This run does not show that the current payload helps models recover
-            more labels or values from a chart.
+            Structured grounding can help a model refuse unsupported claims. This run does not show
+            that the current payload helps models recover more labels or values from a chart.
           </p>
         </aside>
       </section>
 
       <section className="benchmark-chart__chapter" aria-labelledby="first-try-heading">
         <div className="benchmark-chart__chapter-heading">
-          <p>First-attempt generation</p>
+          <p>Original baseline · first-attempt generation</p>
           <h3 id="first-try-heading">Chart choice did not guarantee a valid render.</h3>
           <span>
-            Every proposal had one chance to validate, render visible marks, and
-            avoid error diagnostics. There was no repair pass.
+            Every proposal had one chance to validate, render visible marks, and avoid error
+            diagnostics. There was no repair pass.
           </span>
         </div>
 
         <div className="benchmark-chart__first-try-grid">
-          <div className="benchmark-chart__chart-shell benchmark-chart__chart-shell--compact" ref={firstTryRef}>
+          <div
+            className="benchmark-chart__chart-shell benchmark-chart__chart-shell--compact"
+            ref={firstTryRef}
+          >
             <BarChart
               data={FIRST_TRY_MODELS}
               categoryAccessor="model"
@@ -326,9 +428,9 @@ export function ModelEvaluationReadingRoom() {
         <aside className="benchmark-chart__margin-note benchmark-chart__margin-note--blue">
           <strong>The oracle was part of the system under test</strong>
           <p>
-            Sol’s `BigNumber` choice was not imaginary—it is a real Semiotic
-            component documented in the supplied context. The failure exposed a
-            render-evidence seam as much as a model miss.
+            Sol’s `BigNumber` choice was not imaginary—it is a real Semiotic component documented in
+            the supplied context. The failure exposed a render-evidence seam as much as a model
+            miss.
           </p>
         </aside>
       </section>
@@ -338,8 +440,8 @@ export function ModelEvaluationReadingRoom() {
           <p>Scorer audit</p>
           <h3 id="scorer-heading">The scorer needed a manual review.</h3>
           <span>
-            Before publication, every score change between PNG-only and combined
-            evidence was read by a person. That audit found these lexical traps.
+            Before publication, every score change between PNG-only and combined evidence was read
+            by a person. That audit found these lexical traps.
           </span>
         </div>
 
@@ -364,17 +466,16 @@ export function ModelEvaluationReadingRoom() {
 
       <section className="benchmark-chart__conclusion">
         <p>THE READING</p>
-        <h3>The disagreements define the engineering backlog.</h3>
+        <h3>The repeat separates repaired contracts from residual risk.</h3>
         <div>
           <p>
-            Keep the split scores. Keep the failed proposals. Keep the scorer
-            revision. The aggregate is useful, but the disagreements are where
-            the next product work lives.
+            The revised grounding payload held across every repeated answerable outcome. Six
+            generation fixtures also held everywhere. BigNumber’s remaining HOC-prop confusion stays
+            visible as the next narrow contract problem.
           </p>
           <p>
-            For the deterministic intelligence layer that generated the
-            grounding payload, continue with{" "}
-            <Link to="/examples/what-the-machine-sees">What the Machine Sees</Link>.
+            For the deterministic intelligence layer that generated the grounding payload, continue
+            with <Link to="/examples/what-the-machine-sees">What the Machine Sees</Link>.
           </p>
         </div>
       </section>
@@ -383,9 +484,10 @@ export function ModelEvaluationReadingRoom() {
         <summary>Methods, provenance, and limits</summary>
         <div>
           <p>
-            This is a checked-in snapshot of one response per fixture and
-            condition, not a repeated-trial estimate. The Responses API ran with
-            reasoning effort set to none and provider storage disabled.
+            This page preserves the complete one-response baseline and adds three repeated targeted
+            trials. The follow-up covers the seven generation fixtures that previously failed and
+            all twenty answerable grounding questions; it does not carry forward untouched cases.
+            The Responses API ran with reasoning effort set to none and provider storage disabled.
           </p>
           <dl>
             <div>
@@ -394,7 +496,11 @@ export function ModelEvaluationReadingRoom() {
             </div>
             <div>
               <dt>First-try fixture</dt>
-              <dd>{MODEL_EVALUATION_RUN.firstTryRevision}</dd>
+              <dd>{FOLLOW_UP_RUN.firstTryRevision}</dd>
+            </div>
+            <div>
+              <dt>Follow-up requests</dt>
+              <dd>{INTEGER.format(FOLLOW_UP_RUN.requestCount)}</dd>
             </div>
             <div>
               <dt>Scorer</dt>
@@ -402,10 +508,16 @@ export function ModelEvaluationReadingRoom() {
             </div>
           </dl>
           <p>
-            Cost is the runner’s locked-rate estimate, not a billing ledger.
-            Small model differences should not be treated as stable without
-            repeated trials.
+            Cost is the runner’s locked-rate estimate, not a billing ledger. The repeat supports
+            claims only for its targeted fixtures and answerable questions.
           </p>
+          <a
+            href="https://github.com/nteract/semiotic/tree/main/evals/reports/openai-follow-up"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Open the repeated follow-up report
+          </a>
           <a
             href="https://github.com/nteract/semiotic/tree/main/evals/reports/openai-gpt-5.6-2026-07-27"
             target="_blank"

--- a/docs/src/pages/examples/ModelEvaluationExamplePage.test.jsx
+++ b/docs/src/pages/examples/ModelEvaluationExamplePage.test.jsx
@@ -9,11 +9,11 @@ vi.mock("../../hooks/useResponsiveWidth", () => ({
 }))
 
 vi.mock("semiotic/ordinal", () => ({
+  // Only the repeated post-merge rows carry `attempted`, so the mock keys off
+  // data shape rather than title copy an edit could change.
   GroupedBarChart: ({ data, title, valueLabel }) => (
     <div
-      data-testid={
-        title === "Repeated answerable outcomes" ? "follow-up-grounding-chart" : "grounding-chart"
-      }
+      data-testid={data[0]?.attempted == null ? "grounding-chart" : "follow-up-grounding-chart"}
       data-denominator={data[0]?.denominator}
       data-value-label={valueLabel}
     >

--- a/docs/src/pages/examples/ModelEvaluationExamplePage.test.jsx
+++ b/docs/src/pages/examples/ModelEvaluationExamplePage.test.jsx
@@ -11,7 +11,9 @@ vi.mock("../../hooks/useResponsiveWidth", () => ({
 vi.mock("semiotic/ordinal", () => ({
   GroupedBarChart: ({ data, title, valueLabel }) => (
     <div
-      data-testid="grounding-chart"
+      data-testid={
+        title === "Repeated answerable outcomes" ? "follow-up-grounding-chart" : "grounding-chart"
+      }
       data-denominator={data[0]?.denominator}
       data-value-label={valueLabel}
     >
@@ -33,20 +35,18 @@ describe("ModelEvaluationReadingRoom", () => {
   it("preserves the run ledger and the split score denominators", () => {
     renderRoom()
 
-    expect(screen.getAllByText("516")).toHaveLength(2)
+    expect(screen.getByText("1,119")).toBeTruthy()
+    expect(screen.getAllByText("603")).toHaveLength(2)
+    expect(screen.getByTestId("follow-up-grounding-chart").dataset.denominator).toBe("60")
     expect(screen.getByTestId("grounding-chart").dataset.denominator).toBe("50")
 
     fireEvent.click(screen.getByRole("button", { name: /Answerable, score out of 20/i }))
 
     expect(screen.getByTestId("grounding-chart").dataset.denominator).toBe("20")
     expect(screen.getByTestId("grounding-chart").dataset.valueLabel).toContain("of 20")
-    expect(
-      screen.getByText(/The payload did not add a correct answer/i),
-    ).toBeTruthy()
+    expect(screen.getByText(/The payload did not add a correct answer/i)).toBeTruthy()
 
-    fireEvent.click(
-      screen.getByRole("button", { name: /Correct abstention, score out of 30/i }),
-    )
+    fireEvent.click(screen.getByRole("button", { name: /Correct abstention, score out of 30/i }))
 
     expect(screen.getByTestId("grounding-chart").dataset.denominator).toBe("30")
     expect(screen.getByText(/combined evidence reached 30 of 30/i)).toBeTruthy()
@@ -55,6 +55,8 @@ describe("ModelEvaluationReadingRoom", () => {
   it("keeps failures, scorer corrections, and provenance readable without the charts", () => {
     renderRoom()
 
+    expect(screen.getByText(/revised payload recovered the answerable lookups/i)).toBeTruthy()
+    expect(screen.getByText(/6 fixtures held across every model and trial/i)).toBeTruthy()
     expect(screen.getByText("Failures by fixture family")).toBeTruthy()
     expect(screen.getByText(/render-evidence seam as much as a model miss/i)).toBeTruthy()
     expect(screen.getAllByText(/corrected:/i)).toHaveLength(3)

--- a/docs/src/pages/examples/data/modelEvaluationRun.js
+++ b/docs/src/pages/examples/data/modelEvaluationRun.js
@@ -11,13 +11,27 @@ export const MODEL_EVALUATION_RUN = Object.freeze({
   estimatedUsd: 2.27921653,
 })
 
+export const FOLLOW_UP_RUN = Object.freeze({
+  capturedAt: "2026-07-27",
+  fixtureRevision: "semiotic-grounding-2026-07-27-source-facts",
+  firstTryRevision: "semiotic-first-try-2026-07-27-contracts",
+  trialCount: 3,
+  requestCount: 603,
+  groundingOutcomes: 540,
+  firstTryOutcomes: 63,
+  answerableQuestions: 20,
+  firstTryFixtures: 7,
+  estimatedUsd: 1.95983369,
+})
+
+export const TOTAL_RECORDED_REQUESTS =
+  MODEL_EVALUATION_RUN.requestCount + FOLLOW_UP_RUN.requestCount
+
+export const TOTAL_ESTIMATED_USD = MODEL_EVALUATION_RUN.estimatedUsd + FOLLOW_UP_RUN.estimatedUsd
+
 export const MODEL_ORDER = Object.freeze(["Sol", "Terra", "Luna"])
 
-export const CONDITION_ORDER = Object.freeze([
-  "png-only",
-  "png-plus-grounding",
-  "grounding-only",
-])
+export const CONDITION_ORDER = Object.freeze(["png-only", "png-plus-grounding", "grounding-only"])
 
 export const CONDITION_LABELS = Object.freeze({
   "png-only": "PNG only",
@@ -140,6 +154,103 @@ export const GROUNDING_SCORES = Object.freeze([
     answerable: 12,
     unanswerable: 29,
   },
+])
+
+export const FOLLOW_UP_GROUNDING_SCORES = Object.freeze([
+  {
+    model: "Sol",
+    modelId: "gpt-5.6-sol",
+    condition: "png-only",
+    passed: 47,
+    attempted: 60,
+  },
+  {
+    model: "Sol",
+    modelId: "gpt-5.6-sol",
+    condition: "png-plus-grounding",
+    passed: 60,
+    attempted: 60,
+  },
+  {
+    model: "Sol",
+    modelId: "gpt-5.6-sol",
+    condition: "grounding-only",
+    passed: 60,
+    attempted: 60,
+  },
+  {
+    model: "Terra",
+    modelId: "gpt-5.6-terra",
+    condition: "png-only",
+    passed: 48,
+    attempted: 60,
+  },
+  {
+    model: "Terra",
+    modelId: "gpt-5.6-terra",
+    condition: "png-plus-grounding",
+    passed: 60,
+    attempted: 60,
+  },
+  {
+    model: "Terra",
+    modelId: "gpt-5.6-terra",
+    condition: "grounding-only",
+    passed: 60,
+    attempted: 60,
+  },
+  {
+    model: "Luna",
+    modelId: "gpt-5.6-luna",
+    condition: "png-only",
+    passed: 44,
+    attempted: 60,
+  },
+  {
+    model: "Luna",
+    modelId: "gpt-5.6-luna",
+    condition: "png-plus-grounding",
+    passed: 60,
+    attempted: 60,
+  },
+  {
+    model: "Luna",
+    modelId: "gpt-5.6-luna",
+    condition: "grounding-only",
+    passed: 60,
+    attempted: 60,
+  },
+])
+
+export const FOLLOW_UP_FIRST_TRY_MODELS = Object.freeze([
+  {
+    model: "Sol",
+    modelId: "gpt-5.6-sol",
+    passed: 21,
+    attempted: 21,
+  },
+  {
+    model: "Terra",
+    modelId: "gpt-5.6-terra",
+    passed: 21,
+    attempted: 21,
+  },
+  {
+    model: "Luna",
+    modelId: "gpt-5.6-luna",
+    passed: 19,
+    attempted: 21,
+  },
+])
+
+export const FOLLOW_UP_FIRST_TRY_FIXTURES = Object.freeze([
+  { fixtureId: "line-push", passed: 9, attempted: 9 },
+  { fixtureId: "scatter-push", passed: 9, attempted: 9 },
+  { fixtureId: "bubble-static", passed: 9, attempted: 9 },
+  { fixtureId: "gauge-static", passed: 7, attempted: 9 },
+  { fixtureId: "symbol-map-static", passed: 9, attempted: 9 },
+  { fixtureId: "galton-static", passed: 9, attempted: 9 },
+  { fixtureId: "unit-pile-push", passed: 9, attempted: 9 },
 ])
 
 export const FIRST_TRY_MODELS = Object.freeze([
@@ -267,10 +378,16 @@ export function groundingRowsForMetric(metricId) {
   }))
 }
 
+export function followUpGroundingRows() {
+  return FOLLOW_UP_GROUNDING_SCORES.map((row) => ({
+    ...row,
+    conditionLabel: CONDITION_LABELS[row.condition],
+    denominator: row.attempted,
+  }))
+}
+
 export function combinedGroundingDeltas(model) {
-  const png = GROUNDING_SCORES.find(
-    (row) => row.model === model && row.condition === "png-only",
-  )
+  const png = GROUNDING_SCORES.find((row) => row.model === model && row.condition === "png-only")
   const combined = GROUNDING_SCORES.find(
     (row) => row.model === model && row.condition === "png-plus-grounding",
   )

--- a/docs/src/pages/examples/data/modelEvaluationRun.test.js
+++ b/docs/src/pages/examples/data/modelEvaluationRun.test.js
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest"
 import {
   CONDITION_ORDER,
+  FOLLOW_UP_FIRST_TRY_FIXTURES,
+  FOLLOW_UP_FIRST_TRY_MODELS,
+  FOLLOW_UP_GROUNDING_SCORES,
+  FOLLOW_UP_RUN,
   FIRST_TRY_MODELS,
   GROUNDING_SCORES,
   MODEL_EVALUATION_RUN,
   MODEL_ORDER,
+  TOTAL_RECORDED_REQUESTS,
   combinedGroundingDeltas,
   failedFirstTryCount,
   groundingRowsForMetric,
@@ -26,9 +31,7 @@ describe("model evaluation example data", () => {
     for (const row of GROUNDING_SCORES) {
       expect(row.answerable + row.unanswerable).toBe(row.overall)
     }
-    expect(groundingRowsForMetric("answerable").every((row) => row.denominator === 20)).toBe(
-      true,
-    )
+    expect(groundingRowsForMetric("answerable").every((row) => row.denominator === 20)).toBe(true)
   })
 
   it("pins the combined-grounding tradeoff rather than only its aggregate", () => {
@@ -56,5 +59,22 @@ describe("model evaluation example data", () => {
     for (const row of FIRST_TRY_MODELS) {
       expect(failedFirstTryCount(row.model)).toBe(row.attempted - row.passed)
     }
+  })
+
+  it("keeps the repeated targeted follow-up separate from the complete baseline", () => {
+    expect(FOLLOW_UP_RUN.requestCount).toBe(
+      FOLLOW_UP_RUN.groundingOutcomes + FOLLOW_UP_RUN.firstTryOutcomes,
+    )
+    expect(TOTAL_RECORDED_REQUESTS).toBe(1119)
+    expect(FOLLOW_UP_GROUNDING_SCORES).toHaveLength(MODEL_ORDER.length * CONDITION_ORDER.length)
+    expect(
+      FOLLOW_UP_GROUNDING_SCORES.filter((row) => row.condition !== "png-only").every(
+        (row) => row.passed === row.attempted,
+      ),
+    ).toBe(true)
+    expect(FOLLOW_UP_FIRST_TRY_MODELS.reduce((total, row) => total + row.passed, 0)).toBe(61)
+    expect(
+      FOLLOW_UP_FIRST_TRY_FIXTURES.find((row) => row.fixtureId === "gauge-static"),
+    ).toMatchObject({ passed: 7, attempted: 9 })
   })
 })

--- a/docs/src/pages/examples/data/semioticArchitecture.js
+++ b/docs/src/pages/examples/data/semioticArchitecture.js
@@ -1243,7 +1243,7 @@ const EXPLICIT_EXAMPLE_PROFILES = [
   {
     id: "the-benchmark-is-a-chart-too",
     shortLabel: "Benchmark Is a Chart",
-    note: "A three-model scorecard separates answerable reads from correct abstentions, then keeps the first-attempt failure matrix and scorer corrections beside the aggregate.",
+    note: "A three-model scorecard separates answerable reads from correct abstentions, then places repeated post-merge evidence beside the first-attempt failure matrix and scorer corrections.",
     uses: [
       "input-static",
       "hoc-ordinal-bars",

--- a/docs/src/pages/examples/exampleDefinitions.js
+++ b/docs/src/pages/examples/exampleDefinitions.js
@@ -212,8 +212,7 @@ const PILOT_EXAMPLE_DEFINITIONS = Object.freeze([
       performance: {
         status: "bounded-and-route-split",
         budgets: {
-          bundle:
-            "lazy example route; the optional 110m world reference is dynamically imported",
+          bundle: "lazy example route; the optional 110m world reference is dynamically imported",
           interaction:
             "bounded projected lattice or 50 authored U.S. cells / 177 Natural Earth centroids with memoized responsive layout configuration",
           memory:
@@ -512,8 +511,7 @@ const PILOT_EXAMPLE_DEFINITIONS = Object.freeze([
         reviewCadence: "release",
       },
       accessibility: {
-        summary:
-          "Blocker-amplification comparison, settled task table, and a live observation log",
+        summary: "Blocker-amplification comparison, settled task table, and a live observation log",
         navigation:
           "Selected task drives both views; keyboard-reachable task marks in the swimlane and the machine",
         keyboard: "Native buttons plus canvas keyboard navigation in both charts",
@@ -536,7 +534,8 @@ const PILOT_EXAMPLE_DEFINITIONS = Object.freeze([
       performance: {
         status: "unmeasured",
         budgets: {
-          bundle: "lazy example route using public root, ordinal, physics, and recipes entry points",
+          bundle:
+            "lazy example route using public root, ordinal, physics, and recipes entry points",
           interaction: "unmeasured",
           memory: "20-task dependency machine with a bounded 6-event observation log",
           hiddenPage: "physics suspendWhenHidden inherited from the frame",
@@ -787,20 +786,20 @@ const PILOT_EXAMPLE_DEFINITIONS = Object.freeze([
     title: "The Benchmark Is a Chart, Too",
     eyebrow: "Model evaluation · scorer audit",
     description:
-      "Read the completed compatibility run as evidence: split answers from abstentions, inspect first-attempt failures, and audit the scorer before trusting the total.",
+      "Read the compatibility baseline and repeated post-merge trial as evidence: separate answers from abstentions, inspect repaired contracts and residual failures, and audit the scorer before trusting the total.",
     contract: {
       publicImports: ["semiotic/ordinal"],
       data: {
         states: ["snapshot"],
         fixture: {
-          kind: "checked-in-openai-gpt-5.6-compatibility-run",
+          kind: "checked-in-openai-gpt-5.6-baseline-and-repeat",
           replay: false,
           schemaVersion: "1",
         },
       },
       provenance: {
         source:
-          "Semiotic prove-track OpenAI Responses run, corrected score reports, and request ledger",
+          "Semiotic prove-track OpenAI Responses baseline, repeated targeted trials, corrected score reports, and request ledgers",
         capturedAt: "2026-07-27",
         freshnessOwner: "Semiotic maintainers",
         reviewCadence: "fixture revision",

--- a/evals/README.md
+++ b/evals/README.md
@@ -23,6 +23,12 @@ grounding result is mixed — the combined payload improved Sol's abstention,
 tied PNG-only for Terra and Luna, and did not improve answerable reading — and
 is preserved without reinterpretation.
 
+The subsequent
+[`openai-follow-up`](./reports/openai-follow-up/README.md) report adds three
+targeted post-merge trials: 603 requests covering the seven generation fixtures
+that previously failed and all twenty answerable grounding questions. It
+reports only repeated cases and does not replace the complete baseline.
+
 Run `npm run prepare:ai-evals` after an intentional fixture change, then
 `npm run eval:ai` for the local render oracle. Provider result files conform
 to the schemas in each suite and can be scored with

--- a/evals/reports/openai-follow-up/README.md
+++ b/evals/reports/openai-follow-up/README.md
@@ -1,0 +1,111 @@
+# Post-merge OpenAI evaluation follow-up
+
+This report preserves three repeated, targeted trials run after the MCP
+validation work merged on 2026-07-27. It tests the fixture revisions
+`semiotic-first-try-2026-07-27-contracts` and
+`semiotic-grounding-2026-07-27-source-facts` against `gpt-5.6-sol`,
+`gpt-5.6-terra`, and `gpt-5.6-luna`.
+
+The follow-up does not replace the complete 516-request baseline. It repeats the
+cases changed by the implementation work:
+
+- seven first-attempt generation fixtures that failed for at least one model in
+  the baseline;
+- all twenty answerable grounding questions;
+- all three grounding conditions, so PNG-only remains an internal control.
+
+The source of truth is [`summary.json`](./summary.json). The three trial
+directories retain parsed proposals, answers, usage records, model IDs, fixture
+revisions, response hashes, and resumable request ledgers. They do not retain
+credentials, project IDs, prompts, or raw provider response bodies.
+
+## Run ledger
+
+| Trial | Requests | Estimated cost |
+| --- | ---: | ---: |
+| `postmerge-a` | 201 | $0.85890704 |
+| `postmerge-b` | 201 | $0.55227145 |
+| `postmerge-c` | 201 | $0.54865520 |
+| **Total** | **603** | **$1.95983369** |
+
+Each trial contains 21 generation outcomes and 180 grounding outcomes. The
+runner used concurrency two after the complete baseline showed that higher
+concurrency could exhaust Luna's token-per-minute allowance.
+
+## First-attempt generation
+
+| Model | Passing targeted proposals | Pass rate |
+| --- | ---: | ---: |
+| Sol | 21/21 | 100% |
+| Terra | 21/21 | 100% |
+| Luna | 19/21 | 90.5% |
+| **All models** | **61/63** | **96.8%** |
+
+Six fixtures passed all nine model/trial combinations:
+
+- `line-push`
+- `scatter-push`
+- `bubble-static`
+- `symbol-map-static`
+- `galton-static`
+- `unit-pile-push`
+
+`gauge-static` passed 7/9. Luna chose the documented `BigNumber` component in
+all three trials. Trial A validated and rendered with native evidence. Trials B
+and C added the unsupported chart-HOC prop `accessibleTable` (`true` and
+`false`, respectively), so validation correctly rejected both proposals.
+
+This closes the original BigNumber render-evidence gap and Luna's empty
+GaugeChart failure. The remaining miss is narrower: a model sometimes applies a
+common HOC accessibility prop to a value component despite the component
+contract explicitly excluding it. The result must remain a failure; accepting
+or silently stripping the prop after the fact would weaken the first-attempt
+measure.
+
+## Answerable grounding
+
+Every cell contains 60 outcomes: twenty questions repeated across three trials
+for one model.
+
+| Model | PNG only | PNG + grounding | Grounding only |
+| --- | ---: | ---: | ---: |
+| Sol | 47/60 (78.3%) | 60/60 (100%) | 60/60 (100%) |
+| Terra | 48/60 (80.0%) | 60/60 (100%) | 60/60 (100%) |
+| Luna | 44/60 (73.3%) | 60/60 (100%) | 60/60 (100%) |
+| **All models** | **139/180 (77.2%)** | **180/180 (100%)** | **180/180 (100%)** |
+
+The PNG-only control remained close to the complete baseline's one-response
+answerable split of 47/60. The revised grounding payload recovered every
+targeted answerable lookup in both conditions that supplied it.
+
+This is evidence for the new source-fact projection on these twenty fixtures,
+not a general chart-literacy claim. The follow-up deliberately omitted the
+thirty unanswerable questions because that payload behavior did not change.
+Therefore it does not update the baseline's abstention result or its complete
+overall score.
+
+Four PNG-only questions failed all nine model/trial combinations:
+
+- `request-flow/failed`
+- `storage-tree/largest`
+- `storage-tree/backups`
+- `galton-values/range`
+
+All four passed 18/18 when grounding was present. This is the intended
+information boundary: exact observed facts absent or difficult to recover from
+pixels are explicit in the reader payload.
+
+## Interpretation
+
+The post-merge evidence supports two scoped conclusions:
+
+1. The revised serialized formatter, push, geo, physics, and render-evidence
+   contracts resolved the original targeted failures for Sol and Terra and six
+   of seven fixtures across every model and trial.
+2. The source-fact grounding revision recovered the tested answerable lookups
+   consistently without changing the PNG-only control.
+
+It also leaves one concrete follow-up: make the HOC/value-component boundary
+harder to misread in constrained generation contexts, then retest
+`gauge-static` under a new fixture revision. The current 7/9 result should not
+be rewritten in place.

--- a/evals/reports/openai-follow-up/summary.json
+++ b/evals/reports/openai-follow-up/summary.json
@@ -1,0 +1,8623 @@
+{
+  "version": 1,
+  "generatedAt": "2026-07-27T20:33:31.204Z",
+  "fixtureRevisions": {
+    "firstTry": "semiotic-first-try-2026-07-27-contracts",
+    "grounding": "semiotic-grounding-2026-07-27-source-facts",
+    "groundingScoring": "semiotic-grounding-score-2026-07-27"
+  },
+  "models": [
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna"
+  ],
+  "filters": {
+    "suites": [
+      "first-try",
+      "grounding"
+    ],
+    "firstTryFixtureIds": [
+      "gauge-static",
+      "line-push",
+      "scatter-push",
+      "bubble-static",
+      "symbol-map-static",
+      "unit-pile-push",
+      "galton-static"
+    ],
+    "groundingFixtureIds": [
+      "regional-revenue/highest",
+      "regional-revenue/count",
+      "weekly-users/last",
+      "weekly-users/direction",
+      "payload-latency/largest",
+      "payload-latency/count",
+      "service-latency/categories",
+      "service-latency/max",
+      "request-flow/largest",
+      "request-flow/failed",
+      "storage-tree/largest",
+      "storage-tree/backups",
+      "incident-map/largest",
+      "incident-map/count",
+      "sla-gauge/value",
+      "sla-gauge/maximum",
+      "conversion-funnel/purchases",
+      "conversion-funnel/stages",
+      "galton-values/range",
+      "galton-values/count"
+    ],
+    "groundingConditions": [
+      "png-only",
+      "png-plus-grounding",
+      "grounding-only"
+    ]
+  },
+  "summary": {
+    "trials": 3,
+    "requests": 603,
+    "estimatedUsd": 1.95983369,
+    "firstTryOutcomes": 63,
+    "groundingOutcomes": 540
+  },
+  "trials": [
+    {
+      "trialId": "postmerge-a",
+      "completedAt": "2026-07-27T20:15:11.385Z",
+      "requests": 201,
+      "estimatedUsd": 0.85890704
+    },
+    {
+      "trialId": "postmerge-b",
+      "completedAt": "2026-07-27T20:28:55.981Z",
+      "requests": 201,
+      "estimatedUsd": 0.55227145
+    },
+    {
+      "trialId": "postmerge-c",
+      "completedAt": "2026-07-27T20:33:03.991Z",
+      "requests": 201,
+      "estimatedUsd": 0.5486552
+    }
+  ],
+  "firstTry": {
+    "byModel": [
+      {
+        "model": "gpt-5.6-sol",
+        "trials": 21,
+        "passed": 21,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-terra",
+        "trials": 21,
+        "passed": 21,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-luna",
+        "trials": 21,
+        "passed": 19,
+        "passRate": 0.9048
+      }
+    ],
+    "byFixture": [
+      {
+        "fixtureId": "line-push",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "scatter-push",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "bubble-static",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "gauge-static",
+        "trials": 9,
+        "passed": 7,
+        "passRate": 0.7778
+      },
+      {
+        "fixtureId": "symbol-map-static",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "galton-static",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "unit-pile-push",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      }
+    ],
+    "byModelAndFixture": [
+      {
+        "model": "gpt-5.6-sol",
+        "fixtureId": "line-push",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-sol",
+        "fixtureId": "scatter-push",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-sol",
+        "fixtureId": "bubble-static",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-sol",
+        "fixtureId": "gauge-static",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-sol",
+        "fixtureId": "symbol-map-static",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-static",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-sol",
+        "fixtureId": "unit-pile-push",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-terra",
+        "fixtureId": "line-push",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-terra",
+        "fixtureId": "scatter-push",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-terra",
+        "fixtureId": "bubble-static",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-terra",
+        "fixtureId": "gauge-static",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-terra",
+        "fixtureId": "symbol-map-static",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-static",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-terra",
+        "fixtureId": "unit-pile-push",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-luna",
+        "fixtureId": "line-push",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-luna",
+        "fixtureId": "scatter-push",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-luna",
+        "fixtureId": "bubble-static",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-luna",
+        "fixtureId": "gauge-static",
+        "trials": 3,
+        "passed": 1,
+        "passRate": 0.3333
+      },
+      {
+        "model": "gpt-5.6-luna",
+        "fixtureId": "symbol-map-static",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-static",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-luna",
+        "fixtureId": "unit-pile-push",
+        "trials": 3,
+        "passed": 3,
+        "passRate": 1
+      }
+    ],
+    "outcomes": [
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "line-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 1,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "scatter-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 4,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "bubble-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 3,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "gauge-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 1,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "symbol-map-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 3,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 4,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "unit-pile-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 7,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "line-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 5,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "scatter-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 4,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "bubble-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 3,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "gauge-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 1,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "symbol-map-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 3,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 4,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "unit-pile-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 7,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "line-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 1,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "scatter-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 4,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "bubble-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 3,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "gauge-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 1,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "symbol-map-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 3,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 4,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "unit-pile-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 7,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "line-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 1,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "scatter-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 4,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "bubble-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 3,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "gauge-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 1,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "symbol-map-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 3,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 4,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "unit-pile-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 7,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "line-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 5,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "scatter-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 4,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "bubble-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 3,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "gauge-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 1,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "symbol-map-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 3,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 4,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "unit-pile-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 7,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "line-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 1,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "scatter-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 4,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "bubble-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 3,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "gauge-static",
+        "validated": false,
+        "renderProven": false,
+        "noErrorDiagnostics": false,
+        "markCount": 0,
+        "passed": false
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "symbol-map-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 3,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 4,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "unit-pile-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 7,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "line-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 1,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "scatter-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 4,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "bubble-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 3,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "gauge-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 1,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "symbol-map-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 3,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 4,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "unit-pile-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 7,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "line-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 1,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "scatter-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 4,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "bubble-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 3,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "gauge-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 1,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "symbol-map-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 3,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 4,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "unit-pile-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 7,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "line-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 1,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "scatter-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 4,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "bubble-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 3,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "gauge-static",
+        "validated": false,
+        "renderProven": false,
+        "noErrorDiagnostics": false,
+        "markCount": 0,
+        "passed": false
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "symbol-map-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 3,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-static",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 4,
+        "passed": true
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "unit-pile-push",
+        "validated": true,
+        "renderProven": true,
+        "noErrorDiagnostics": true,
+        "markCount": 7,
+        "passed": true
+      }
+    ]
+  },
+  "grounding": {
+    "byModel": [
+      {
+        "model": "gpt-5.6-sol",
+        "trials": 180,
+        "passed": 167,
+        "passRate": 0.9278
+      },
+      {
+        "model": "gpt-5.6-terra",
+        "trials": 180,
+        "passed": 168,
+        "passRate": 0.9333
+      },
+      {
+        "model": "gpt-5.6-luna",
+        "trials": 180,
+        "passed": 164,
+        "passRate": 0.9111
+      }
+    ],
+    "byModelAndCondition": [
+      {
+        "model": "gpt-5.6-sol",
+        "condition": "png-only",
+        "trials": 60,
+        "passed": 47,
+        "passRate": 0.7833
+      },
+      {
+        "model": "gpt-5.6-sol",
+        "condition": "png-plus-grounding",
+        "trials": 60,
+        "passed": 60,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-sol",
+        "condition": "grounding-only",
+        "trials": 60,
+        "passed": 60,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-terra",
+        "condition": "png-only",
+        "trials": 60,
+        "passed": 48,
+        "passRate": 0.8
+      },
+      {
+        "model": "gpt-5.6-terra",
+        "condition": "png-plus-grounding",
+        "trials": 60,
+        "passed": 60,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-terra",
+        "condition": "grounding-only",
+        "trials": 60,
+        "passed": 60,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-luna",
+        "condition": "png-only",
+        "trials": 60,
+        "passed": 44,
+        "passRate": 0.7333
+      },
+      {
+        "model": "gpt-5.6-luna",
+        "condition": "png-plus-grounding",
+        "trials": 60,
+        "passed": 60,
+        "passRate": 1
+      },
+      {
+        "model": "gpt-5.6-luna",
+        "condition": "grounding-only",
+        "trials": 60,
+        "passed": 60,
+        "passRate": 1
+      }
+    ],
+    "byFixtureAndCondition": [
+      {
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "regional-revenue/highest",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "regional-revenue/count",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "weekly-users/last",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "weekly-users/last",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "weekly-users/last",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "weekly-users/direction",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 8,
+        "passRate": 0.8889
+      },
+      {
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "payload-latency/largest",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "payload-latency/count",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "payload-latency/count",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "payload-latency/count",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "service-latency/categories",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "service-latency/categories",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "service-latency/categories",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "service-latency/max",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "service-latency/max",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "service-latency/max",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "request-flow/largest",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "request-flow/largest",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "request-flow/largest",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "request-flow/failed",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 0,
+        "passRate": 0
+      },
+      {
+        "fixtureId": "request-flow/failed",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "request-flow/failed",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 0,
+        "passRate": 0
+      },
+      {
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "storage-tree/largest",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 0,
+        "passRate": 0
+      },
+      {
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "storage-tree/backups",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "incident-map/largest",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 8,
+        "passRate": 0.8889
+      },
+      {
+        "fixtureId": "incident-map/largest",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "incident-map/largest",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "incident-map/count",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "incident-map/count",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "incident-map/count",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "sla-gauge/value",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "galton-values/range",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 0,
+        "passRate": 0
+      },
+      {
+        "fixtureId": "galton-values/range",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "galton-values/range",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "galton-values/count",
+        "condition": "png-only",
+        "trials": 9,
+        "passed": 6,
+        "passRate": 0.6667
+      },
+      {
+        "fixtureId": "galton-values/count",
+        "condition": "png-plus-grounding",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      },
+      {
+        "fixtureId": "galton-values/count",
+        "condition": "grounding-only",
+        "trials": 9,
+        "passed": 9,
+        "passRate": 1
+      }
+    ],
+    "outcomes": [
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "regional-revenue/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "weekly-users/last",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "weekly-users/last",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "weekly-users/last",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "weekly-users/direction",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "payload-latency/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "payload-latency/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "payload-latency/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "payload-latency/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "service-latency/categories",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "service-latency/categories",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "service-latency/categories",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "service-latency/max",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "service-latency/max",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "service-latency/max",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "request-flow/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "request-flow/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "request-flow/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "request-flow/failed",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": false,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "request-flow/failed",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "request-flow/failed",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "storage-tree/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "storage-tree/backups",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "incident-map/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "incident-map/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "incident-map/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "incident-map/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "incident-map/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "incident-map/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "sla-gauge/value",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-values/range",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-values/range",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-values/range",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-values/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-values/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-values/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "regional-revenue/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "weekly-users/last",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "weekly-users/last",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "weekly-users/last",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "weekly-users/direction",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "payload-latency/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "payload-latency/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "payload-latency/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "payload-latency/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "service-latency/categories",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "service-latency/categories",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "service-latency/categories",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "service-latency/max",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "service-latency/max",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "service-latency/max",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "request-flow/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "request-flow/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "request-flow/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "request-flow/failed",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "request-flow/failed",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "request-flow/failed",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "storage-tree/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "storage-tree/backups",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "incident-map/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "incident-map/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "incident-map/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "incident-map/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "incident-map/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "incident-map/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "sla-gauge/value",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-values/range",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false,
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-values/range",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-values/range",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-values/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-values/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-values/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "regional-revenue/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "weekly-users/last",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "weekly-users/last",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "weekly-users/last",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "weekly-users/direction",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "payload-latency/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "payload-latency/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "payload-latency/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "payload-latency/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "service-latency/categories",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "service-latency/categories",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "service-latency/categories",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "service-latency/max",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "service-latency/max",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "service-latency/max",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "request-flow/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "request-flow/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "request-flow/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "request-flow/failed",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "request-flow/failed",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "request-flow/failed",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "storage-tree/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "storage-tree/backups",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "incident-map/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "incident-map/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "incident-map/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "incident-map/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "incident-map/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "incident-map/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "sla-gauge/value",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-values/range",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false,
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-values/range",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-values/range",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-values/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-values/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-a",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-values/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "regional-revenue/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "weekly-users/last",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "weekly-users/last",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "weekly-users/last",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "weekly-users/direction",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "payload-latency/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "payload-latency/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "payload-latency/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "payload-latency/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "service-latency/categories",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "service-latency/categories",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "service-latency/categories",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "service-latency/max",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "service-latency/max",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "service-latency/max",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "request-flow/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "request-flow/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "request-flow/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "request-flow/failed",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": false,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "request-flow/failed",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "request-flow/failed",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "storage-tree/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "storage-tree/backups",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "incident-map/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "incident-map/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "incident-map/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "incident-map/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "incident-map/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "incident-map/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "sla-gauge/value",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-values/range",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-values/range",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-values/range",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-values/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-values/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-values/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "regional-revenue/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "weekly-users/last",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "weekly-users/last",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "weekly-users/last",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "weekly-users/direction",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "payload-latency/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "payload-latency/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "payload-latency/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "payload-latency/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "service-latency/categories",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "service-latency/categories",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "service-latency/categories",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "service-latency/max",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "service-latency/max",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "service-latency/max",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "request-flow/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "request-flow/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "request-flow/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "request-flow/failed",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "request-flow/failed",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "request-flow/failed",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "storage-tree/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "storage-tree/backups",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "incident-map/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "incident-map/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "incident-map/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "incident-map/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "incident-map/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "incident-map/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "sla-gauge/value",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-values/range",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false,
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-values/range",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-values/range",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-values/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-values/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-values/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "regional-revenue/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "weekly-users/last",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "weekly-users/last",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "weekly-users/last",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "weekly-users/direction",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "payload-latency/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "payload-latency/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "payload-latency/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "payload-latency/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "service-latency/categories",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "service-latency/categories",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "service-latency/categories",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "service-latency/max",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "service-latency/max",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "service-latency/max",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "request-flow/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "request-flow/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "request-flow/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "request-flow/failed",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "request-flow/failed",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "request-flow/failed",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "storage-tree/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "storage-tree/backups",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "incident-map/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "incident-map/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "incident-map/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "incident-map/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "incident-map/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "incident-map/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "sla-gauge/value",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-values/range",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false,
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-values/range",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-values/range",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-values/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-values/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-b",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-values/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "regional-revenue/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "weekly-users/last",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "weekly-users/last",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "weekly-users/last",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "weekly-users/direction",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "payload-latency/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "payload-latency/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "payload-latency/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "payload-latency/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "service-latency/categories",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "service-latency/categories",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "service-latency/categories",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "service-latency/max",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "service-latency/max",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "service-latency/max",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "request-flow/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "request-flow/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "request-flow/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "request-flow/failed",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": false,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "request-flow/failed",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "request-flow/failed",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "storage-tree/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "storage-tree/backups",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "incident-map/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": false,
+        "matched": [
+          false,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "incident-map/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "incident-map/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "incident-map/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "incident-map/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "incident-map/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "sla-gauge/value",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-values/range",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-values/range",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-values/range",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-values/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-values/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-sol",
+        "fixtureId": "galton-values/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "regional-revenue/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "weekly-users/last",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "weekly-users/last",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "weekly-users/last",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "weekly-users/direction",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "payload-latency/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "payload-latency/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "payload-latency/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "payload-latency/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "service-latency/categories",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "service-latency/categories",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "service-latency/categories",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "service-latency/max",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "service-latency/max",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "service-latency/max",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "request-flow/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "request-flow/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "request-flow/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "request-flow/failed",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "request-flow/failed",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "request-flow/failed",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "storage-tree/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "storage-tree/backups",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "incident-map/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "incident-map/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "incident-map/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "incident-map/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "incident-map/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "incident-map/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "sla-gauge/value",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-values/range",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false,
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-values/range",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-values/range",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-values/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-values/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-terra",
+        "fixtureId": "galton-values/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "regional-revenue/highest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "regional-revenue/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "regional-revenue/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "weekly-users/last",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "weekly-users/last",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "weekly-users/last",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "weekly-users/direction",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "weekly-users/direction",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "payload-latency/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "payload-latency/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "payload-latency/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "payload-latency/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "payload-latency/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "service-latency/categories",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "service-latency/categories",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "service-latency/categories",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "service-latency/max",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "service-latency/max",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "service-latency/max",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "request-flow/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "request-flow/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "request-flow/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "request-flow/failed",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "request-flow/failed",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "request-flow/failed",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "storage-tree/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "storage-tree/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "storage-tree/backups",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "storage-tree/backups",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "incident-map/largest",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "incident-map/largest",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "incident-map/largest",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "incident-map/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "incident-map/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "incident-map/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "sla-gauge/value",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "sla-gauge/value",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "sla-gauge/maximum",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "conversion-funnel/purchases",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "conversion-funnel/stages",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-values/range",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false,
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-values/range",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-values/range",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true,
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-values/count",
+        "condition": "png-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": false,
+        "abstained": true,
+        "matched": [
+          false
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-values/count",
+        "condition": "png-plus-grounding",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      },
+      {
+        "trialId": "postmerge-c",
+        "model": "gpt-5.6-luna",
+        "fixtureId": "galton-values/count",
+        "condition": "grounding-only",
+        "answerable": true,
+        "status": "scored",
+        "passed": true,
+        "abstained": false,
+        "matched": [
+          true
+        ]
+      }
+    ]
+  }
+}

--- a/evals/reports/openai-follow-up/trial-a/gpt-5.6-luna/first-try-results.json
+++ b/evals/reports/openai-follow-up/trial-a/gpt-5.6-luna/first-try-results.json
@@ -1,0 +1,225 @@
+{
+  "metadata": {
+    "modelId": "gpt-5.6-luna",
+    "clientVersion": "semiotic-openai-eval/1",
+    "fixtureRevision": "semiotic-first-try-2026-07-27-contracts",
+    "date": "2026-07-27",
+    "context": [
+      "CLAUDE.md",
+      "docs/public/llms.txt"
+    ]
+  },
+  "results": [
+    {
+      "fixtureId": "line-push",
+      "proposal": {
+        "component": "LineChart",
+        "props": {
+          "data": [
+            {
+              "week": 1,
+              "users": 120
+            },
+            {
+              "week": 2,
+              "users": 138
+            },
+            {
+              "week": 3,
+              "users": 151
+            }
+          ],
+          "xAccessor": "week",
+          "yAccessor": "users"
+        }
+      },
+      "rawOutputSha256": "aa45c1a9bc81bd075f976a9d2867a77f43a85fada4beb75edd44baa972fad878"
+    },
+    {
+      "fixtureId": "scatter-push",
+      "proposal": {
+        "component": "Scatterplot",
+        "props": {
+          "data": [
+            {
+              "payload_kb": 8,
+              "response_ms": 42
+            },
+            {
+              "payload_kb": 16,
+              "response_ms": 61
+            },
+            {
+              "payload_kb": 32,
+              "response_ms": 95
+            }
+          ],
+          "xAccessor": "payload_kb",
+          "yAccessor": "response_ms",
+          "pointIdAccessor": "payload_kb",
+          "width": 600,
+          "height": 400,
+          "title": "Response time by payload size",
+          "description": "Scatterplot showing response time in milliseconds by payload size in kilobytes.",
+          "summary": "Response time increases from 42 ms at 8 KB to 95 ms at 32 KB. The chart supports ref-based streaming pushes in React.",
+          "accessibleTable": true,
+          "enableHover": true,
+          "tooltip": true
+        }
+      },
+      "rawOutputSha256": "78ce45a07b9a3c21a46c53c9c96d9806967a9b986b5a3691615cb3183a5451e2"
+    },
+    {
+      "fixtureId": "bubble-static",
+      "proposal": {
+        "component": "BubbleChart",
+        "props": {
+          "data": [
+            {
+              "company": "A",
+              "growth": 12,
+              "retention": 86,
+              "customers": 300
+            },
+            {
+              "company": "B",
+              "growth": 18,
+              "retention": 78,
+              "customers": 180
+            },
+            {
+              "company": "C",
+              "growth": 9,
+              "retention": 92,
+              "customers": 420
+            }
+          ],
+          "xAccessor": "growth",
+          "yAccessor": "retention",
+          "sizeBy": "customers",
+          "colorBy": "company",
+          "sizeRange": [
+            10,
+            40
+          ],
+          "width": 600,
+          "height": 400,
+          "title": "Company growth and retention",
+          "description": "Comparison of companies by growth and retention, with bubble size representing customer count.",
+          "accessibleTable": true
+        }
+      },
+      "rawOutputSha256": "000247ae5d4beb81f95ac5d80e2110b7c35e2c0cb8d50dd3a0682003ffceac2a"
+    },
+    {
+      "fixtureId": "gauge-static",
+      "proposal": {
+        "component": "BigNumber",
+        "props": {
+          "value": 97,
+          "label": "SLA attainment",
+          "format": "number",
+          "suffix": "%",
+          "target": {
+            "value": 99,
+            "label": "target",
+            "format": "number",
+            "suffix": "%"
+          },
+          "description": "Current SLA attainment is 97 percent against a 99 percent target.",
+          "summary": "SLA attainment is 2 percentage points below the 99 percent target."
+        }
+      },
+      "rawOutputSha256": "bfd14ea9176add1c44aee79aafeba9c18c65a86d1872e652be7cfdb0a8d4c85a"
+    },
+    {
+      "fixtureId": "symbol-map-static",
+      "proposal": {
+        "component": "ProportionalSymbolMap",
+        "props": {
+          "points": [
+            {
+              "city": "A",
+              "longitude": -122.4,
+              "latitude": 37.8,
+              "incidents": 18
+            },
+            {
+              "city": "B",
+              "longitude": -74,
+              "latitude": 40.7,
+              "incidents": 31
+            },
+            {
+              "city": "C",
+              "longitude": -87.6,
+              "latitude": 41.9,
+              "incidents": 12
+            }
+          ],
+          "xAccessor": "longitude",
+          "yAccessor": "latitude",
+          "sizeBy": "incidents"
+        }
+      },
+      "rawOutputSha256": "ad24651613cc32bb1d985f9b720d7709628bca2d19c4ffee0240543e78d278c4"
+    },
+    {
+      "fixtureId": "galton-static",
+      "proposal": {
+        "component": "GaltonBoardChart",
+        "props": {
+          "data": [
+            {
+              "id": "a",
+              "value": 1
+            },
+            {
+              "id": "b",
+              "value": 2
+            },
+            {
+              "id": "c",
+              "value": 3
+            },
+            {
+              "id": "d",
+              "value": 4
+            }
+          ],
+          "valueAccessor": "value",
+          "seed": 42
+        }
+      },
+      "rawOutputSha256": "991ca987758a3d66c30df0a4dd882b4635a3245c7651c0c03e15f5cc707ab4a9"
+    },
+    {
+      "fixtureId": "unit-pile-push",
+      "proposal": {
+        "component": "UnitPileChart",
+        "props": {
+          "data": [
+            {
+              "id": "a",
+              "team": "Blue",
+              "value": 3
+            },
+            {
+              "id": "b",
+              "team": "Green",
+              "value": 2
+            }
+          ],
+          "categoryAccessor": "team",
+          "valueAccessor": "value",
+          "colorBy": "team",
+          "title": "Queued work by team",
+          "description": "Unit piles show the amount of queued work for each team.",
+          "summary": "Blue has 3 units of queued work and Green has 2 units. Additional rows can be appended through the chart ref in React.",
+          "accessibleTable": true
+        }
+      },
+      "rawOutputSha256": "eda545576bece4435bf7c5c8cf46ae359865c2151329ff44e450e35559d9eeea"
+    }
+  ]
+}

--- a/evals/reports/openai-follow-up/trial-a/gpt-5.6-luna/grounding-results.json
+++ b/evals/reports/openai-follow-up/trial-a/gpt-5.6-luna/grounding-results.json
@@ -1,0 +1,310 @@
+{
+  "metadata": {
+    "modelId": "gpt-5.6-luna",
+    "clientVersion": "semiotic-openai-eval/1",
+    "fixtureRevision": "semiotic-grounding-2026-07-27-source-facts",
+    "date": "2026-07-27"
+  },
+  "responses": [
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "png-only",
+      "answer": "North, with revenue of 18."
+    },
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "png-plus-grounding",
+      "answer": "North has the highest revenue, at 18."
+    },
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "grounding-only",
+      "answer": "North has the highest revenue, with a value of 18."
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "png-only",
+      "answer": "3 regions"
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "png-plus-grounding",
+      "answer": "3 regions."
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "grounding-only",
+      "answer": "3 regions"
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "png-only",
+      "answer": "165 users"
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "png-plus-grounding",
+      "answer": "The last observed user count is 165 (week 4)."
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "grounding-only",
+      "answer": "The last observed user count was 165 users (week 4)."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "png-only",
+      "answer": "The series rises across the observed weeks, increasing from about 120 in week 1 to about 165 in week 4."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "png-plus-grounding",
+      "answer": "The series rises across the observed weeks, increasing from 120 users in week 1 to 165 users in week 4."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "grounding-only",
+      "answer": "The series rises across the observed weeks, increasing from 120 users in week 1 to 165 users in week 4."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "png-only",
+      "answer": "The largest payload is approximately 64, paired with a latency of approximately 142."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "png-plus-grounding",
+      "answer": "The largest payload is 64, paired with a latency of 142."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "grounding-only",
+      "answer": "The largest payload is 64, paired with a latency of 142."
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "png-only",
+      "answer": "4 observations"
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "png-plus-grounding",
+      "answer": "4 observations"
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "grounding-only",
+      "answer": "4 observations"
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "png-only",
+      "answer": "API and Worker"
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "png-plus-grounding",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "grounding-only",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "png-only",
+      "answer": "160"
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "png-plus-grounding",
+      "answer": "The largest observed latency is 160."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "grounding-only",
+      "answer": "The largest observed latency is 160."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "png-only",
+      "answer": "Success receives the largest flow."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Success receives the largest flow, with a value of 78."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "grounding-only",
+      "answer": "Success receives the largest flow, with a value of 78."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "png-only",
+      "answer": "Cannot determine the number of requests flowing to Failure from the chart."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "png-plus-grounding",
+      "answer": "7 requests flow to Failure."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "grounding-only",
+      "answer": "7 requests flow to Failure."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "png-only",
+      "answer": "Cannot determine; the chart labels Logs, Images, and Backups but provides no values or sizes."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Images is the largest storage category, with a value of 48."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "grounding-only",
+      "answer": "Images, with a value of 48."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "png-only",
+      "answer": "Cannot determine; the chart labels “Backups” but does not show a value."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "png-plus-grounding",
+      "answer": "Backups is assigned a value of 20."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "grounding-only",
+      "answer": "Backups is assigned a value of 20."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "png-only",
+      "answer": "City B has the most incidents, with 31 incidents."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "png-plus-grounding",
+      "answer": "City B has the most incidents, with 31."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "grounding-only",
+      "answer": "City B has the most incidents, with 31."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "png-only",
+      "answer": "3 locations"
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "png-plus-grounding",
+      "answer": "3 locations."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "grounding-only",
+      "answer": "3 locations are plotted."
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "png-only",
+      "answer": "97 of 100"
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "png-plus-grounding",
+      "answer": "The current gauge value is 97."
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "grounding-only",
+      "answer": "Current gauge value: 97"
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "png-only",
+      "answer": "The gauge maximum is 100."
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "png-plus-grounding",
+      "answer": "The maximum defining the gauge scale is 100."
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "grounding-only",
+      "answer": "The gauge scale maximum is 100."
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "png-only",
+      "answer": "200"
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "png-plus-grounding",
+      "answer": "Purchases: 200"
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "grounding-only",
+      "answer": "Purchases: 200"
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "png-only",
+      "answer": "Visits; Trials; Purchases"
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "png-plus-grounding",
+      "answer": "Visits, Trials, Purchases"
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "grounding-only",
+      "answer": "Visits, Trials, and Purchases."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "png-only",
+      "answer": "Smallest observed value: cannot determine; largest observed value: cannot determine."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "png-plus-grounding",
+      "answer": "Smallest observed value: 1. Largest observed value: 4."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "grounding-only",
+      "answer": "Smallest observed value: 1. Largest observed value: 4."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "png-only",
+      "answer": "Cannot determine from the supplied evidence."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "png-plus-grounding",
+      "answer": "4 observed rows"
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "grounding-only",
+      "answer": "4 observed rows"
+    }
+  ]
+}

--- a/evals/reports/openai-follow-up/trial-a/gpt-5.6-sol/first-try-results.json
+++ b/evals/reports/openai-follow-up/trial-a/gpt-5.6-sol/first-try-results.json
@@ -1,0 +1,228 @@
+{
+  "metadata": {
+    "modelId": "gpt-5.6-sol",
+    "clientVersion": "semiotic-openai-eval/1",
+    "fixtureRevision": "semiotic-first-try-2026-07-27-contracts",
+    "date": "2026-07-27",
+    "context": [
+      "CLAUDE.md",
+      "docs/public/llms.txt"
+    ]
+  },
+  "results": [
+    {
+      "fixtureId": "line-push",
+      "proposal": {
+        "component": "LineChart",
+        "props": {
+          "data": [
+            {
+              "week": 1,
+              "users": 120
+            },
+            {
+              "week": 2,
+              "users": 138
+            },
+            {
+              "week": 3,
+              "users": 151
+            }
+          ],
+          "xAccessor": "week",
+          "yAccessor": "users"
+        }
+      },
+      "rawOutputSha256": "aa45c1a9bc81bd075f976a9d2867a77f43a85fada4beb75edd44baa972fad878"
+    },
+    {
+      "fixtureId": "scatter-push",
+      "proposal": {
+        "component": "Scatterplot",
+        "props": {
+          "data": [
+            {
+              "payload_kb": 8,
+              "response_ms": 42
+            },
+            {
+              "payload_kb": 16,
+              "response_ms": 61
+            },
+            {
+              "payload_kb": 32,
+              "response_ms": 95
+            }
+          ],
+          "xAccessor": "payload_kb",
+          "yAccessor": "response_ms",
+          "title": "Response Time by Payload Size",
+          "description": "Scatterplot of response time in milliseconds against payload size in kilobytes.",
+          "summary": "Response time increases as payload size increases.",
+          "accessibleTable": true,
+          "enableHover": true
+        }
+      },
+      "rawOutputSha256": "06f9ea5e886ec7cb00497ba6ae2021140fa1269a0873045c8eefd81a04355dd8"
+    },
+    {
+      "fixtureId": "bubble-static",
+      "proposal": {
+        "component": "BubbleChart",
+        "props": {
+          "data": [
+            {
+              "company": "A",
+              "growth": 12,
+              "retention": 86,
+              "customers": 300
+            },
+            {
+              "company": "B",
+              "growth": 18,
+              "retention": 78,
+              "customers": 180
+            },
+            {
+              "company": "C",
+              "growth": 9,
+              "retention": 92,
+              "customers": 420
+            }
+          ],
+          "xAccessor": "growth",
+          "yAccessor": "retention",
+          "sizeBy": "customers",
+          "colorBy": "company",
+          "title": "Company Growth and Retention",
+          "description": "Bubble chart comparing company growth and retention, with bubble size representing customer count.",
+          "summary": "Company C has the highest retention and largest customer base, while Company B has the highest growth and lowest retention.",
+          "showLegend": true,
+          "accessibleTable": true
+        }
+      },
+      "rawOutputSha256": "f29d43baab01575b088d0ac57f3a0c00025770d2484b5a45a8aa53a06bd7f737"
+    },
+    {
+      "fixtureId": "gauge-static",
+      "proposal": {
+        "component": "BigNumber",
+        "props": {
+          "value": 97,
+          "label": "SLA attainment",
+          "format": "number",
+          "suffix": "%",
+          "target": {
+            "value": 99,
+            "label": "target",
+            "format": "number"
+          },
+          "thresholds": [
+            {
+              "at": 0,
+              "level": "warning",
+              "color": "#c7952f",
+              "label": "Below target"
+            },
+            {
+              "at": 99,
+              "level": "success",
+              "color": "#2a8f68",
+              "label": "Meets target"
+            }
+          ],
+          "description": "Current SLA attainment is 97 percent against a target of 99 percent.",
+          "summary": "SLA attainment is 2 percentage points below target.",
+          "mode": "tile"
+        }
+      },
+      "rawOutputSha256": "476907f679e7fac333bd718cdad67fce1ef7b96320244e154ed2569cdd0f6a82"
+    },
+    {
+      "fixtureId": "symbol-map-static",
+      "proposal": {
+        "component": "ProportionalSymbolMap",
+        "props": {
+          "points": [
+            {
+              "city": "A",
+              "longitude": -122.4,
+              "latitude": 37.8,
+              "incidents": 18
+            },
+            {
+              "city": "B",
+              "longitude": -74,
+              "latitude": 40.7,
+              "incidents": 31
+            },
+            {
+              "city": "C",
+              "longitude": -87.6,
+              "latitude": 41.9,
+              "incidents": 12
+            }
+          ],
+          "xAccessor": "longitude",
+          "yAccessor": "latitude",
+          "sizeBy": "incidents"
+        }
+      },
+      "rawOutputSha256": "ad24651613cc32bb1d985f9b720d7709628bca2d19c4ffee0240543e78d278c4"
+    },
+    {
+      "fixtureId": "galton-static",
+      "proposal": {
+        "component": "GaltonBoardChart",
+        "props": {
+          "data": [
+            {
+              "id": "a",
+              "value": 1
+            },
+            {
+              "id": "b",
+              "value": 2
+            },
+            {
+              "id": "c",
+              "value": 3
+            },
+            {
+              "id": "d",
+              "value": 4
+            }
+          ],
+          "valueAccessor": "value",
+          "mode": "sample",
+          "seed": 42
+        }
+      },
+      "rawOutputSha256": "cca21da3fc818855f93324ed9a2a7b2081c559ba52cead21a388968b5acf2df3"
+    },
+    {
+      "fixtureId": "unit-pile-push",
+      "proposal": {
+        "component": "UnitPileChart",
+        "props": {
+          "data": [
+            {
+              "id": "a",
+              "team": "Blue",
+              "value": 3
+            },
+            {
+              "id": "b",
+              "team": "Green",
+              "value": 2
+            }
+          ],
+          "categoryAccessor": "team",
+          "valueAccessor": "value",
+          "unitValue": 1
+        }
+      },
+      "rawOutputSha256": "add8e8477487c817bce0146d71d94720611ed4029bb7f902fc3ab25e9c086bfd"
+    }
+  ]
+}

--- a/evals/reports/openai-follow-up/trial-a/gpt-5.6-sol/grounding-results.json
+++ b/evals/reports/openai-follow-up/trial-a/gpt-5.6-sol/grounding-results.json
@@ -1,0 +1,310 @@
+{
+  "metadata": {
+    "modelId": "gpt-5.6-sol",
+    "clientVersion": "semiotic-openai-eval/1",
+    "fixtureRevision": "semiotic-grounding-2026-07-27-source-facts",
+    "date": "2026-07-27"
+  },
+  "responses": [
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "png-only",
+      "answer": "North has the highest revenue, at 18."
+    },
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "png-plus-grounding",
+      "answer": "North has the highest revenue at 18."
+    },
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "grounding-only",
+      "answer": "North has the highest revenue, at 18."
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "png-only",
+      "answer": "3 regions: North, South, and West."
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "png-plus-grounding",
+      "answer": "3 regions: North, South, and West."
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "grounding-only",
+      "answer": "3 regions."
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "png-only",
+      "answer": "The last observed user count is 165 weekly active users."
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "png-plus-grounding",
+      "answer": "Week 4: 165 users."
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "grounding-only",
+      "answer": "Week 4: 165 users."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "png-only",
+      "answer": "The Weekly active users series rises across the observed weeks, increasing from about 120 in week 1 to about 165 in week 4."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "png-plus-grounding",
+      "answer": "The series rises across the observed weeks: users increase from 120 in week 1 to 138 in week 2, 151 in week 3, and 165 in week 4."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "grounding-only",
+      "answer": "The series rises across the observed weeks: Week 1: 120 users; Week 2: 138; Week 3: 151; Week 4: 165."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "png-only",
+      "answer": "The largest payload is paired with a latency of approximately 142."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "png-plus-grounding",
+      "answer": "The largest payload, 64, is paired with a latency of 142."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "grounding-only",
+      "answer": "The largest payload, 64, is paired with a latency of 142."
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "png-only",
+      "answer": "4 observations."
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "png-plus-grounding",
+      "answer": "4 observations."
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "grounding-only",
+      "answer": "4 observations."
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "png-only",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "png-plus-grounding",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "grounding-only",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "png-only",
+      "answer": "The largest observed latency is 160 for API."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "png-plus-grounding",
+      "answer": "The largest observed latency is 160 (API)."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "grounding-only",
+      "answer": "The largest observed latency is 160."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "png-only",
+      "answer": "Success receives the largest flow."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Success receives the largest flow: 78."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "grounding-only",
+      "answer": "Success receives the largest flow: 78."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "png-only",
+      "answer": "Failure: 30 requests"
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "png-plus-grounding",
+      "answer": "Failure: 7 requests."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "grounding-only",
+      "answer": "Failure: 7 requests."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "png-only",
+      "answer": "Cannot determine. The chart labels Images, Logs, and Backups but does not show distinct sizes or values for the categories."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Images is the largest storage category, with a value of 48."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "grounding-only",
+      "answer": "Images — 48."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "png-only",
+      "answer": "Backups: cannot determine."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "png-plus-grounding",
+      "answer": "Backups: 20"
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "grounding-only",
+      "answer": "Backups: 20"
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "png-only",
+      "answer": "City B has the most incidents, with 31."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "png-plus-grounding",
+      "answer": "City B has the most incidents, with 31."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "grounding-only",
+      "answer": "City B has the most incidents, with 31."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "png-only",
+      "answer": "3 locations."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "png-plus-grounding",
+      "answer": "3 locations are plotted: A, B, and C."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "grounding-only",
+      "answer": "3 locations are plotted: A, B, and C."
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "png-only",
+      "answer": "Current gauge value: 97 of 100."
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "png-plus-grounding",
+      "answer": "Current gauge value: 97."
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "grounding-only",
+      "answer": "Current gauge value: 97."
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "png-only",
+      "answer": "The gauge scale maximum is 100."
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "png-plus-grounding",
+      "answer": "Maximum: 100."
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "grounding-only",
+      "answer": "The gauge scale maximum is 100."
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "png-only",
+      "answer": "Purchases: 200 (20%)."
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "png-plus-grounding",
+      "answer": "Purchases: 200"
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "grounding-only",
+      "answer": "Purchases: 200"
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "png-only",
+      "answer": "Visits, Trials, Purchases."
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "png-plus-grounding",
+      "answer": "Visits, Trials, Purchases."
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "grounding-only",
+      "answer": "Visits: 1,000; Trials: 400; Purchases: 200."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "png-only",
+      "answer": "Cannot determine: the chart shows four points but provides no axis labels or numeric scale."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "png-plus-grounding",
+      "answer": "Smallest observed value: 1. Largest observed value: 4."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "grounding-only",
+      "answer": "Smallest observed value: 1. Largest observed value: 4."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "png-only",
+      "answer": "4 observed rows."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "png-plus-grounding",
+      "answer": "Observed rows: 4."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "grounding-only",
+      "answer": "Observed rows: 4."
+    }
+  ]
+}

--- a/evals/reports/openai-follow-up/trial-a/gpt-5.6-terra/first-try-results.json
+++ b/evals/reports/openai-follow-up/trial-a/gpt-5.6-terra/first-try-results.json
@@ -1,0 +1,246 @@
+{
+  "metadata": {
+    "modelId": "gpt-5.6-terra",
+    "clientVersion": "semiotic-openai-eval/1",
+    "fixtureRevision": "semiotic-first-try-2026-07-27-contracts",
+    "date": "2026-07-27",
+    "context": [
+      "CLAUDE.md",
+      "docs/public/llms.txt"
+    ]
+  },
+  "results": [
+    {
+      "fixtureId": "line-push",
+      "proposal": {
+        "component": "LineChart",
+        "props": {
+          "data": [
+            {
+              "week": 1,
+              "users": 120
+            },
+            {
+              "week": 2,
+              "users": 138
+            },
+            {
+              "week": 3,
+              "users": 151
+            }
+          ],
+          "xAccessor": "week",
+          "yAccessor": "users",
+          "title": "Active Users by Week",
+          "xLabel": "Week",
+          "yLabel": "Active Users",
+          "showPoints": true,
+          "pointRadius": 3
+        }
+      },
+      "rawOutputSha256": "4ab18391e0dc371322b615cefda19cbb07e980ea57d576091ff507ca8e7be82c"
+    },
+    {
+      "fixtureId": "scatter-push",
+      "proposal": {
+        "component": "Scatterplot",
+        "props": {
+          "data": [
+            {
+              "payload_kb": 8,
+              "response_ms": 42
+            },
+            {
+              "payload_kb": 16,
+              "response_ms": 61
+            },
+            {
+              "payload_kb": 32,
+              "response_ms": 95
+            }
+          ],
+          "xAccessor": "payload_kb",
+          "yAccessor": "response_ms",
+          "xLabel": "Payload size (KB)",
+          "yLabel": "Response time (ms)",
+          "title": "Response time by payload size",
+          "description": "Scatterplot of response time in milliseconds against payload size in kilobytes.",
+          "summary": "Response time increases from 42 milliseconds at 8 KB to 95 milliseconds at 32 KB. The chart supports ref-based streaming pushes in React."
+        }
+      },
+      "rawOutputSha256": "140802ff3747ce7fa9dfc4b8bbcb37dff40dc81e76e1035d0cdb08822bbe3cde"
+    },
+    {
+      "fixtureId": "bubble-static",
+      "proposal": {
+        "component": "BubbleChart",
+        "props": {
+          "data": [
+            {
+              "company": "A",
+              "growth": 12,
+              "retention": 86,
+              "customers": 300
+            },
+            {
+              "company": "B",
+              "growth": 18,
+              "retention": 78,
+              "customers": 180
+            },
+            {
+              "company": "C",
+              "growth": 9,
+              "retention": 92,
+              "customers": 420
+            }
+          ],
+          "xAccessor": "growth",
+          "yAccessor": "retention",
+          "sizeBy": "customers",
+          "colorBy": "company",
+          "xLabel": "Growth",
+          "yLabel": "Retention",
+          "title": "Growth and retention by company",
+          "description": "Bubble chart comparing company growth and retention, with bubble size representing customers.",
+          "summary": "Company C has the highest retention and customer count; Company B has the highest growth.",
+          "showLegend": true,
+          "tooltip": true
+        }
+      },
+      "rawOutputSha256": "31d319c7a31fa8c9ad64d4cce56e913e400f045d87132b9174f1778088512eec"
+    },
+    {
+      "fixtureId": "gauge-static",
+      "proposal": {
+        "component": "BigNumber",
+        "props": {
+          "value": 97,
+          "label": "SLA attainment",
+          "format": "number",
+          "suffix": "%",
+          "target": {
+            "value": 99,
+            "label": "target",
+            "format": "number"
+          },
+          "description": "Current SLA attainment is 97 percent against a target of 99 percent.",
+          "summary": "SLA attainment is 2 percentage points below the 99 percent target.",
+          "thresholds": [
+            {
+              "at": 0,
+              "level": "warning",
+              "color": "#c7952f",
+              "label": "Below target"
+            },
+            {
+              "at": 99,
+              "level": "success",
+              "color": "#2a8f68",
+              "label": "Meets target"
+            }
+          ]
+        }
+      },
+      "rawOutputSha256": "7fa27221bf02508a28913beb7e8a1d491055de36bc38dd8b96eeadd0fef8f253"
+    },
+    {
+      "fixtureId": "symbol-map-static",
+      "proposal": {
+        "component": "ProportionalSymbolMap",
+        "props": {
+          "points": [
+            {
+              "city": "A",
+              "longitude": -122.4,
+              "latitude": 37.8,
+              "incidents": 18
+            },
+            {
+              "city": "B",
+              "longitude": -74,
+              "latitude": 40.7,
+              "incidents": 31
+            },
+            {
+              "city": "C",
+              "longitude": -87.6,
+              "latitude": 41.9,
+              "incidents": 12
+            }
+          ],
+          "xAccessor": "longitude",
+          "yAccessor": "latitude",
+          "sizeBy": "incidents",
+          "sizeRange": [
+            5,
+            40
+          ],
+          "colorBy": "city",
+          "title": "Incident counts by location",
+          "description": "Proportional symbols show incident counts at three longitude and latitude locations.",
+          "showLegend": true
+        }
+      },
+      "rawOutputSha256": "ad62b2258a4503b52e6aae4a82b5fc7622f17b0697b29aac3fe0d0cc4a01b40c"
+    },
+    {
+      "fixtureId": "galton-static",
+      "proposal": {
+        "component": "GaltonBoardChart",
+        "props": {
+          "data": [
+            {
+              "id": "a",
+              "value": 1
+            },
+            {
+              "id": "b",
+              "value": 2
+            },
+            {
+              "id": "c",
+              "value": 3
+            },
+            {
+              "id": "d",
+              "value": 4
+            }
+          ],
+          "valueAccessor": "value",
+          "bins": 4,
+          "seed": 42
+        }
+      },
+      "rawOutputSha256": "a2cd7e9c911fc269d1fce6f111b3f6c27dc9f3059a7186b6645992cf9933b087"
+    },
+    {
+      "fixtureId": "unit-pile-push",
+      "proposal": {
+        "component": "UnitPileChart",
+        "props": {
+          "data": [
+            {
+              "id": "a",
+              "team": "Blue",
+              "value": 3
+            },
+            {
+              "id": "b",
+              "team": "Green",
+              "value": 2
+            }
+          ],
+          "categoryAccessor": "team",
+          "valueAccessor": "value",
+          "colorBy": "team",
+          "unitValue": 1,
+          "title": "Queued work by team",
+          "description": "A unit pile showing queued work totals by team.",
+          "summary": "Blue has 3 units of queued work and Green has 2 units. Additional source rows can be added through the chart ref push API."
+        }
+      },
+      "rawOutputSha256": "840faf4b612604fe82eb0a8f098916797a3229490167a34b49582f2261f99e3d"
+    }
+  ]
+}

--- a/evals/reports/openai-follow-up/trial-a/gpt-5.6-terra/grounding-results.json
+++ b/evals/reports/openai-follow-up/trial-a/gpt-5.6-terra/grounding-results.json
@@ -1,0 +1,310 @@
+{
+  "metadata": {
+    "modelId": "gpt-5.6-terra",
+    "clientVersion": "semiotic-openai-eval/1",
+    "fixtureRevision": "semiotic-grounding-2026-07-27-source-facts",
+    "date": "2026-07-27"
+  },
+  "responses": [
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "png-only",
+      "answer": "North has the highest revenue, with a value of 18."
+    },
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "png-plus-grounding",
+      "answer": "North has the highest revenue, at 18."
+    },
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "grounding-only",
+      "answer": "North has the highest revenue, at 18."
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "png-only",
+      "answer": "3 regions"
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "png-plus-grounding",
+      "answer": "3 regions"
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "grounding-only",
+      "answer": "3 regions."
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "png-only",
+      "answer": "165"
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "png-plus-grounding",
+      "answer": "Last observed user count (week 4): 165."
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "grounding-only",
+      "answer": "Week 4: 165 users."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "png-only",
+      "answer": "The series rises across the observed weeks, increasing from about 120 at week 1 to about 165 at week 4."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "png-plus-grounding",
+      "answer": "Rise: users increase from 120 in week 1 to 165 in week 4."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "grounding-only",
+      "answer": "The series rises across the observed weeks, from 120 users in week 1 to 165 users in week 4."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "png-only",
+      "answer": "The largest payload is 142, paired with a latency of 64."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "png-plus-grounding",
+      "answer": "At the largest payload, 64, the latency is 142."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "grounding-only",
+      "answer": "At the largest payload, 64, the latency is 142."
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "png-only",
+      "answer": "4 observations"
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "png-plus-grounding",
+      "answer": "4 observations are plotted."
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "grounding-only",
+      "answer": "4 observations are plotted."
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "png-only",
+      "answer": "API and Worker"
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "png-plus-grounding",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "grounding-only",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "png-only",
+      "answer": "160"
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "png-plus-grounding",
+      "answer": "160"
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "grounding-only",
+      "answer": "160"
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "png-only",
+      "answer": "Success"
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Success receives the largest flow: 78."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "grounding-only",
+      "answer": "Success receives the largest flow: 78."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "png-only",
+      "answer": "Cannot determine; the chart shows a flow to Failure but provides no numeric value."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "png-plus-grounding",
+      "answer": "Failure: 7 requests."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "grounding-only",
+      "answer": "7 requests flow to Failure."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "png-only",
+      "answer": "Cannot determine; the chart labels Images, Logs, and Backups but provides no values or relative sizes."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Images is the largest storage category, with a value of 48."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "grounding-only",
+      "answer": "Images is the largest storage category, with a value of 48."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "png-only",
+      "answer": "cannot determine"
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "png-plus-grounding",
+      "answer": "Backups: 20"
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "grounding-only",
+      "answer": "Backups: 20"
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "png-only",
+      "answer": "B has the most incidents, with 31."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "png-plus-grounding",
+      "answer": "City B has the most incidents: 31."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "grounding-only",
+      "answer": "City B has the most incidents: 31."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "png-only",
+      "answer": "3 locations"
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "png-plus-grounding",
+      "answer": "3 locations are plotted: A, B, and C."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "grounding-only",
+      "answer": "3 locations are plotted."
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "png-only",
+      "answer": "97 of 100"
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "png-plus-grounding",
+      "answer": "97"
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "grounding-only",
+      "answer": "97"
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "png-only",
+      "answer": "100"
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "png-plus-grounding",
+      "answer": "100"
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "grounding-only",
+      "answer": "100"
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "png-only",
+      "answer": "Purchases: 200 (20%)"
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "png-plus-grounding",
+      "answer": "Purchases: 200"
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "grounding-only",
+      "answer": "Purchases: 200"
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "png-only",
+      "answer": "Visits; Trials; Purchases."
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "png-plus-grounding",
+      "answer": "Visits; Trials; Purchases."
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "grounding-only",
+      "answer": "Visits, Trials, Purchases."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "png-only",
+      "answer": "Smallest observed value: cannot determine. Largest observed value: cannot determine."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "png-plus-grounding",
+      "answer": "Smallest observed value: 1. Largest observed value: 4."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "grounding-only",
+      "answer": "Smallest observed value: 1. Largest observed value: 4."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "png-only",
+      "answer": "4 observed rows"
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "png-plus-grounding",
+      "answer": "4 observed rows."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "grounding-only",
+      "answer": "4 observed rows."
+    }
+  ]
+}

--- a/evals/reports/openai-follow-up/trial-a/run-manifest.json
+++ b/evals/reports/openai-follow-up/trial-a/run-manifest.json
@@ -1,0 +1,4684 @@
+{
+  "version": 1,
+  "clientVersion": "semiotic-openai-eval/1",
+  "priceRevision": "openai-standard-2026-07-26",
+  "models": [
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna"
+  ],
+  "trialId": "postmerge-a",
+  "filters": {
+    "suites": [
+      "first-try",
+      "grounding"
+    ],
+    "firstTryFixtureIds": [
+      "gauge-static",
+      "line-push",
+      "scatter-push",
+      "bubble-static",
+      "symbol-map-static",
+      "unit-pile-push",
+      "galton-static"
+    ],
+    "groundingFixtureIds": [
+      "regional-revenue/highest",
+      "regional-revenue/count",
+      "weekly-users/last",
+      "weekly-users/direction",
+      "payload-latency/largest",
+      "payload-latency/count",
+      "service-latency/categories",
+      "service-latency/max",
+      "request-flow/largest",
+      "request-flow/failed",
+      "storage-tree/largest",
+      "storage-tree/backups",
+      "incident-map/largest",
+      "incident-map/count",
+      "sla-gauge/value",
+      "sla-gauge/maximum",
+      "conversion-funnel/purchases",
+      "conversion-funnel/stages",
+      "galton-values/range",
+      "galton-values/count"
+    ],
+    "groundingConditions": [
+      "png-only",
+      "png-plus-grounding",
+      "grounding-only"
+    ]
+  },
+  "projectFingerprint": "cc3c2be40c1f",
+  "maxUsd": 3,
+  "startedAt": "2026-07-27T20:12:30.469Z",
+  "completedAt": "2026-07-27T20:15:11.385Z",
+  "requests": [
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/png-only",
+      "responseId": "resp_0f1f9a5fa965b59b016a67bbaf7da88198982031b6bc4d48ac",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 374,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 397
+      },
+      "estimatedUsd": 0.00256,
+      "latencyMs": 2759,
+      "rawOutputSha256": "e8097e8a1fab95b2e2feeb201aa95be0437944be071961969ffda4f2e85982c3"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/png-plus-grounding",
+      "responseId": "resp_02df62ae8e44c104016a67bbaf757c819b8c995e2a86da548c",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 996,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 22,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1018
+      },
+      "estimatedUsd": 0.00564,
+      "latencyMs": 2628,
+      "rawOutputSha256": "c81939e353845b25553c7f2f05b0f704a55bd3afe7e913e7d37cf1584772cec3"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/grounding-only",
+      "responseId": "resp_0cc87c40a1e0f7b5016a67bbb1563081998ce887d00553e8cc",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 699,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 722
+      },
+      "estimatedUsd": 0.004185,
+      "latencyMs": 1101,
+      "rawOutputSha256": "e8097e8a1fab95b2e2feeb201aa95be0437944be071961969ffda4f2e85982c3"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/png-only",
+      "responseId": "resp_05c34eae6d8924c3016a67bbb159ec819ab52e20123e7b2e55",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 390
+      },
+      "estimatedUsd": 0.002525,
+      "latencyMs": 1503,
+      "rawOutputSha256": "fcf77bad7f39f8de12bdace68707c9dfe9fe18f3becb676f96507e56f2df4998"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/png-plus-grounding",
+      "responseId": "resp_0813d8ba6ea360a7016a67bbb3b0e081989ce99b2e8e488cf6",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 989,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1012
+      },
+      "estimatedUsd": 0.005635,
+      "latencyMs": 2019,
+      "rawOutputSha256": "fcf77bad7f39f8de12bdace68707c9dfe9fe18f3becb676f96507e56f2df4998"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/grounding-only",
+      "responseId": "resp_0cb8a640d27ea16c016a67bbb2d6048198bd116a307e6c4bcd",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 692,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 708
+      },
+      "estimatedUsd": 0.00394,
+      "latencyMs": 1182,
+      "rawOutputSha256": "0f68b1bf58d9ad62e6fef8b78533bc3c7a29a4abd9c7f842c105da58f45e9b86"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/png-only",
+      "responseId": "resp_0daeebb7b6ca0108016a67bbb4f4ec819aa0442e8e3c70b1ef",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 394
+      },
+      "estimatedUsd": 0.002595,
+      "latencyMs": 1815,
+      "rawOutputSha256": "9536770b6303f30b4aa672f0fa53b7ededfd2d33a82308857ce927bae9c1c046"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/png-plus-grounding",
+      "responseId": "resp_0e40f56fa92cdad9016a67bbb4ec248199bd05f0b1abdd32d9",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1104,
+        "input_tokens_details": {
+          "cache_write_tokens": 1101,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1125
+      },
+      "estimatedUsd": 0.00752625,
+      "latencyMs": 1463,
+      "rawOutputSha256": "75bbef3f8990abc3c267e7e306e775c6fc4f1435c7d19a2ddd81440f2019fa42"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/grounding-only",
+      "responseId": "resp_033a60e90acdf111016a67bbb6afb4819bb8d63e2d538c472f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 807,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 828
+      },
+      "estimatedUsd": 0.004665,
+      "latencyMs": 2270,
+      "rawOutputSha256": "75bbef3f8990abc3c267e7e306e775c6fc4f1435c7d19a2ddd81440f2019fa42"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/png-only",
+      "responseId": "resp_027445880d7b5c82016a67bbb6cc8c8198b585204eae3db006",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 372,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 42,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 414
+      },
+      "estimatedUsd": 0.00312,
+      "latencyMs": 2487,
+      "rawOutputSha256": "7a511c1e18e52f0b8059f1736b86e5d86f85518cd1620145fd3a80b41eafe9be"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/png-plus-grounding",
+      "responseId": "resp_0d05b32abed0ab08016a67bbb97c60819a9c5a758d7cf54698",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1107,
+        "input_tokens_details": {
+          "cache_write_tokens": 1104,
+          "cached_tokens": 0
+        },
+        "output_tokens": 53,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1160
+      },
+      "estimatedUsd": 0.008505,
+      "latencyMs": 2161,
+      "rawOutputSha256": "dc6ff18716d3119e48dc01facb5e5f7fed2f924bcaf29fcc6de080024d70daf5"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/grounding-only",
+      "responseId": "resp_0f44a427db1c8911016a67bbb9346c819a866afc6f717e7102",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 810,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 50,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 860
+      },
+      "estimatedUsd": 0.00555,
+      "latencyMs": 1298,
+      "rawOutputSha256": "d8917ada7c49000fe18c35b6058cd7ea308f22f202f6e50b07b6d9fa662ff6c2"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/png-only",
+      "responseId": "resp_036cfc22825ca449016a67bbbb7054819883ef15b953b0884a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 370,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 396
+      },
+      "estimatedUsd": 0.00263,
+      "latencyMs": 1375,
+      "rawOutputSha256": "d9b4eb4774cf41dc65ddf9f4da5b6166ca4cdaae9cafe083cdd38e63b2ab1fee"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/png-plus-grounding",
+      "responseId": "resp_01c63b9f9f49bdea016a67bbbb5cbc81989a2de61b6698b6d1",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1077,
+        "input_tokens_details": {
+          "cache_write_tokens": 1074,
+          "cached_tokens": 0
+        },
+        "output_tokens": 29,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1106
+      },
+      "estimatedUsd": 0.0075975,
+      "latencyMs": 1279,
+      "rawOutputSha256": "9a1005e108b19746a0b86f4bd0e4506d16407fa1d53e89dd7146c87139af541b"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/grounding-only",
+      "responseId": "resp_0cee1d3acb49190a016a67bbbcc1f4819aa5619a16f78bdb66",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 780,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 29,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 809
+      },
+      "estimatedUsd": 0.00477,
+      "latencyMs": 1082,
+      "rawOutputSha256": "9a1005e108b19746a0b86f4bd0e4506d16407fa1d53e89dd7146c87139af541b"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/png-only",
+      "responseId": "resp_0b6604a04bf64b67016a67bbbcc3988199ae626fdb21ea4458",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 383
+      },
+      "estimatedUsd": 0.002315,
+      "latencyMs": 1734,
+      "rawOutputSha256": "db581f71a007f0598a6a640bbb858c5256af62c79ae61f149233e32cce4679b2"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/png-plus-grounding",
+      "responseId": "resp_0c561cf24ad8615f016a67bbbe85b88199b39a1be753ddf88d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1074,
+        "input_tokens_details": {
+          "cache_write_tokens": 1071,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1090
+      },
+      "estimatedUsd": 0.00718875,
+      "latencyMs": 2023,
+      "rawOutputSha256": "db581f71a007f0598a6a640bbb858c5256af62c79ae61f149233e32cce4679b2"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/grounding-only",
+      "responseId": "resp_0a076031b9799441016a67bbbe7e608199a0c769ffdd29bca8",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 777,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 793
+      },
+      "estimatedUsd": 0.004365,
+      "latencyMs": 1670,
+      "rawOutputSha256": "db581f71a007f0598a6a640bbb858c5256af62c79ae61f149233e32cce4679b2"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/png-only",
+      "responseId": "resp_0d75e6ec099efa62016a67bbc087c8819ab1f867349bd6cff9",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 384
+      },
+      "estimatedUsd": 0.002345,
+      "latencyMs": 1255,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/png-plus-grounding",
+      "responseId": "resp_0c8972c5836c7d0e016a67bbc08660819894783cba70ddc741",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1061,
+        "input_tokens_details": {
+          "cache_write_tokens": 1058,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1078
+      },
+      "estimatedUsd": 0.0071375,
+      "latencyMs": 1112,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/grounding-only",
+      "responseId": "resp_0621fae60782b625016a67bbc1c94c819983574e97fe62c8e4",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 764,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 781
+      },
+      "estimatedUsd": 0.00433,
+      "latencyMs": 1748,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/png-only",
+      "responseId": "resp_0bd76c7f3ad8428b016a67bbc1d73c8198a9ea467fa1219e9d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 391
+      },
+      "estimatedUsd": 0.00253,
+      "latencyMs": 1309,
+      "rawOutputSha256": "dd5b187eca43b71840c6b69c39be2d8d42faca9bc58d5ea07cd2ee3f9876b954"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/png-plus-grounding",
+      "responseId": "resp_0ce9e24ae38e8482016a67bbc387cc819980076849f0bfb5d3",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1062,
+        "input_tokens_details": {
+          "cache_write_tokens": 1059,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1085
+      },
+      "estimatedUsd": 0.00732375,
+      "latencyMs": 1261,
+      "rawOutputSha256": "ba97bc35a0fe8024bdb3f8cd46fd4da5885a4226ed918e9c15bb482ea189c77a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/grounding-only",
+      "responseId": "resp_0ec245a399abec67016a67bbc38bf48199978190e3dc1857e9",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 765,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 786
+      },
+      "estimatedUsd": 0.004455,
+      "latencyMs": 1261,
+      "rawOutputSha256": "7295c9d5d6f4ea0ac2c58c12d63f39e12cb5f365069d19d9781948860e8a936b"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/png-only",
+      "responseId": "resp_07c4272f98609232016a67bbc4ce888199a6ee13d0cc89579a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 387
+      },
+      "estimatedUsd": 0.00241,
+      "latencyMs": 2660,
+      "rawOutputSha256": "8ce76a2cc90fce86f33856eb397f5d7929bd4c1c263686f1bda00c74e84c8b7f"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/png-plus-grounding",
+      "responseId": "resp_01b8ed48c5f60b46016a67bbc4ccd4819aa770295460b823b6",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 674,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 22,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 696
+      },
+      "estimatedUsd": 0.00403,
+      "latencyMs": 1197,
+      "rawOutputSha256": "3522e67ce72bcb303645530a065d780fa303860630b3a4c07d6ca105c11d4811"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/grounding-only",
+      "responseId": "resp_09a431405c943225016a67bbc77974819883e32ab30d64febd",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 377,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 22,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 399
+      },
+      "estimatedUsd": 0.002545,
+      "latencyMs": 977,
+      "rawOutputSha256": "3522e67ce72bcb303645530a065d780fa303860630b3a4c07d6ca105c11d4811"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/png-only",
+      "responseId": "resp_089a4b3c509a5b21016a67bbc77a40819aaad7e05e633a0cfd",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 386
+      },
+      "estimatedUsd": 0.00238,
+      "latencyMs": 2384,
+      "rawOutputSha256": "f49046c75e0d825d6780bddd36b2531507a2710a2f2b26ffcb004b4851cb3582"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/png-plus-grounding",
+      "responseId": "resp_0031cb7811e7fc86016a67bbc9e444819a99c8aa8ef8f68fc3",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 674,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 693
+      },
+      "estimatedUsd": 0.00394,
+      "latencyMs": 1683,
+      "rawOutputSha256": "5fa497f3f8106c6f31d32a111886afafa13772704cab1817afa1cace02f54dd1"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/grounding-only",
+      "responseId": "resp_07ccbfdb26835f3f016a67bbc9dbc4819bb04182797c3ed365",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 377,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 396
+      },
+      "estimatedUsd": 0.002455,
+      "latencyMs": 1239,
+      "rawOutputSha256": "5fa497f3f8106c6f31d32a111886afafa13772704cab1817afa1cace02f54dd1"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/png-only",
+      "responseId": "resp_07ae162e3ff265d1016a67bbcb91388199a2171e8b171f819d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 38,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 405
+      },
+      "estimatedUsd": 0.002975,
+      "latencyMs": 1854,
+      "rawOutputSha256": "f5ea42a82c01b8a9a5ad23cbb37eace2cac27ecaca5c2590fafae237227ba806"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/png-plus-grounding",
+      "responseId": "resp_081456b41cb3d553016a67bbcb917c8199aeddcb4ba1e6d1de",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 592,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 619
+      },
+      "estimatedUsd": 0.00377,
+      "latencyMs": 2397,
+      "rawOutputSha256": "37ef39016a208daaa941288e460ec85c9c1c7fded730f6768e232b9cb9bcf20a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/grounding-only",
+      "responseId": "resp_06dd5f436068a741016a67bbcdf8bc819bb2f35735038b6b19",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 295,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 313
+      },
+      "estimatedUsd": 0.002015,
+      "latencyMs": 1451,
+      "rawOutputSha256": "7f244ee40a26cd329aaa70e1417ed8be11e42081f387b637245500866fc408ab"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/png-only",
+      "responseId": "resp_020ac8e7b3cff9a8016a67bbcdf8e4819baee1a07bd0747039",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 388
+      },
+      "estimatedUsd": 0.002415,
+      "latencyMs": 1361,
+      "rawOutputSha256": "a8406cbafeff6310f2d3c7f58dbaf2fd9fccffe490afc3e7d50a2764cd1a36df"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/png-plus-grounding",
+      "responseId": "resp_0c191ec78ffee891016a67bbcf6c30819b9259d23132ad720c",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 594,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 612
+      },
+      "estimatedUsd": 0.00351,
+      "latencyMs": 2460,
+      "rawOutputSha256": "753f86bf4602c0d28bab029088ca178bb2f2e9959e70868f46aaf03ce6dd0d1a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/grounding-only",
+      "responseId": "resp_0efcb308661015e2016a67bbcf7b90819abf0641246be80298",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 297,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 315
+      },
+      "estimatedUsd": 0.002025,
+      "latencyMs": 1150,
+      "rawOutputSha256": "753f86bf4602c0d28bab029088ca178bb2f2e9959e70868f46aaf03ce6dd0d1a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/png-only",
+      "responseId": "resp_045d4ee97c2ae72c016a67bbd1e724819a942ab473ee86170f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 24,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 393
+      },
+      "estimatedUsd": 0.002565,
+      "latencyMs": 1403,
+      "rawOutputSha256": "0bfc9b74a5ecae617f08db8725ab35bc9ff9714491e643cb6710c85538500c7d"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/png-plus-grounding",
+      "responseId": "resp_0971c5a1f261bf85016a67bbd1e888819a9c304a303974c75e",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 991,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 24,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1015
+      },
+      "estimatedUsd": 0.005675,
+      "latencyMs": 1352,
+      "rawOutputSha256": "0bfc9b74a5ecae617f08db8725ab35bc9ff9714491e643cb6710c85538500c7d"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/grounding-only",
+      "responseId": "resp_01e463650d6b0cc7016a67bbd34d9081988786eed7b179a8a5",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 694,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 24,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 718
+      },
+      "estimatedUsd": 0.00419,
+      "latencyMs": 916,
+      "rawOutputSha256": "0bfc9b74a5ecae617f08db8725ab35bc9ff9714491e643cb6710c85538500c7d"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/png-only",
+      "responseId": "resp_06e6d59e015333dd016a67bbd350f08198922da14ea85fd835",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 383
+      },
+      "estimatedUsd": 0.002315,
+      "latencyMs": 1099,
+      "rawOutputSha256": "b563d101b1efff47e10dc9660bd96e7064798112c50ebe882f0027b11cd987b8"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/png-plus-grounding",
+      "responseId": "resp_0af3ab111d9c1e65016a67bbd63b5881989d1406df48cf2b8f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 989,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1014
+      },
+      "estimatedUsd": 0.005695,
+      "latencyMs": 2966,
+      "rawOutputSha256": "acec872f2e5bca19e5e9c871a5e288699d213b7be49c8f3e24f524feab22b55d"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/grounding-only",
+      "responseId": "resp_01866d6984bff0a5016a67bbd4680c819aa473acdaca75378d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 692,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 717
+      },
+      "estimatedUsd": 0.00421,
+      "latencyMs": 1070,
+      "rawOutputSha256": "acec872f2e5bca19e5e9c871a5e288699d213b7be49c8f3e24f524feab22b55d"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/png-only",
+      "responseId": "resp_01d5907afcfd60d8016a67bbd76d00819abccee57b1de9bff9",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 391
+      },
+      "estimatedUsd": 0.00253,
+      "latencyMs": 1551,
+      "rawOutputSha256": "4c5c937a88b9b0c005d960dd07cb16d392de1e5460996191434a65c360e49896"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/png-plus-grounding",
+      "responseId": "resp_0bd337892f6393a6016a67bbd76a0081998e39bcb4981076d0",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 559,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 579
+      },
+      "estimatedUsd": 0.003395,
+      "latencyMs": 1314,
+      "rawOutputSha256": "958f838b0bece7c1fc0719d53f1eed638c12159b3846f67c669f4ef9bb62a74a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/grounding-only",
+      "responseId": "resp_048ed1e7942c24b7016a67bbd8eed48198b0f532140ac7b65f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 262,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 282
+      },
+      "estimatedUsd": 0.00191,
+      "latencyMs": 1067,
+      "rawOutputSha256": "958f838b0bece7c1fc0719d53f1eed638c12159b3846f67c669f4ef9bb62a74a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/png-only",
+      "responseId": "resp_0bc65d0980031266016a67bbd8f378819ba83965bafbba2e7d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 389
+      },
+      "estimatedUsd": 0.00247,
+      "latencyMs": 1772,
+      "rawOutputSha256": "d0c9d91e3bc79bfd1d1618e809ea049706a9ad55d3f130f3bf759deeb094e3b0"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/png-plus-grounding",
+      "responseId": "resp_08d487760d8d72e3016a67bbdabcb0819bb2b35236dae85abc",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 559,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 577
+      },
+      "estimatedUsd": 0.003335,
+      "latencyMs": 1999,
+      "rawOutputSha256": "6dafee0f8bba9d1845c91736502d1c41dedca95a59e32c7a9bea1f621476fe9c"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/grounding-only",
+      "responseId": "resp_0498711d237473ff016a67bbdabccc819a89d3c9802098f22e",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 262,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 283
+      },
+      "estimatedUsd": 0.00194,
+      "latencyMs": 1873,
+      "rawOutputSha256": "d0c9d91e3bc79bfd1d1618e809ea049706a9ad55d3f130f3bf759deeb094e3b0"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/png-only",
+      "responseId": "resp_0a08d6a76e50657c016a67bbdcbcec81988ce6b50fc425d534",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 388
+      },
+      "estimatedUsd": 0.002465,
+      "latencyMs": 2191,
+      "rawOutputSha256": "a2d6d0ce8f82c61b1439f5bf86afefe2c0cbf01d2a861b7f2fbf241b225895ef"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/png-plus-grounding",
+      "responseId": "resp_0431abba3b8d9bba016a67bbdcbb708198b08f0a3f8160fd10",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 884,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 902
+      },
+      "estimatedUsd": 0.00496,
+      "latencyMs": 1861,
+      "rawOutputSha256": "53eb447c645b500ce3cf4152992e02c96d721a682101397aa0e4098ddeaf69b3"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/grounding-only",
+      "responseId": "resp_094d1476b5f81c50016a67bbdefb38819893ec4ef338610f41",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 587,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 605
+      },
+      "estimatedUsd": 0.003475,
+      "latencyMs": 1421,
+      "rawOutputSha256": "53eb447c645b500ce3cf4152992e02c96d721a682101397aa0e4098ddeaf69b3"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/png-only",
+      "responseId": "resp_059c0c8cc3ffee8c016a67bbdefca88198ba0c3b1120ef8e7c",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 387
+      },
+      "estimatedUsd": 0.002435,
+      "latencyMs": 1614,
+      "rawOutputSha256": "d14ebd0907eaf7ddae354b824f1f1e3898e62efbef4d2f78f789b4d4dda758ab"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/png-plus-grounding",
+      "responseId": "resp_0060d1ff68c7d520016a67bbe09124819a84b0826f3d9b5ff7",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 883,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 903
+      },
+      "estimatedUsd": 0.005015,
+      "latencyMs": 1066,
+      "rawOutputSha256": "d14ebd0907eaf7ddae354b824f1f1e3898e62efbef4d2f78f789b4d4dda758ab"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/grounding-only",
+      "responseId": "resp_08c5def408871a07016a67bbe08e70819b83cd2d013b2386a8",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 586,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 31,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 617
+      },
+      "estimatedUsd": 0.00386,
+      "latencyMs": 1415,
+      "rawOutputSha256": "fb3f2b4b434e0b15c51e39f30f04a6e4a2928fcaa5930e84f7d4caef58c428f3"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/png-only",
+      "responseId": "resp_08634db56200fe05016a67bbe1fbd8819aba4f576f8420bbd9",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 370,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 30,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 400
+      },
+      "estimatedUsd": 0.00275,
+      "latencyMs": 1529,
+      "rawOutputSha256": "3f144cfcfdefea4b6f8ddebc5f92d86a0442c71e265b1c76be474a7f783e2f1e"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/png-plus-grounding",
+      "responseId": "resp_01605a8d9ea11b17016a67bbe1fc0c819987f2749ebc24d539",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 653,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 681
+      },
+      "estimatedUsd": 0.004105,
+      "latencyMs": 1235,
+      "rawOutputSha256": "9d816351d2918a194334f4b04295830b941c93a77d064e761547fdc126976a7e"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/grounding-only",
+      "responseId": "resp_08f0d720bdb2e318016a67bbe38058819b999f04649cbf88cd",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 356,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 384
+      },
+      "estimatedUsd": 0.00262,
+      "latencyMs": 879,
+      "rawOutputSha256": "9d816351d2918a194334f4b04295830b941c93a77d064e761547fdc126976a7e"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/png-only",
+      "responseId": "resp_06930f719516d928016a67bbe384e4819b9a187a0792b25559",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 386
+      },
+      "estimatedUsd": 0.002355,
+      "latencyMs": 1164,
+      "rawOutputSha256": "d0761adfdaab789f0ce8882c72e019dc623027f78a541107564058ad81136ef3"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/png-plus-grounding",
+      "responseId": "resp_016a7b3cabf85025016a67bbe4b1708198b2c9d870f859eb62",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 652,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 671
+      },
+      "estimatedUsd": 0.00383,
+      "latencyMs": 2982,
+      "rawOutputSha256": "d8a2e6ff8d390abc669f65f8dfff4a5bb11cf40bb73ff7cae1650e6fcf834d1e"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/grounding-only",
+      "responseId": "resp_00de15c625543766016a67bbe4add0819badd96b1bb05aa4a1",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 355,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 374
+      },
+      "estimatedUsd": 0.002345,
+      "latencyMs": 1682,
+      "rawOutputSha256": "d8a2e6ff8d390abc669f65f8dfff4a5bb11cf40bb73ff7cae1650e6fcf834d1e"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "line-push",
+      "responseId": "resp_0bc562954b382312016a67bbe7b3308198980ec5feb9e3caf0",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27328,
+        "input_tokens_details": {
+          "cache_write_tokens": 146,
+          "cached_tokens": 27179
+        },
+        "output_tokens": 53,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27381
+      },
+      "estimatedUsd": 0.016107,
+      "latencyMs": 1742,
+      "rawOutputSha256": "aa45c1a9bc81bd075f976a9d2867a77f43a85fada4beb75edd44baa972fad878"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "scatter-push",
+      "responseId": "resp_0b09c8ec4bf229a5016a67bbe7b6dc8199a0b0cf9484de2dc4",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27334,
+        "input_tokens_details": {
+          "cache_write_tokens": 27331,
+          "cached_tokens": 0
+        },
+        "output_tokens": 110,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27444
+      },
+      "estimatedUsd": 0.17413375,
+      "latencyMs": 2785,
+      "rawOutputSha256": "06f9ea5e886ec7cb00497ba6ae2021140fa1269a0873045c8eefd81a04355dd8"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "bubble-static",
+      "responseId": "resp_094f6f9b510e2d4f016a67bbea7e18819bb1ac768fb5c314f8",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27279,
+        "input_tokens_details": {
+          "cache_write_tokens": 97,
+          "cached_tokens": 27179
+        },
+        "output_tokens": 150,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27429
+      },
+      "estimatedUsd": 0.01871075,
+      "latencyMs": 2681,
+      "rawOutputSha256": "f29d43baab01575b088d0ac57f3a0c00025770d2484b5a45a8aa53a06bd7f737"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "gauge-static",
+      "responseId": "resp_052f1b52dd104355016a67bbea9d388198a41064f2f2b323fa",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27281,
+        "input_tokens_details": {
+          "cache_write_tokens": 99,
+          "cached_tokens": 27179
+        },
+        "output_tokens": 131,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27412
+      },
+      "estimatedUsd": 0.01815325,
+      "latencyMs": 2724,
+      "rawOutputSha256": "476907f679e7fac333bd718cdad67fce1ef7b96320244e154ed2569cdd0f6a82"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "symbol-map-static",
+      "responseId": "resp_0826947a227b814e016a67bbed3e9c819886077b2d275abbab",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27294,
+        "input_tokens_details": {
+          "cache_write_tokens": 112,
+          "cached_tokens": 27179
+        },
+        "output_tokens": 102,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27396
+      },
+      "estimatedUsd": 0.0173645,
+      "latencyMs": 2088,
+      "rawOutputSha256": "ad24651613cc32bb1d985f9b720d7709628bca2d19c4ffee0240543e78d278c4"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "galton-static",
+      "responseId": "resp_06885c5919ee254d016a67bbed46e8819989603d419d3c8f7f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27260,
+        "input_tokens_details": {
+          "cache_write_tokens": 78,
+          "cached_tokens": 27179
+        },
+        "output_tokens": 66,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27326
+      },
+      "estimatedUsd": 0.016072,
+      "latencyMs": 1739,
+      "rawOutputSha256": "cca21da3fc818855f93324ed9a2a7b2081c559ba52cead21a388968b5acf2df3"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "unit-pile-push",
+      "responseId": "resp_041fe6f0dc79637b016a67bbef5718819a9b45d147ed436374",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27325,
+        "input_tokens_details": {
+          "cache_write_tokens": 143,
+          "cached_tokens": 27179
+        },
+        "output_tokens": 59,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27384
+      },
+      "estimatedUsd": 0.01626825,
+      "latencyMs": 2834,
+      "rawOutputSha256": "add8e8477487c817bce0146d71d94720611ed4029bb7f902fc3ab25e9c086bfd"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/png-only",
+      "responseId": "resp_0882b9764f35ea97016a67bbef54a88198b73658cc9c45917c",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 374,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 400
+      },
+      "estimatedUsd": 0.001325,
+      "latencyMs": 1071,
+      "rawOutputSha256": "88936eda3d8e7302c9379539aefd611e4bf5cb0034befd12025a91ca79f7d558"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/png-plus-grounding",
+      "responseId": "resp_0ecf14a2e1ceaa1a016a67bbf22c6c819899dc87eaa2d4da97",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 996,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1019
+      },
+      "estimatedUsd": 0.002835,
+      "latencyMs": 1074,
+      "rawOutputSha256": "e8097e8a1fab95b2e2feeb201aa95be0437944be071961969ffda4f2e85982c3"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/grounding-only",
+      "responseId": "resp_0ac11159379d0caa016a67bbf22f448199950d33b5225b4248",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 699,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 722
+      },
+      "estimatedUsd": 0.0020925,
+      "latencyMs": 1060,
+      "rawOutputSha256": "e8097e8a1fab95b2e2feeb201aa95be0437944be071961969ffda4f2e85982c3"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/png-only",
+      "responseId": "resp_016da6a5a6093cdc016a67bbf3406c819a8ebf611e2b60b67d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.0011425,
+      "latencyMs": 1089,
+      "rawOutputSha256": "139191d99676236271ad7f49706a7bb8bfd33648dc4662402beed84cde5397af"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/png-plus-grounding",
+      "responseId": "resp_04a56424d4ca2741016a67bbf341c4819992ccd8a94fdf4241",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 989,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1004
+      },
+      "estimatedUsd": 0.0026975,
+      "latencyMs": 1187,
+      "rawOutputSha256": "139191d99676236271ad7f49706a7bb8bfd33648dc4662402beed84cde5397af"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/grounding-only",
+      "responseId": "resp_0d9ac536efa47028016a67bbf474b081989c8d52cd646dd664",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 692,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 708
+      },
+      "estimatedUsd": 0.00197,
+      "latencyMs": 1201,
+      "rawOutputSha256": "0f68b1bf58d9ad62e6fef8b78533bc3c7a29a4abd9c7f842c105da58f45e9b86"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/png-only",
+      "responseId": "resp_09c887cebbc55ef8016a67bbf4735c8199be5f84521d19cb99",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 383
+      },
+      "estimatedUsd": 0.0011325,
+      "latencyMs": 1201,
+      "rawOutputSha256": "55db033120bd8822d113989369c02fa976a8ff0f3b45b9e618b894612552bbc8"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/png-plus-grounding",
+      "responseId": "resp_07fb67df09f7abe5016a67bbf5a514819991d4ff6b5d245a50",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1104,
+        "input_tokens_details": {
+          "cache_write_tokens": 1101,
+          "cached_tokens": 0
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1129
+      },
+      "estimatedUsd": 0.00382313,
+      "latencyMs": 2214,
+      "rawOutputSha256": "46fd471bcd0762a2c4836a2e0d0532bc47131190f74435bd7c1688ea3d2a6d98"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/grounding-only",
+      "responseId": "resp_059957867215d02b016a67bbf5a0148199881cff1f8abfe04c",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 807,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 828
+      },
+      "estimatedUsd": 0.0023325,
+      "latencyMs": 752,
+      "rawOutputSha256": "75bbef3f8990abc3c267e7e306e775c6fc4f1435c7d19a2ddd81440f2019fa42"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/png-only",
+      "responseId": "resp_07788f57725176f5016a67bbf7df7c819b8a2736d6ac8dc6f7",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 372,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 39,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 411
+      },
+      "estimatedUsd": 0.001515,
+      "latencyMs": 1322,
+      "rawOutputSha256": "4084052faa9237bb6fbe709bf521e551d3914244ccf5eaeda351258a16898326"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/png-plus-grounding",
+      "responseId": "resp_07e9dd0b1a0a1e79016a67bbf7daa0819bbe20e6c972b996fa",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1107,
+        "input_tokens_details": {
+          "cache_write_tokens": 1104,
+          "cached_tokens": 0
+        },
+        "output_tokens": 32,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1139
+      },
+      "estimatedUsd": 0.0039375,
+      "latencyMs": 1148,
+      "rawOutputSha256": "83999fd6799499ba8cb196b32255ed9195351bd0ceb2e8ac86ddca07350f185c"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/grounding-only",
+      "responseId": "resp_0672214a310cf1e1016a67bbf93360819b94cc5f7a0c576a79",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 810,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 38,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 848
+      },
+      "estimatedUsd": 0.002595,
+      "latencyMs": 1155,
+      "rawOutputSha256": "e63981d0befbc36e4435c42e226f7c8fae71ca7f61d19d7624b11bacbf660b10"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/png-only",
+      "responseId": "resp_08cadf11cb78e337016a67bbf93854819a9ee885023cc8d3f4",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 370,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 398
+      },
+      "estimatedUsd": 0.001345,
+      "latencyMs": 1380,
+      "rawOutputSha256": "0b05d0eb4395a488dce2d7b8e62baab2dfc47543b9e97a61b751bcb7f6f9800b"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/png-plus-grounding",
+      "responseId": "resp_05a13d2f39a4ed42016a67bbfabc00819bbf4694ac720397ee",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1077,
+        "input_tokens_details": {
+          "cache_write_tokens": 1074,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1104
+      },
+      "estimatedUsd": 0.00376875,
+      "latencyMs": 1638,
+      "rawOutputSha256": "fc3ca6ad038166d9cd095fb6a28b9e7975ee049aa75d7f44ed92dcd8d3017bbb"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/grounding-only",
+      "responseId": "resp_0591d613b087e967016a67bbfa9488819a87d1d9f6d61cbc21",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 780,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 807
+      },
+      "estimatedUsd": 0.002355,
+      "latencyMs": 2454,
+      "rawOutputSha256": "fc3ca6ad038166d9cd095fb6a28b9e7975ee049aa75d7f44ed92dcd8d3017bbb"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/png-only",
+      "responseId": "resp_060bd3d87fef673f016a67bbfd24a0819a94a072500cf1c059",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.0011425,
+      "latencyMs": 1150,
+      "rawOutputSha256": "162c22f13b349170282a67ca830479c3ab9bdd5c246da8847e3eb9602ab5bad0"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/png-plus-grounding",
+      "responseId": "resp_0ad9643b7f898e03016a67bbfd0e44819ab40e6bef4516a3bd",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1074,
+        "input_tokens_details": {
+          "cache_write_tokens": 1071,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1092
+      },
+      "estimatedUsd": 0.00362437,
+      "latencyMs": 1062,
+      "rawOutputSha256": "3c3eeaf75b600452370e78a739d4d431ba57064c98163b837081438f2c78873e"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/grounding-only",
+      "responseId": "resp_05e8fd2214657f9a016a67bbfe329481998295f5cb57af9854",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 777,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 795
+      },
+      "estimatedUsd": 0.0022125,
+      "latencyMs": 800,
+      "rawOutputSha256": "3c3eeaf75b600452370e78a739d4d431ba57064c98163b837081438f2c78873e"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/png-only",
+      "responseId": "resp_015636d9cb6e3cb8016a67bbfe318c819999f0b8bb680478e0",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 383
+      },
+      "estimatedUsd": 0.0011575,
+      "latencyMs": 1406,
+      "rawOutputSha256": "6e33072acb074d489d6d31794e02ed7c874e350e0c9d69eaa92ad1527129276a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/png-plus-grounding",
+      "responseId": "resp_0bbe198d70fb16c1016a67bbffa000819a8c17d82283222dcc",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1061,
+        "input_tokens_details": {
+          "cache_write_tokens": 1058,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1078
+      },
+      "estimatedUsd": 0.00356875,
+      "latencyMs": 931,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/grounding-only",
+      "responseId": "resp_018ff70866255b74016a67bbff9e08819b8d428cff42100ad5",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 764,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 781
+      },
+      "estimatedUsd": 0.002165,
+      "latencyMs": 851,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/png-only",
+      "responseId": "resp_0d0379cc998fec86016a67bc008d388199909fcdf3a215f185",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.00113,
+      "latencyMs": 1107,
+      "rawOutputSha256": "4fa4c8e85fcec46fdf1c47a79beae825dd532385e6e9270997f377d80b2ef697"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/png-plus-grounding",
+      "responseId": "resp_00664fb3a1c51d17016a67bc008ff0819883cf8bc8bc52dec8",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1062,
+        "input_tokens_details": {
+          "cache_write_tokens": 1059,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1076
+      },
+      "estimatedUsd": 0.00352688,
+      "latencyMs": 1189,
+      "rawOutputSha256": "4fa4c8e85fcec46fdf1c47a79beae825dd532385e6e9270997f377d80b2ef697"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/grounding-only",
+      "responseId": "resp_02416bcb14eea112016a67bc01bf5c819ab61e56cd013190a3",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 765,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 779
+      },
+      "estimatedUsd": 0.0021225,
+      "latencyMs": 962,
+      "rawOutputSha256": "4fa4c8e85fcec46fdf1c47a79beae825dd532385e6e9270997f377d80b2ef697"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/png-only",
+      "responseId": "resp_05f92108506019e6016a67bc01bd348199ad83dcbd00fd0f79",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.00113,
+      "latencyMs": 792,
+      "rawOutputSha256": "71fb75bf5fcc0e8b3636105dc27bb7b2dca95e74307b096680d0dcc6671b3865"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/png-plus-grounding",
+      "responseId": "resp_0fd5f64a6356abec016a67bc030aa4819982e06e0c163b75c4",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 674,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 22,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 696
+      },
+      "estimatedUsd": 0.002015,
+      "latencyMs": 1923,
+      "rawOutputSha256": "3522e67ce72bcb303645530a065d780fa303860630b3a4c07d6ca105c11d4811"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/grounding-only",
+      "responseId": "resp_0dbd6806fce086ba016a67bc02b948819aa73ca6e3a7c52e03",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 377,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 22,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 399
+      },
+      "estimatedUsd": 0.0012725,
+      "latencyMs": 844,
+      "rawOutputSha256": "3522e67ce72bcb303645530a065d780fa303860630b3a4c07d6ca105c11d4811"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/png-only",
+      "responseId": "resp_05e58c3d8976bce3016a67bc04a924819a94f231a6f262bdf8",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 29,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 397
+      },
+      "estimatedUsd": 0.001355,
+      "latencyMs": 1174,
+      "rawOutputSha256": "057b6d31341eca604142496a9a3d287b6370628be7a00342f4385ee3e0f2f481"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/png-plus-grounding",
+      "responseId": "resp_01df53db9fa38533016a67bc04add0819bba6be0f4be45f40e",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 674,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 693
+      },
+      "estimatedUsd": 0.00197,
+      "latencyMs": 1072,
+      "rawOutputSha256": "5fa497f3f8106c6f31d32a111886afafa13772704cab1817afa1cace02f54dd1"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/grounding-only",
+      "responseId": "resp_0588fde97618fedb016a67bc05d714819aafa7eb6384431e05",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 377,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 396
+      },
+      "estimatedUsd": 0.0012275,
+      "latencyMs": 1053,
+      "rawOutputSha256": "eb476af13299bba6bf03ef2fc81f45f3f2fe4c5eb0baf9e0779c718d69891938"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/png-only",
+      "responseId": "resp_019ef2600a968720016a67bc0617e4819a903f013c57aa9fee",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 34,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 401
+      },
+      "estimatedUsd": 0.0014275,
+      "latencyMs": 1927,
+      "rawOutputSha256": "6718a27ab31a16b7d6507cf17cc1a90a89f712ba66c2bc3ed14e8f7876ff1e6d"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/png-plus-grounding",
+      "responseId": "resp_0b58c42fcb2d8702016a67bc07c4a8819ba15204da1b468363",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 592,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 619
+      },
+      "estimatedUsd": 0.001885,
+      "latencyMs": 977,
+      "rawOutputSha256": "37ef39016a208daaa941288e460ec85c9c1c7fded730f6768e232b9cb9bcf20a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/grounding-only",
+      "responseId": "resp_0be3a1c8dd698550016a67bc07c2d8819bbb258a55218429bd",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 295,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 322
+      },
+      "estimatedUsd": 0.0011425,
+      "latencyMs": 860,
+      "rawOutputSha256": "37ef39016a208daaa941288e460ec85c9c1c7fded730f6768e232b9cb9bcf20a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/png-only",
+      "responseId": "resp_06dbe95513a1a5d8016a67bc08bffc819886927c66cd9a13e2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 384
+      },
+      "estimatedUsd": 0.0011475,
+      "latencyMs": 841,
+      "rawOutputSha256": "19e5b23bbfe73715f941bcbbe902eef9c924ba2d6e268de396d0e5037f8e731b"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/png-plus-grounding",
+      "responseId": "resp_0d4825bf0a42dad4016a67bc08c75c819ba9c02902564e6521",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 594,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 612
+      },
+      "estimatedUsd": 0.001755,
+      "latencyMs": 975,
+      "rawOutputSha256": "753f86bf4602c0d28bab029088ca178bb2f2e9959e70868f46aaf03ce6dd0d1a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/grounding-only",
+      "responseId": "resp_07b7a500786d1669016a67bc09caa8819ba0ab4d9728006157",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 297,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 315
+      },
+      "estimatedUsd": 0.0010125,
+      "latencyMs": 765,
+      "rawOutputSha256": "753f86bf4602c0d28bab029088ca178bb2f2e9959e70868f46aaf03ce6dd0d1a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/png-only",
+      "responseId": "resp_040310dec65335d5016a67bc09c10c819a8a5c41c91d05c676",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 392
+      },
+      "estimatedUsd": 0.0012675,
+      "latencyMs": 1072,
+      "rawOutputSha256": "1e93c437f100f8ac32ef1fa3498cf8e8f4aba9d88b7db79118d5eb3f79061fd8"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/png-plus-grounding",
+      "responseId": "resp_024c7e7c6cf6b9b9016a67bc0ad0c08198b40cf6c94f9f7146",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 991,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1014
+      },
+      "estimatedUsd": 0.0028225,
+      "latencyMs": 1091,
+      "rawOutputSha256": "aab71f12b87d6c2de6eecc920195891341458434364ed59a0fac4c731b189e69"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/grounding-only",
+      "responseId": "resp_03b3361b1e8326e6016a67bc0acf188198ac2d44bd88af3763",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 694,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 717
+      },
+      "estimatedUsd": 0.00208,
+      "latencyMs": 827,
+      "rawOutputSha256": "aab71f12b87d6c2de6eecc920195891341458434364ed59a0fac4c731b189e69"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/png-only",
+      "responseId": "resp_0f89a49db325cfa2016a67bc0bec30819ab307ed8df80eb727",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.0011425,
+      "latencyMs": 1124,
+      "rawOutputSha256": "57713459e8dc9d76ffd769bdeab211636e28289bd04732040ff557176131a96f"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/png-plus-grounding",
+      "responseId": "resp_0fb60fc88c8789c5016a67bc0bed108199a769e0e537cc1410",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 989,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1014
+      },
+      "estimatedUsd": 0.0028475,
+      "latencyMs": 911,
+      "rawOutputSha256": "acec872f2e5bca19e5e9c871a5e288699d213b7be49c8f3e24f524feab22b55d"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/grounding-only",
+      "responseId": "resp_0d436f372f74ab1c016a67bc0d236c819891bcaebc1a6c236a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 692,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 710
+      },
+      "estimatedUsd": 0.002,
+      "latencyMs": 1444,
+      "rawOutputSha256": "1760697eb73e58cde8936922849298389b6c393ec24bbd982ac84c7fb4682702"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/png-only",
+      "responseId": "resp_00f0eae85f5a6a33016a67bc0d0d80819a939ed152e01058c4",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 385
+      },
+      "estimatedUsd": 0.001175,
+      "latencyMs": 2960,
+      "rawOutputSha256": "39cc280018911ae5f39f958f625651a5ae5c3c61278dc6050d9cc96abf787705"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/png-plus-grounding",
+      "responseId": "resp_0f1abf60e1119076016a67bc1007e08198a08f2f6a4a6aac00",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 559,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 573
+      },
+      "estimatedUsd": 0.0016075,
+      "latencyMs": 1099,
+      "rawOutputSha256": "986f12b5b317b7b5c4efe40dbcfb3837e62bd0f229c257de1267cdf25a85b447"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/grounding-only",
+      "responseId": "resp_06fc0e67566714cc016a67bc1008188199a8671a46ed1a2747",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 262,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 276
+      },
+      "estimatedUsd": 0.000865,
+      "latencyMs": 961,
+      "rawOutputSha256": "986f12b5b317b7b5c4efe40dbcfb3837e62bd0f229c257de1267cdf25a85b447"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/png-only",
+      "responseId": "resp_09e30f96ffdae247016a67bc11244081999a056020e8c35602",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.00113,
+      "latencyMs": 1243,
+      "rawOutputSha256": "37b714bd7f3ab357c8ff281f4f6e8d73b3247e72873c581e56dbb7c45cbc6b28"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/png-plus-grounding",
+      "responseId": "resp_0884ef35b25c76e4016a67bc112644819bbb8c44b7551c20c9",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 559,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 573
+      },
+      "estimatedUsd": 0.0016075,
+      "latencyMs": 1014,
+      "rawOutputSha256": "37b714bd7f3ab357c8ff281f4f6e8d73b3247e72873c581e56dbb7c45cbc6b28"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/grounding-only",
+      "responseId": "resp_0797d6762e637286016a67bc1262e4819badec819fce288d38",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 262,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 276
+      },
+      "estimatedUsd": 0.000865,
+      "latencyMs": 770,
+      "rawOutputSha256": "37b714bd7f3ab357c8ff281f4f6e8d73b3247e72873c581e56dbb7c45cbc6b28"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/png-only",
+      "responseId": "resp_0b41946a9106d604016a67bc12670481999f0fd088bed4b66c",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 388
+      },
+      "estimatedUsd": 0.0012325,
+      "latencyMs": 1044,
+      "rawOutputSha256": "a572446d27d5e9bd19fbde2f3c0aa584d3f2badd982189efa690127ffbc3c0ae"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/png-plus-grounding",
+      "responseId": "resp_099ef9dd8ac9b470016a67bc137a14819993bd2f429b36d563",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 884,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 902
+      },
+      "estimatedUsd": 0.00248,
+      "latencyMs": 994,
+      "rawOutputSha256": "53eb447c645b500ce3cf4152992e02c96d721a682101397aa0e4098ddeaf69b3"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/grounding-only",
+      "responseId": "resp_0bdd397578332dc0016a67bc1370f88198b0dccfb34cff68f7",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 587,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 605
+      },
+      "estimatedUsd": 0.0017375,
+      "latencyMs": 968,
+      "rawOutputSha256": "53eb447c645b500ce3cf4152992e02c96d721a682101397aa0e4098ddeaf69b3"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/png-only",
+      "responseId": "resp_0ca9387306c04488016a67bc148374819a81e7340672e6c51d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 387
+      },
+      "estimatedUsd": 0.0012175,
+      "latencyMs": 1241,
+      "rawOutputSha256": "cf17b012dc1a3efb89f8ae93a4e31c4c9d6a6a584d34cc26df4cae3c9f52830a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/png-plus-grounding",
+      "responseId": "resp_0476963e8990c5ef016a67bc1476588198867132014e15c971",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 883,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 903
+      },
+      "estimatedUsd": 0.0025075,
+      "latencyMs": 1356,
+      "rawOutputSha256": "cf17b012dc1a3efb89f8ae93a4e31c4c9d6a6a584d34cc26df4cae3c9f52830a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/grounding-only",
+      "responseId": "resp_0892eee8c6775381016a67bc15d7fc819b93a25b5ad664c1cd",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 586,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 606
+      },
+      "estimatedUsd": 0.001765,
+      "latencyMs": 1090,
+      "rawOutputSha256": "d14ebd0907eaf7ddae354b824f1f1e3898e62efbef4d2f78f789b4d4dda758ab"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/png-only",
+      "responseId": "resp_0f27b748aca6116c016a67bc15cea481998564b58255c438ef",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 370,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 398
+      },
+      "estimatedUsd": 0.001345,
+      "latencyMs": 978,
+      "rawOutputSha256": "3a4ba5d60d8bd29ccae6c247f919c3a54cd039327d6d2314fbf99de359416f50"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/png-plus-grounding",
+      "responseId": "resp_0f2b29600061258d016a67bc16e8ac819a967bcaf5eec540d0",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 653,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 681
+      },
+      "estimatedUsd": 0.0020525,
+      "latencyMs": 824,
+      "rawOutputSha256": "9d816351d2918a194334f4b04295830b941c93a77d064e761547fdc126976a7e"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/grounding-only",
+      "responseId": "resp_0cfdf3b746eb9fcc016a67bc16e974819bb47ae8f2ba2928d0",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 356,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 384
+      },
+      "estimatedUsd": 0.00131,
+      "latencyMs": 870,
+      "rawOutputSha256": "9d816351d2918a194334f4b04295830b941c93a77d064e761547fdc126976a7e"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/png-only",
+      "responseId": "resp_0c37cf307284b417016a67bc17cdbc819a967c3c708bfc0346",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 385
+      },
+      "estimatedUsd": 0.0011625,
+      "latencyMs": 1184,
+      "rawOutputSha256": "4fc5fa4367adf5d671f36647483094920a174a9e10a32538442aafeb73c0946c"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/png-plus-grounding",
+      "responseId": "resp_03c17880a67ecdd8016a67bc17ccdc819ab66dfe217a6c604f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 652,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 669
+      },
+      "estimatedUsd": 0.001885,
+      "latencyMs": 1076,
+      "rawOutputSha256": "d0761adfdaab789f0ce8882c72e019dc623027f78a541107564058ad81136ef3"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/grounding-only",
+      "responseId": "resp_00855dadae2d589e016a67bc18f93481998abcbb71d6e09f77",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 355,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 372
+      },
+      "estimatedUsd": 0.0011425,
+      "latencyMs": 1052,
+      "rawOutputSha256": "d0761adfdaab789f0ce8882c72e019dc623027f78a541107564058ad81136ef3"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "line-push",
+      "responseId": "resp_07dd3cc04dc31503016a67bc18fa388199bbe56ae2f833bf42",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27328,
+        "input_tokens_details": {
+          "cache_write_tokens": 27325,
+          "cached_tokens": 0
+        },
+        "output_tokens": 81,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27409
+      },
+      "estimatedUsd": 0.08661312,
+      "latencyMs": 1359,
+      "rawOutputSha256": "4ab18391e0dc371322b615cefda19cbb07e980ea57d576091ff507ca8e7be82c"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "scatter-push",
+      "responseId": "resp_0279b1bb29c316b3016a67bc1a5d9c81988def7e2adf7128f9",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27334,
+        "input_tokens_details": {
+          "cache_write_tokens": 152,
+          "cached_tokens": 27179
+        },
+        "output_tokens": 141,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27475
+      },
+      "estimatedUsd": 0.00939225,
+      "latencyMs": 1916,
+      "rawOutputSha256": "140802ff3747ce7fa9dfc4b8bbcb37dff40dc81e76e1035d0cdb08822bbe3cde"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "bubble-static",
+      "responseId": "resp_097d47bc3670486b016a67bc1a5efc81988a460daa93da177d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27279,
+        "input_tokens_details": {
+          "cache_write_tokens": 97,
+          "cached_tokens": 27179
+        },
+        "output_tokens": 153,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27432
+      },
+      "estimatedUsd": 0.00940038,
+      "latencyMs": 2289,
+      "rawOutputSha256": "31d319c7a31fa8c9ad64d4cce56e913e400f045d87132b9174f1778088512eec"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "gauge-static",
+      "responseId": "resp_0efcb77d18f5cab9016a67bc1ca90481999d4a135a9e0dbddb",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27281,
+        "input_tokens_details": {
+          "cache_write_tokens": 99,
+          "cached_tokens": 27179
+        },
+        "output_tokens": 132,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27413
+      },
+      "estimatedUsd": 0.00909163,
+      "latencyMs": 1721,
+      "rawOutputSha256": "7fa27221bf02508a28913beb7e8a1d491055de36bc38dd8b96eeadd0fef8f253"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "symbol-map-static",
+      "responseId": "resp_0d94a6fb12b771f6016a67bc1ca8b081999405205b1470b4a3",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27294,
+        "input_tokens_details": {
+          "cache_write_tokens": 112,
+          "cached_tokens": 27179
+        },
+        "output_tokens": 142,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27436
+      },
+      "estimatedUsd": 0.00928225,
+      "latencyMs": 1651,
+      "rawOutputSha256": "ad62b2258a4503b52e6aae4a82b5fc7622f17b0697b29aac3fe0d0cc4a01b40c"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "galton-static",
+      "responseId": "resp_0242715374f08b6e016a67bc1f01f0819b88951342462ec7c5",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27260,
+        "input_tokens_details": {
+          "cache_write_tokens": 78,
+          "cached_tokens": 27179
+        },
+        "output_tokens": 66,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27326
+      },
+      "estimatedUsd": 0.008036,
+      "latencyMs": 8225,
+      "rawOutputSha256": "a2cd7e9c911fc269d1fce6f111b3f6c27dc9f3059a7186b6645992cf9933b087"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "unit-pile-push",
+      "responseId": "resp_0c072993db827262016a67bc1e889c8198a77f75199cd2e3ab",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27325,
+        "input_tokens_details": {
+          "cache_write_tokens": 143,
+          "cached_tokens": 27179
+        },
+        "output_tokens": 114,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27439
+      },
+      "estimatedUsd": 0.00895913,
+      "latencyMs": 2119,
+      "rawOutputSha256": "840faf4b612604fe82eb0a8f098916797a3229490167a34b49582f2261f99e3d"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/png-only",
+      "responseId": "resp_08f359ac61b6a148016a67bc269a5c81998704564239be2e46",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 374,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 395
+      },
+      "estimatedUsd": 0.0005,
+      "latencyMs": 693,
+      "rawOutputSha256": "a9a73509d8411871e116f1d4b34fd00fcce64b86be98154bed7d315d7a665256"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/png-plus-grounding",
+      "responseId": "resp_05a091355d441de7016a67bc26e10c819a980ece92431c8d02",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 996,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1019
+      },
+      "estimatedUsd": 0.001134,
+      "latencyMs": 930,
+      "rawOutputSha256": "e8097e8a1fab95b2e2feeb201aa95be0437944be071961969ffda4f2e85982c3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/grounding-only",
+      "responseId": "resp_072e0e8de32be91b016a67bc27b59481998606470a7c734702",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 699,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 725
+      },
+      "estimatedUsd": 0.000855,
+      "latencyMs": 1382,
+      "rawOutputSha256": "88936eda3d8e7302c9379539aefd611e4bf5cb0034befd12025a91ca79f7d558"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/png-only",
+      "responseId": "resp_00069b210eedc55a016a67bc278dc88199a5d78dd1cd2d818c",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.000457,
+      "latencyMs": 795,
+      "rawOutputSha256": "139191d99676236271ad7f49706a7bb8bfd33648dc4662402beed84cde5397af"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/png-plus-grounding",
+      "responseId": "resp_01be17da87dde2cf016a67bc28f12c8199a6ab25d07b61986b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 989,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1005
+      },
+      "estimatedUsd": 0.001085,
+      "latencyMs": 686,
+      "rawOutputSha256": "0f68b1bf58d9ad62e6fef8b78533bc3c7a29a4abd9c7f842c105da58f45e9b86"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/grounding-only",
+      "responseId": "resp_01a87893d917e67d016a67bc28ebd4819bb9e0860a287dbb9d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 692,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 707
+      },
+      "estimatedUsd": 0.000782,
+      "latencyMs": 509,
+      "rawOutputSha256": "139191d99676236271ad7f49706a7bb8bfd33648dc4662402beed84cde5397af"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/png-only",
+      "responseId": "resp_0e2a821a9f9ac0df016a67bc29a4b48199b5b1079cfe6cac97",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 384
+      },
+      "estimatedUsd": 0.000459,
+      "latencyMs": 961,
+      "rawOutputSha256": "e2fecba5f95c02aae27d4e5d5644998931ac2a3061172afd22ba353217703c8f"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/png-plus-grounding",
+      "responseId": "resp_0e0a2041d1f98b44016a67bc29a1f8819b8e088f2c81faba0a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1104,
+        "input_tokens_details": {
+          "cache_write_tokens": 1101,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1130
+      },
+      "estimatedUsd": 0.00153525,
+      "latencyMs": 1212,
+      "rawOutputSha256": "aa3e91fa2780ee5f9a8dc2d8331aedb58b79057ef34371f64300956bf0f24582"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/grounding-only",
+      "responseId": "resp_0095a12c94ef57a4016a67bc2ad764819bba980ec795c0e0ed",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 807,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 834
+      },
+      "estimatedUsd": 0.000969,
+      "latencyMs": 1111,
+      "rawOutputSha256": "5783723d21b573997f5fce50ff0f31b115da63de8ad395fd96c032f59e0f06d5"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/png-only",
+      "responseId": "resp_0dc831e24cd24c1d016a67bc2ada30819b8aaa3688023f8faf",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 372,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 39,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 411
+      },
+      "estimatedUsd": 0.000606,
+      "latencyMs": 914,
+      "rawOutputSha256": "de972e53523d89cdae1c0a8509e442a3bbdfc8e3349e495b0218aab744c63fd4"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/png-plus-grounding",
+      "responseId": "resp_0a8706e4d41fcd61016a67bc2bff648198b50a07d27e740f07",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1107,
+        "input_tokens_details": {
+          "cache_write_tokens": 1104,
+          "cached_tokens": 0
+        },
+        "output_tokens": 39,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1146
+      },
+      "estimatedUsd": 0.001617,
+      "latencyMs": 1006,
+      "rawOutputSha256": "daf7ef1c98d9cbc68403e9230501fb1ffde6e00d528d575b1f8d5c76583f2f5f"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/grounding-only",
+      "responseId": "resp_047f8bc44dcbf589016a67bc2bff3c819b87c84bb6b53a8fe2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 810,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 39,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 849
+      },
+      "estimatedUsd": 0.001044,
+      "latencyMs": 1066,
+      "rawOutputSha256": "daf7ef1c98d9cbc68403e9230501fb1ffde6e00d528d575b1f8d5c76583f2f5f"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/png-only",
+      "responseId": "resp_03fa58576c44109d016a67bc2d0d60819989bcf85a8eddf008",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 370,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 30,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 400
+      },
+      "estimatedUsd": 0.00055,
+      "latencyMs": 794,
+      "rawOutputSha256": "6c352dbb0ddb8f530853ef2e9e67374002c6ef8b6d1c8dbc5345ef315dbd87dd"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/png-plus-grounding",
+      "responseId": "resp_0a8025a5220df946016a67bc2d1d948198bf9c8418789fd2bb",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1077,
+        "input_tokens_details": {
+          "cache_write_tokens": 1074,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1105
+      },
+      "estimatedUsd": 0.0015135,
+      "latencyMs": 1257,
+      "rawOutputSha256": "f3f5d9ba945975d3f6c2276f3f6996a6ffcef411030dba19eeb47d91aaf7638a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/grounding-only",
+      "responseId": "resp_093733f95336efbf016a67bc2e513c81999f64582070fc912e",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 780,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 808
+      },
+      "estimatedUsd": 0.000948,
+      "latencyMs": 1107,
+      "rawOutputSha256": "f3f5d9ba945975d3f6c2276f3f6996a6ffcef411030dba19eeb47d91aaf7638a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/png-only",
+      "responseId": "resp_096cc1896e4273aa016a67bc2e4ea4819aba33c49e7862474a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.000457,
+      "latencyMs": 2829,
+      "rawOutputSha256": "162c22f13b349170282a67ca830479c3ab9bdd5c246da8847e3eb9602ab5bad0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/png-plus-grounding",
+      "responseId": "resp_01f20fe4dddcd683016a67bc31286081999696d90f2b56428c",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1074,
+        "input_tokens_details": {
+          "cache_write_tokens": 1071,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1089
+      },
+      "estimatedUsd": 0.00143175,
+      "latencyMs": 801,
+      "rawOutputSha256": "162c22f13b349170282a67ca830479c3ab9bdd5c246da8847e3eb9602ab5bad0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/grounding-only",
+      "responseId": "resp_0efae7c38d438635016a67bc312588819ab7766575d65a4bf3",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 777,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 792
+      },
+      "estimatedUsd": 0.000867,
+      "latencyMs": 784,
+      "rawOutputSha256": "162c22f13b349170282a67ca830479c3ab9bdd5c246da8847e3eb9602ab5bad0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/png-only",
+      "responseId": "resp_0463fbeeb9a535ff016a67bc320958819bb8f70c39349ac3bf",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 383
+      },
+      "estimatedUsd": 0.000463,
+      "latencyMs": 2619,
+      "rawOutputSha256": "6e33072acb074d489d6d31794e02ed7c874e350e0c9d69eaa92ad1527129276a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/png-plus-grounding",
+      "responseId": "resp_0f7c52ba886a9ab0016a67bc31fdd0819b8323674ae3c84c30",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1061,
+        "input_tokens_details": {
+          "cache_write_tokens": 1058,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1078
+      },
+      "estimatedUsd": 0.0014275,
+      "latencyMs": 923,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/grounding-only",
+      "responseId": "resp_0a24a6621f35f535016a67bc34987c81999d5188c3f5b00365",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 764,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 781
+      },
+      "estimatedUsd": 0.000866,
+      "latencyMs": 821,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/png-only",
+      "responseId": "resp_017356e2c7eb7f1a016a67bc349e48819a988a386cb206e36d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.000452,
+      "latencyMs": 821,
+      "rawOutputSha256": "4fa4c8e85fcec46fdf1c47a79beae825dd532385e6e9270997f377d80b2ef697"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/png-plus-grounding",
+      "responseId": "resp_02624c50b9afa63d016a67bc356dcc819a8815091c6bbe2f36",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1062,
+        "input_tokens_details": {
+          "cache_write_tokens": 1059,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1083
+      },
+      "estimatedUsd": 0.00145275,
+      "latencyMs": 655,
+      "rawOutputSha256": "7295c9d5d6f4ea0ac2c58c12d63f39e12cb5f365069d19d9781948860e8a936b"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/grounding-only",
+      "responseId": "resp_022e756955db7a14016a67bc3570308199bbd4a68d8f15073d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 765,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 786
+      },
+      "estimatedUsd": 0.000891,
+      "latencyMs": 911,
+      "rawOutputSha256": "7295c9d5d6f4ea0ac2c58c12d63f39e12cb5f365069d19d9781948860e8a936b"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/png-only",
+      "responseId": "resp_07d373557e749db3016a67bc365de081999a80fa3bd613761e",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 387
+      },
+      "estimatedUsd": 0.000482,
+      "latencyMs": 762,
+      "rawOutputSha256": "8ce76a2cc90fce86f33856eb397f5d7929bd4c1c263686f1bda00c74e84c8b7f"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/png-plus-grounding",
+      "responseId": "resp_01f157980cd71396016a67bc365bd8819a91f9076d89768d62",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 674,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 700
+      },
+      "estimatedUsd": 0.00083,
+      "latencyMs": 850,
+      "rawOutputSha256": "c713a07fb2312f9fff73682b5b1eb18f75e63d98269a17a174e5264d66821f61"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/grounding-only",
+      "responseId": "resp_0d7e65fbfe055998016a67bc3737cc81998adc0871f59bab64",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 377,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 403
+      },
+      "estimatedUsd": 0.000533,
+      "latencyMs": 717,
+      "rawOutputSha256": "c713a07fb2312f9fff73682b5b1eb18f75e63d98269a17a174e5264d66821f61"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/png-only",
+      "responseId": "resp_00cb5e905970a51e016a67bc374620819a919ecb76745cb7ac",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 394
+      },
+      "estimatedUsd": 0.000524,
+      "latencyMs": 1235,
+      "rawOutputSha256": "4022f6f38946c6811b41a7ada3e9ff450f2dcaaf27013a7216547f9f0e925763"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/png-plus-grounding",
+      "responseId": "resp_0bd0781db147124f016a67bc38786c81999128bc6836d5264f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 674,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 693
+      },
+      "estimatedUsd": 0.000788,
+      "latencyMs": 772,
+      "rawOutputSha256": "eb476af13299bba6bf03ef2fc81f45f3f2fe4c5eb0baf9e0779c718d69891938"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/grounding-only",
+      "responseId": "resp_0b9c5d1c6c5633ee016a67bc3870c4819aaec3dd8348530187",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 377,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 396
+      },
+      "estimatedUsd": 0.000491,
+      "latencyMs": 819,
+      "rawOutputSha256": "eb476af13299bba6bf03ef2fc81f45f3f2fe4c5eb0baf9e0779c718d69891938"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/png-only",
+      "responseId": "resp_0ad425be7fc878cb016a67bc39491c8199b94291cef91abf1d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 33,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 400
+      },
+      "estimatedUsd": 0.000565,
+      "latencyMs": 1071,
+      "rawOutputSha256": "64d71f5fd5fac07b2e76c1aad7fcdc3b620df71717c9d66b10d76fa9119ab738"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/png-plus-grounding",
+      "responseId": "resp_08ec6b0df5fbe806016a67bc394a78819a8e5d5e49c8b1ba4b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 592,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 619
+      },
+      "estimatedUsd": 0.000754,
+      "latencyMs": 962,
+      "rawOutputSha256": "37ef39016a208daaa941288e460ec85c9c1c7fded730f6768e232b9cb9bcf20a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/grounding-only",
+      "responseId": "resp_0653e0f361e9d6c0016a67bc3a5b188199bb63a36e281b41b3",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 295,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 22,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 317
+      },
+      "estimatedUsd": 0.000427,
+      "latencyMs": 948,
+      "rawOutputSha256": "152fd3bc8ceaccc31d0a2940befac8e34808e99de45eb5e89003f16d191b2d8b"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/png-only",
+      "responseId": "resp_0a8a7081950dce92016a67bc3a5c8c819bb2dc1a747e01f108",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 30,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 399
+      },
+      "estimatedUsd": 0.000549,
+      "latencyMs": 976,
+      "rawOutputSha256": "b31ba7e30294ad094a8faf0700e59277c97d9cb12c9318cd154b66599c8e8260"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/png-plus-grounding",
+      "responseId": "resp_0714f403aaa3f75b016a67bc3b5f80819a8716906594892354",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 594,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 617
+      },
+      "estimatedUsd": 0.000732,
+      "latencyMs": 775,
+      "rawOutputSha256": "5131dbca7f7ac689da5a1c1b58bd92d072b459dc8826474b2af4c5c203d401d3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/grounding-only",
+      "responseId": "resp_09b955615629e293016a67bc3b59dc819b880526a1c3ace79b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 297,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 320
+      },
+      "estimatedUsd": 0.000435,
+      "latencyMs": 731,
+      "rawOutputSha256": "5131dbca7f7ac689da5a1c1b58bd92d072b459dc8826474b2af4c5c203d401d3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/png-only",
+      "responseId": "resp_047339f72427e257016a67bc3c28e481988dbf6fad1245af54",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 394
+      },
+      "estimatedUsd": 0.000519,
+      "latencyMs": 1030,
+      "rawOutputSha256": "1ef474bbcaca40bd75057dc3966aaecb95face1195bda4b82e32e8a8dbe4627b"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/png-plus-grounding",
+      "responseId": "resp_003445ab26cec45b016a67bc3c2240819a8dd04b6f6b659239",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 991,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 24,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1015
+      },
+      "estimatedUsd": 0.001135,
+      "latencyMs": 676,
+      "rawOutputSha256": "0bfc9b74a5ecae617f08db8725ab35bc9ff9714491e643cb6710c85538500c7d"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/grounding-only",
+      "responseId": "resp_04799ed3742c9cc2016a67bc3d2ce881999f4ec0e0716f2db7",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 694,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 24,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 718
+      },
+      "estimatedUsd": 0.000838,
+      "latencyMs": 708,
+      "rawOutputSha256": "0bfc9b74a5ecae617f08db8725ab35bc9ff9714491e643cb6710c85538500c7d"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/png-only",
+      "responseId": "resp_099d395a18862062016a67bc3d2e20819b8c82626098671cc1",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.000457,
+      "latencyMs": 888,
+      "rawOutputSha256": "57713459e8dc9d76ffd769bdeab211636e28289bd04732040ff557176131a96f"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/png-plus-grounding",
+      "responseId": "resp_0e7fe0003877155d016a67bc3e1c40819b8d39f2d3289a34e7",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 989,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1005
+      },
+      "estimatedUsd": 0.001085,
+      "latencyMs": 817,
+      "rawOutputSha256": "b563d101b1efff47e10dc9660bd96e7064798112c50ebe882f0027b11cd987b8"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/grounding-only",
+      "responseId": "resp_0055b8e8dbacb23c016a67bc3e0f38819ba3bebba0f8f2fccd",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 692,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 710
+      },
+      "estimatedUsd": 0.0008,
+      "latencyMs": 777,
+      "rawOutputSha256": "1760697eb73e58cde8936922849298389b6c393ec24bbd982ac84c7fb4682702"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/png-only",
+      "responseId": "resp_035a1ccf7114b5c7016a67bc3ef004819b901b4015e04c7287",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 385
+      },
+      "estimatedUsd": 0.00047,
+      "latencyMs": 761,
+      "rawOutputSha256": "39cc280018911ae5f39f958f625651a5ae5c3c61278dc6050d9cc96abf787705"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/png-plus-grounding",
+      "responseId": "resp_05a64dc33c632234016a67bc3ee8048199b3701a6c362ba90f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 559,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 580
+      },
+      "estimatedUsd": 0.000685,
+      "latencyMs": 893,
+      "rawOutputSha256": "65587e2cd4ae5cab44b4f6f934a0efc040ed33c3a514fb306ebae4207950e5e8"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/grounding-only",
+      "responseId": "resp_0f8cfdeaa4c0acdb016a67bc3fd5b8819a8175692f17d056fc",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 262,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 281
+      },
+      "estimatedUsd": 0.000376,
+      "latencyMs": 1047,
+      "rawOutputSha256": "66ec984f75fcce61dcbc812ecf7fe618ed7917a11381e17aeb919d16cb37f612"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/png-only",
+      "responseId": "resp_0486e7037e82f5ea016a67bc3fd6288198b4e57a55d208c99b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 388
+      },
+      "estimatedUsd": 0.000488,
+      "latencyMs": 1186,
+      "rawOutputSha256": "5ed64282336dcb1c5ba87650a75b0fddd7f03b81a0cf69262846e7162cf5bb1a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/png-plus-grounding",
+      "responseId": "resp_056f019b6d2799b8016a67bc4108b88198b40dadac75cfcfd5",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 559,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 582
+      },
+      "estimatedUsd": 0.000697,
+      "latencyMs": 1119,
+      "rawOutputSha256": "9242d26cbe64ba1e16898ad431b3dc65bbacdac88bd38a0a1aa8a45832381946"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/grounding-only",
+      "responseId": "resp_0fb309e0d5064681016a67bc4101b4819aa8787877b64b441d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 262,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 283
+      },
+      "estimatedUsd": 0.000388,
+      "latencyMs": 779,
+      "rawOutputSha256": "d0c9d91e3bc79bfd1d1618e809ea049706a9ad55d3f130f3bf759deeb094e3b0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/png-only",
+      "responseId": "resp_09d1e31efd853c5a016a67bc4228288198bc8f26e090ea7e58",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 381
+      },
+      "estimatedUsd": 0.000451,
+      "latencyMs": 1002,
+      "rawOutputSha256": "e37fca342d25607f161bfd5072fa3b4e3d6c344dd9ef1c530522a00414473f71"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/png-plus-grounding",
+      "responseId": "resp_08982e5b2f08d4ad016a67bc4226e4819aa20793eaa6460902",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 884,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 902
+      },
+      "estimatedUsd": 0.000992,
+      "latencyMs": 818,
+      "rawOutputSha256": "53eb447c645b500ce3cf4152992e02c96d721a682101397aa0e4098ddeaf69b3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/grounding-only",
+      "responseId": "resp_02cc2ce261158dab016a67bc4364488199817df453e0d3aa19",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 587,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 605
+      },
+      "estimatedUsd": 0.000695,
+      "latencyMs": 663,
+      "rawOutputSha256": "53eb447c645b500ce3cf4152992e02c96d721a682101397aa0e4098ddeaf69b3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/png-only",
+      "responseId": "resp_0f7208c585b207fc016a67bc4368cc819b9c69c849b0ef2570",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 386
+      },
+      "estimatedUsd": 0.000481,
+      "latencyMs": 781,
+      "rawOutputSha256": "a3bfb81b76092b3531f6c71ecc9cb21017cd97f78d1c3bc918c981a267895e05"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/png-plus-grounding",
+      "responseId": "resp_0175a19fa9067498016a67bc4433888199bbe525333a8f02d2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 883,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 902
+      },
+      "estimatedUsd": 0.000997,
+      "latencyMs": 1135,
+      "rawOutputSha256": "478c4a4c7da2c142e990688964e6e5a62235d8a57a9d8a3ca4e79a7d2b29c929"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/grounding-only",
+      "responseId": "resp_02c8f87b28f09d45016a67bc442c94819b8bbd5f12a1e173d2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 586,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 607
+      },
+      "estimatedUsd": 0.000712,
+      "latencyMs": 930,
+      "rawOutputSha256": "c0b02428c60234d33e4d0d347ad3c6741abe7369711de8be4112974e7faf44b4"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/png-only",
+      "responseId": "resp_0d5eade292c1b9c1016a67bc455848819b9df13e5198dbbb43",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 370,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 398
+      },
+      "estimatedUsd": 0.000538,
+      "latencyMs": 1218,
+      "rawOutputSha256": "0ee9dc34bce97c48f9e3c49a39940aa9a92fbabd804e9e096f3a8f3ea0131ffd"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/png-plus-grounding",
+      "responseId": "resp_00ed49c1f6a7d413016a67bc454fd88199bf8708b6eb090928",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 653,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 681
+      },
+      "estimatedUsd": 0.000821,
+      "latencyMs": 821,
+      "rawOutputSha256": "9d816351d2918a194334f4b04295830b941c93a77d064e761547fdc126976a7e"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/grounding-only",
+      "responseId": "resp_062dfdd800c6e82e016a67bc4690308199ba7759195ffe4d96",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 356,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 384
+      },
+      "estimatedUsd": 0.000524,
+      "latencyMs": 902,
+      "rawOutputSha256": "9d816351d2918a194334f4b04295830b941c93a77d064e761547fdc126976a7e"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/png-only",
+      "responseId": "resp_0ecee2c6ef302a63016a67bc4689808199840860ede7879832",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 389
+      },
+      "estimatedUsd": 0.000489,
+      "latencyMs": 925,
+      "rawOutputSha256": "560effdba8f060b9cb62e2d6835597d6bc026756f134bf3210a2108906efc9a0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/png-plus-grounding",
+      "responseId": "resp_02dcf7be896a3435016a67bc477e788199ae68a26c3fc27c0b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 652,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 668
+      },
+      "estimatedUsd": 0.000748,
+      "latencyMs": 985,
+      "rawOutputSha256": "4fc5fa4367adf5d671f36647483094920a174a9e10a32538442aafeb73c0946c"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/grounding-only",
+      "responseId": "resp_0fb5d6cdc5616754016a67bc4779908199bc3d37ccedf9319c",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 355,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 371
+      },
+      "estimatedUsd": 0.000451,
+      "latencyMs": 692,
+      "rawOutputSha256": "4fc5fa4367adf5d671f36647483094920a174a9e10a32538442aafeb73c0946c"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "line-push",
+      "responseId": "resp_04fa95c39c6e706d016a67bc488f4481999ae102c4196abf29",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27328,
+        "input_tokens_details": {
+          "cache_write_tokens": 27325,
+          "cached_tokens": 0
+        },
+        "output_tokens": 53,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27381
+      },
+      "estimatedUsd": 0.03447725,
+      "latencyMs": 1194,
+      "rawOutputSha256": "aa45c1a9bc81bd075f976a9d2867a77f43a85fada4beb75edd44baa972fad878"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "scatter-push",
+      "responseId": "resp_0d3a06fc3d6f27f2016a67bc48a790819bb4b4aecfcde5ffc0",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27334,
+        "input_tokens_details": {
+          "cache_write_tokens": 152,
+          "cached_tokens": 27179
+        },
+        "output_tokens": 152,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27486
+      },
+      "estimatedUsd": 0.0038229,
+      "latencyMs": 2340,
+      "rawOutputSha256": "78ce45a07b9a3c21a46c53c9c96d9806967a9b986b5a3691615cb3183a5451e2"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "bubble-static",
+      "responseId": "resp_0355bbf4f71919c1016a67bc4ade1c819ba6641fdf7ff11138",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27279,
+        "input_tokens_details": {
+          "cache_write_tokens": 97,
+          "cached_tokens": 27179
+        },
+        "output_tokens": 135,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27414
+      },
+      "estimatedUsd": 0.00365215,
+      "latencyMs": 1484,
+      "rawOutputSha256": "000247ae5d4beb81f95ac5d80e2110b7c35e2c0cb8d50dd3a0682003ffceac2a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "gauge-static",
+      "responseId": "resp_0e73aa5dc123b04f016a67bc4ae28c819aa74cb536e2b1d518",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27281,
+        "input_tokens_details": {
+          "cache_write_tokens": 99,
+          "cached_tokens": 27179
+        },
+        "output_tokens": 86,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27367
+      },
+      "estimatedUsd": 0.00336065,
+      "latencyMs": 1364,
+      "rawOutputSha256": "bfd14ea9176add1c44aee79aafeba9c18c65a86d1872e652be7cfdb0a8d4c85a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "symbol-map-static",
+      "responseId": "resp_008127ee425f543a016a67bc4c5e60819985f92a27d1cbdfc3",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27294,
+        "input_tokens_details": {
+          "cache_write_tokens": 112,
+          "cached_tokens": 27179
+        },
+        "output_tokens": 102,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27396
+      },
+      "estimatedUsd": 0.0034729,
+      "latencyMs": 1298,
+      "rawOutputSha256": "ad24651613cc32bb1d985f9b720d7709628bca2d19c4ffee0240543e78d278c4"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "galton-static",
+      "responseId": "resp_0f98db5b14b80089016a67bc4c61c4819a887688b8c37182b8",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27260,
+        "input_tokens_details": {
+          "cache_write_tokens": 78,
+          "cached_tokens": 27179
+        },
+        "output_tokens": 62,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27322
+      },
+      "estimatedUsd": 0.0031904,
+      "latencyMs": 1291,
+      "rawOutputSha256": "991ca987758a3d66c30df0a4dd882b4635a3245c7651c0c03e15f5cc707ab4a9"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "unit-pile-push",
+      "responseId": "resp_03bff14c54f7c80e016a67bc4da9c48199b57c3700742cc60a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27325,
+        "input_tokens_details": {
+          "cache_write_tokens": 143,
+          "cached_tokens": 27179
+        },
+        "output_tokens": 114,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27439
+      },
+      "estimatedUsd": 0.00358365,
+      "latencyMs": 1837,
+      "rawOutputSha256": "eda545576bece4435bf7c5c8cf46ae359865c2151329ff44e450e35559d9eeea"
+    }
+  ],
+  "estimatedUsd": 0.85890704,
+  "requestCount": 201
+}

--- a/evals/reports/openai-follow-up/trial-b/gpt-5.6-luna/first-try-results.json
+++ b/evals/reports/openai-follow-up/trial-b/gpt-5.6-luna/first-try-results.json
@@ -1,0 +1,225 @@
+{
+  "metadata": {
+    "modelId": "gpt-5.6-luna",
+    "clientVersion": "semiotic-openai-eval/1",
+    "fixtureRevision": "semiotic-first-try-2026-07-27-contracts",
+    "date": "2026-07-27",
+    "context": [
+      "CLAUDE.md",
+      "docs/public/llms.txt"
+    ]
+  },
+  "results": [
+    {
+      "fixtureId": "line-push",
+      "proposal": {
+        "component": "LineChart",
+        "props": {
+          "data": [
+            {
+              "week": 1,
+              "users": 120
+            },
+            {
+              "week": 2,
+              "users": 138
+            },
+            {
+              "week": 3,
+              "users": 151
+            }
+          ],
+          "xAccessor": "week",
+          "yAccessor": "users",
+          "title": "Active users by week",
+          "description": "A line chart showing active users across weeks 1 through 3.",
+          "accessibleTable": true
+        }
+      },
+      "rawOutputSha256": "e8553d6ce8393ed59002b752cf08b251b03c0ec6843d0c94c1eeebd80979e16f"
+    },
+    {
+      "fixtureId": "scatter-push",
+      "proposal": {
+        "component": "Scatterplot",
+        "props": {
+          "data": [
+            {
+              "payload_kb": 8,
+              "response_ms": 42
+            },
+            {
+              "payload_kb": 16,
+              "response_ms": 61
+            },
+            {
+              "payload_kb": 32,
+              "response_ms": 95
+            }
+          ],
+          "xAccessor": "payload_kb",
+          "yAccessor": "response_ms",
+          "title": "Response time vs payload size",
+          "description": "Scatterplot showing response time in milliseconds against payload size in kilobytes.",
+          "summary": "Response time increases from 42 ms at 8 KB to 95 ms at 32 KB. The chart supports ref-based push for future observations.",
+          "pointIdAccessor": "payload_kb",
+          "enableHover": true,
+          "accessibleTable": true
+        }
+      },
+      "rawOutputSha256": "0592f943d7c32ddfbdc7dba770b07fffde7b49133ed6101b22db6c5421b3da4f"
+    },
+    {
+      "fixtureId": "bubble-static",
+      "proposal": {
+        "component": "BubbleChart",
+        "props": {
+          "data": [
+            {
+              "company": "A",
+              "growth": 12,
+              "retention": 86,
+              "customers": 300
+            },
+            {
+              "company": "B",
+              "growth": 18,
+              "retention": 78,
+              "customers": 180
+            },
+            {
+              "company": "C",
+              "growth": 9,
+              "retention": 92,
+              "customers": 420
+            }
+          ],
+          "xAccessor": "growth",
+          "yAccessor": "retention",
+          "sizeBy": "customers",
+          "colorBy": "company",
+          "sizeRange": [
+            10,
+            40
+          ],
+          "title": "Company growth and retention",
+          "description": "Comparison of companies by growth and retention, with bubble size representing customer count.",
+          "accessibleTable": true
+        }
+      },
+      "rawOutputSha256": "19d26b70da99222ddc3e79327d029c9c2eea2f5669c9dc86a12e7b668a0253ce"
+    },
+    {
+      "fixtureId": "gauge-static",
+      "proposal": {
+        "component": "BigNumber",
+        "props": {
+          "value": 97,
+          "label": "SLA attainment",
+          "format": "number",
+          "suffix": "%",
+          "target": {
+            "value": 99,
+            "label": "target",
+            "format": "number",
+            "suffix": "%"
+          },
+          "description": "Current SLA attainment is 97 percent against a 99 percent target.",
+          "summary": "SLA attainment is 2 percentage points below the 99 percent target.",
+          "accessibleTable": true
+        }
+      },
+      "rawOutputSha256": "02739cc93a57217400b1df8ec32957027d8b0abe3dc29e5896762633f956ff57"
+    },
+    {
+      "fixtureId": "symbol-map-static",
+      "proposal": {
+        "component": "ProportionalSymbolMap",
+        "props": {
+          "points": [
+            {
+              "city": "A",
+              "longitude": -122.4,
+              "latitude": 37.8,
+              "incidents": 18
+            },
+            {
+              "city": "B",
+              "longitude": -74,
+              "latitude": 40.7,
+              "incidents": 31
+            },
+            {
+              "city": "C",
+              "longitude": -87.6,
+              "latitude": 41.9,
+              "incidents": 12
+            }
+          ],
+          "xAccessor": "longitude",
+          "yAccessor": "latitude",
+          "sizeBy": "incidents"
+        }
+      },
+      "rawOutputSha256": "ad24651613cc32bb1d985f9b720d7709628bca2d19c4ffee0240543e78d278c4"
+    },
+    {
+      "fixtureId": "galton-static",
+      "proposal": {
+        "component": "GaltonBoardChart",
+        "props": {
+          "data": [
+            {
+              "id": "a",
+              "value": 1
+            },
+            {
+              "id": "b",
+              "value": 2
+            },
+            {
+              "id": "c",
+              "value": 3
+            },
+            {
+              "id": "d",
+              "value": 4
+            }
+          ],
+          "valueAccessor": "value",
+          "seed": 42
+        }
+      },
+      "rawOutputSha256": "991ca987758a3d66c30df0a4dd882b4635a3245c7651c0c03e15f5cc707ab4a9"
+    },
+    {
+      "fixtureId": "unit-pile-push",
+      "proposal": {
+        "component": "UnitPileChart",
+        "props": {
+          "data": [
+            {
+              "id": "a",
+              "team": "Blue",
+              "value": 3
+            },
+            {
+              "id": "b",
+              "team": "Green",
+              "value": 2
+            }
+          ],
+          "categoryAccessor": "team",
+          "valueAccessor": "value",
+          "colorBy": "team",
+          "unitValue": 1,
+          "title": "Queued work by team",
+          "description": "Unit piles show queued work for each team, with each unit representing one item of work.",
+          "summary": "Blue has 3 units of queued work and Green has 2 units. Additional rows can be appended through the chart ref in React.",
+          "accessibleTable": true
+        }
+      },
+      "rawOutputSha256": "2bf05605b03998a82ef6fe4990c35825b72ffa55af86832cfbc24535fb6e11ab"
+    }
+  ]
+}

--- a/evals/reports/openai-follow-up/trial-b/gpt-5.6-luna/grounding-results.json
+++ b/evals/reports/openai-follow-up/trial-b/gpt-5.6-luna/grounding-results.json
@@ -1,0 +1,310 @@
+{
+  "metadata": {
+    "modelId": "gpt-5.6-luna",
+    "clientVersion": "semiotic-openai-eval/1",
+    "fixtureRevision": "semiotic-grounding-2026-07-27-source-facts",
+    "date": "2026-07-27"
+  },
+  "responses": [
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "png-only",
+      "answer": "North has the highest revenue, at 18."
+    },
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "png-plus-grounding",
+      "answer": "North has the highest revenue, at 18."
+    },
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "grounding-only",
+      "answer": "North has the highest revenue, at 18."
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "png-only",
+      "answer": "3 regions"
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "png-plus-grounding",
+      "answer": "3 regions."
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "grounding-only",
+      "answer": "3 regions"
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "png-only",
+      "answer": "165 users"
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "png-plus-grounding",
+      "answer": "The last observed user count is 165."
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "grounding-only",
+      "answer": "The last observed user count was 165 users (week 4)."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "png-only",
+      "answer": "The series rises across the observed weeks, increasing from about 120 in week 1 to about 165 in week 4."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "png-plus-grounding",
+      "answer": "The series rises across the observed weeks, from 120 users in week 1 to 165 users in week 4."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "grounding-only",
+      "answer": "The series rises across the observed weeks, increasing from 120 users in week 1 to 165 users in week 4."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "png-only",
+      "answer": "The largest payload is approximately 64, paired with a latency of approximately 142."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "png-plus-grounding",
+      "answer": "The largest payload is 64, paired with a latency of 142."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "grounding-only",
+      "answer": "The largest payload is 64, paired with a latency of 142."
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "png-only",
+      "answer": "4 observations"
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "png-plus-grounding",
+      "answer": "4 observations"
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "grounding-only",
+      "answer": "4 observations"
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "png-only",
+      "answer": "API and Worker"
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "png-plus-grounding",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "grounding-only",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "png-only",
+      "answer": "The largest observed latency is 160 ms for API."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "png-plus-grounding",
+      "answer": "The largest observed latency is 160."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "grounding-only",
+      "answer": "The largest observed latency is 160."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "png-only",
+      "answer": "Success receives the largest flow."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Success receives the largest flow, with a value of 78."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "grounding-only",
+      "answer": "Success receives the largest flow, with a value of 78."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "png-only",
+      "answer": "Cannot determine from the chart; it shows flow proportions but no numeric request counts."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "png-plus-grounding",
+      "answer": "7 requests flow to Failure."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "grounding-only",
+      "answer": "Failure: 7 requests."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "png-only",
+      "answer": "Cannot determine—the chart shows Logs, Images, and Backups, but provides no values or sizes."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Images is the largest storage category, with a value of 48."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "grounding-only",
+      "answer": "Images is the largest storage category, with a value of 48."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "png-only",
+      "answer": "Cannot determine the value assigned to Backups from the chart."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "png-plus-grounding",
+      "answer": "Backups is assigned a value of 20."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "grounding-only",
+      "answer": "Backups is assigned a value of 20."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "png-only",
+      "answer": "B, with 31 incidents."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "png-plus-grounding",
+      "answer": "City B has the most incidents, with 31."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "grounding-only",
+      "answer": "City B has the most incidents, with 31."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "png-only",
+      "answer": "3 locations"
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "png-plus-grounding",
+      "answer": "3 locations"
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "grounding-only",
+      "answer": "3 locations are plotted."
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "png-only",
+      "answer": "97 out of 100"
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "png-plus-grounding",
+      "answer": "The current gauge value is 97."
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "grounding-only",
+      "answer": "Current gauge value: 97."
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "png-only",
+      "answer": "The gauge scale maximum is 100."
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "png-plus-grounding",
+      "answer": "The maximum defining the gauge scale is 100."
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "grounding-only",
+      "answer": "The gauge scale maximum is 100."
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "png-only",
+      "answer": "200 purchases"
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "png-plus-grounding",
+      "answer": "Purchases: 200"
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "grounding-only",
+      "answer": "Purchases: 200"
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "png-only",
+      "answer": "Visits, Trials, Purchases"
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "png-plus-grounding",
+      "answer": "Visits, Trials, and Purchases."
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "grounding-only",
+      "answer": "Visits, Trials, and Purchases."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "png-only",
+      "answer": "Smallest observed value: cannot determine. Largest observed value: cannot determine."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "png-plus-grounding",
+      "answer": "Smallest observed value: 1. Largest observed value: 4."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "grounding-only",
+      "answer": "Smallest observed value: 1. Largest observed value: 4."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "png-only",
+      "answer": "Cannot determine from the supplied chart."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "png-plus-grounding",
+      "answer": "4 observed rows"
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "grounding-only",
+      "answer": "4 observed rows feed the board."
+    }
+  ]
+}

--- a/evals/reports/openai-follow-up/trial-b/gpt-5.6-sol/first-try-results.json
+++ b/evals/reports/openai-follow-up/trial-b/gpt-5.6-sol/first-try-results.json
@@ -1,0 +1,240 @@
+{
+  "metadata": {
+    "modelId": "gpt-5.6-sol",
+    "clientVersion": "semiotic-openai-eval/1",
+    "fixtureRevision": "semiotic-first-try-2026-07-27-contracts",
+    "date": "2026-07-27",
+    "context": [
+      "CLAUDE.md",
+      "docs/public/llms.txt"
+    ]
+  },
+  "results": [
+    {
+      "fixtureId": "line-push",
+      "proposal": {
+        "component": "LineChart",
+        "props": {
+          "data": [
+            {
+              "week": 1,
+              "users": 120
+            },
+            {
+              "week": 2,
+              "users": 138
+            },
+            {
+              "week": 3,
+              "users": 151
+            }
+          ],
+          "xAccessor": "week",
+          "yAccessor": "users",
+          "title": "Active Users by Week",
+          "description": "Line chart showing active users by week."
+        }
+      },
+      "rawOutputSha256": "7fd2b49f954eefe2e1aec19faeb185907657c217797615e13a9862c0b40f8c41"
+    },
+    {
+      "fixtureId": "scatter-push",
+      "proposal": {
+        "component": "Scatterplot",
+        "props": {
+          "data": [
+            {
+              "payload_kb": 8,
+              "response_ms": 42
+            },
+            {
+              "payload_kb": 16,
+              "response_ms": 61
+            },
+            {
+              "payload_kb": 32,
+              "response_ms": 95
+            }
+          ],
+          "xAccessor": "payload_kb",
+          "yAccessor": "response_ms",
+          "xLabel": "Payload size (KB)",
+          "yLabel": "Response time (ms)",
+          "title": "Response Time by Payload Size",
+          "description": "Scatterplot of response time in milliseconds against payload size in kilobytes.",
+          "summary": "Response time rises as payload size increases. This chart supports ref-based streaming observations.",
+          "accessibleTable": true,
+          "enableHover": true
+        }
+      },
+      "rawOutputSha256": "4d58e8ec0db5608540a0299115dba7b04ffe173335336b1e430fc5db1577d297"
+    },
+    {
+      "fixtureId": "bubble-static",
+      "proposal": {
+        "component": "BubbleChart",
+        "props": {
+          "data": [
+            {
+              "company": "A",
+              "growth": 12,
+              "retention": 86,
+              "customers": 300
+            },
+            {
+              "company": "B",
+              "growth": 18,
+              "retention": 78,
+              "customers": 180
+            },
+            {
+              "company": "C",
+              "growth": 9,
+              "retention": 92,
+              "customers": 420
+            }
+          ],
+          "xAccessor": "growth",
+          "yAccessor": "retention",
+          "sizeBy": "customers",
+          "colorBy": "company",
+          "title": "Company Growth and Retention",
+          "description": "Bubble chart comparing company growth and retention, with bubble size representing customers.",
+          "summary": "Company B has the highest growth, Company C has the highest retention and largest customer base, and Company A falls between them.",
+          "showLegend": true,
+          "accessibleTable": true
+        }
+      },
+      "rawOutputSha256": "33e281fcd90211daef28fdbd29f851e958b370f164ff088d90c2da4212b5b01c"
+    },
+    {
+      "fixtureId": "gauge-static",
+      "proposal": {
+        "component": "BigNumber",
+        "props": {
+          "value": 97,
+          "label": "SLA attainment",
+          "format": "number",
+          "suffix": "%",
+          "target": {
+            "value": 99,
+            "label": "target",
+            "format": "number"
+          },
+          "thresholds": [
+            {
+              "at": 0,
+              "level": "warning",
+              "color": "#c7952f",
+              "label": "Below target"
+            },
+            {
+              "at": 99,
+              "level": "success",
+              "color": "#2a8f68",
+              "label": "Meets target"
+            }
+          ],
+          "description": "Current SLA attainment is 97 percent against a 99 percent target.",
+          "summary": "SLA attainment is 2 percentage points below target."
+        }
+      },
+      "rawOutputSha256": "e2ee95a90654f0ceda37b676718fb5eafe15681e4efdff0d1596948061ead803"
+    },
+    {
+      "fixtureId": "symbol-map-static",
+      "proposal": {
+        "component": "ProportionalSymbolMap",
+        "props": {
+          "points": [
+            {
+              "city": "A",
+              "longitude": -122.4,
+              "latitude": 37.8,
+              "incidents": 18
+            },
+            {
+              "city": "B",
+              "longitude": -74,
+              "latitude": 40.7,
+              "incidents": 31
+            },
+            {
+              "city": "C",
+              "longitude": -87.6,
+              "latitude": 41.9,
+              "incidents": 12
+            }
+          ],
+          "xAccessor": "longitude",
+          "yAccessor": "latitude",
+          "sizeBy": "incidents",
+          "sizeRange": [
+            5,
+            40
+          ],
+          "title": "Incident Counts by Location",
+          "description": "A proportional symbol map showing incident counts at three longitude and latitude locations.",
+          "summary": "City B has the most incidents with 31, followed by City A with 18 and City C with 12.",
+          "accessibleTable": true,
+          "tooltip": true
+        }
+      },
+      "rawOutputSha256": "e2056506eb20d5faf0503bb50f25612615cf1a4b6063b6341ad53365d168145d"
+    },
+    {
+      "fixtureId": "galton-static",
+      "proposal": {
+        "component": "GaltonBoardChart",
+        "props": {
+          "data": [
+            {
+              "id": "a",
+              "value": 1
+            },
+            {
+              "id": "b",
+              "value": 2
+            },
+            {
+              "id": "c",
+              "value": 3
+            },
+            {
+              "id": "d",
+              "value": 4
+            }
+          ],
+          "valueAccessor": "value",
+          "mode": "sample",
+          "seed": 42
+        }
+      },
+      "rawOutputSha256": "cca21da3fc818855f93324ed9a2a7b2081c559ba52cead21a388968b5acf2df3"
+    },
+    {
+      "fixtureId": "unit-pile-push",
+      "proposal": {
+        "component": "UnitPileChart",
+        "props": {
+          "data": [
+            {
+              "id": "a",
+              "team": "Blue",
+              "value": 3
+            },
+            {
+              "id": "b",
+              "team": "Green",
+              "value": 2
+            }
+          ],
+          "categoryAccessor": "team",
+          "valueAccessor": "value",
+          "unitValue": 1
+        }
+      },
+      "rawOutputSha256": "add8e8477487c817bce0146d71d94720611ed4029bb7f902fc3ab25e9c086bfd"
+    }
+  ]
+}

--- a/evals/reports/openai-follow-up/trial-b/gpt-5.6-sol/grounding-results.json
+++ b/evals/reports/openai-follow-up/trial-b/gpt-5.6-sol/grounding-results.json
@@ -1,0 +1,310 @@
+{
+  "metadata": {
+    "modelId": "gpt-5.6-sol",
+    "clientVersion": "semiotic-openai-eval/1",
+    "fixtureRevision": "semiotic-grounding-2026-07-27-source-facts",
+    "date": "2026-07-27"
+  },
+  "responses": [
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "png-only",
+      "answer": "North has the highest revenue, with a value of 18."
+    },
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "png-plus-grounding",
+      "answer": "North has the highest revenue, at 18."
+    },
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "grounding-only",
+      "answer": "North has the highest revenue, at 18."
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "png-only",
+      "answer": "3 regions: North, South, and West."
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "png-plus-grounding",
+      "answer": "3 regions: North, South, and West."
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "grounding-only",
+      "answer": "3 regions."
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "png-only",
+      "answer": "Last observed user count: 165."
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "png-plus-grounding",
+      "answer": "Week 4: 165 users."
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "grounding-only",
+      "answer": "Week 4: 165 users."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "png-only",
+      "answer": "The Weekly active users series rises across the observed weeks, increasing from about 120 in week 1 to about 165 in week 4."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "png-plus-grounding",
+      "answer": "The series rises across the observed weeks: Week 1: 120 users; Week 2: 138; Week 3: 151; Week 4: 165."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "grounding-only",
+      "answer": "The series rises across the observed weeks: Week 1: 120 users; Week 2: 138; Week 3: 151; Week 4: 165."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "png-only",
+      "answer": "The largest payload is paired with a latency of approximately 142."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "png-plus-grounding",
+      "answer": "The largest payload is 64, paired with a latency of 142."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "grounding-only",
+      "answer": "The largest payload, 64, is paired with a latency of 142."
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "png-only",
+      "answer": "4 observations."
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "png-plus-grounding",
+      "answer": "4 observations are plotted."
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "grounding-only",
+      "answer": "4 observations are plotted."
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "png-only",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "png-plus-grounding",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "grounding-only",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "png-only",
+      "answer": "The largest observed latency is 160 for the API service."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "png-plus-grounding",
+      "answer": "The largest observed latency is 160 (API)."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "grounding-only",
+      "answer": "The largest observed latency is 160."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "png-only",
+      "answer": "Success receives the largest flow."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Success receives the largest flow, with a value of 78."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "grounding-only",
+      "answer": "Success receives the largest flow, with a value of 78."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "png-only",
+      "answer": "Failure: 20 requests"
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "png-plus-grounding",
+      "answer": "Failure: 7 requests."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "grounding-only",
+      "answer": "Failure: 7 requests."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "png-only",
+      "answer": "Cannot determine. The chart labels Images, Logs, and Backups, but does not show distinct sizes or values for the categories."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Images — 48."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "grounding-only",
+      "answer": "Images — 48."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "png-only",
+      "answer": "Backups: cannot determine."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "png-plus-grounding",
+      "answer": "Backups: 20."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "grounding-only",
+      "answer": "Backups: 20"
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "png-only",
+      "answer": "City B has the most incidents, with 31."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "png-plus-grounding",
+      "answer": "City B has the most incidents: 31."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "grounding-only",
+      "answer": "City B has the most incidents, with 31."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "png-only",
+      "answer": "3 locations are plotted."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "png-plus-grounding",
+      "answer": "3 locations are plotted: A, B, and C."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "grounding-only",
+      "answer": "3 locations are plotted: A, B, and C."
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "png-only",
+      "answer": "Current gauge value: 97 of 100."
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "png-plus-grounding",
+      "answer": "Current gauge value: 97."
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "grounding-only",
+      "answer": "Current gauge value: 97."
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "png-only",
+      "answer": "The gauge scale maximum is 100."
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "png-plus-grounding",
+      "answer": "The gauge scale maximum is 100."
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "grounding-only",
+      "answer": "The gauge scale maximum is 100."
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "png-only",
+      "answer": "Purchases: 200 (20%)."
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "png-plus-grounding",
+      "answer": "Purchases: 200"
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "grounding-only",
+      "answer": "Purchases: 200"
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "png-only",
+      "answer": "Visits — 1.0K; Trials — 400 (40%); Purchases — 200 (20%)."
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "png-plus-grounding",
+      "answer": "Visits, Trials, and Purchases."
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "grounding-only",
+      "answer": "Visits (1,000), Trials (400), and Purchases (200)."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "png-only",
+      "answer": "Cannot determine: the chart shows four points but provides no axis labels or numeric scale."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "png-plus-grounding",
+      "answer": "Smallest observed value: 1. Largest observed value: 4."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "grounding-only",
+      "answer": "Smallest observed value: 1. Largest observed value: 4."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "png-only",
+      "answer": "4 observed rows feed the board."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "png-plus-grounding",
+      "answer": "Observed rows: 4."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "grounding-only",
+      "answer": "Observed rows: 4."
+    }
+  ]
+}

--- a/evals/reports/openai-follow-up/trial-b/gpt-5.6-terra/first-try-results.json
+++ b/evals/reports/openai-follow-up/trial-b/gpt-5.6-terra/first-try-results.json
@@ -1,0 +1,250 @@
+{
+  "metadata": {
+    "modelId": "gpt-5.6-terra",
+    "clientVersion": "semiotic-openai-eval/1",
+    "fixtureRevision": "semiotic-first-try-2026-07-27-contracts",
+    "date": "2026-07-27",
+    "context": [
+      "CLAUDE.md",
+      "docs/public/llms.txt"
+    ]
+  },
+  "results": [
+    {
+      "fixtureId": "line-push",
+      "proposal": {
+        "component": "LineChart",
+        "props": {
+          "data": [
+            {
+              "week": 1,
+              "users": 120
+            },
+            {
+              "week": 2,
+              "users": 138
+            },
+            {
+              "week": 3,
+              "users": 151
+            }
+          ],
+          "xAccessor": "week",
+          "yAccessor": "users",
+          "title": "Active users by week",
+          "description": "Line chart showing active users increasing from 120 in week 1 to 151 in week 3.",
+          "xLabel": "Week",
+          "yLabel": "Active users",
+          "showPoints": true
+        }
+      },
+      "rawOutputSha256": "6e257e58ab4714382eb299dff2f6952b7262d83fe9d1bdaf177a892b57135980"
+    },
+    {
+      "fixtureId": "scatter-push",
+      "proposal": {
+        "component": "Scatterplot",
+        "props": {
+          "data": [
+            {
+              "payload_kb": 8,
+              "response_ms": 42
+            },
+            {
+              "payload_kb": 16,
+              "response_ms": 61
+            },
+            {
+              "payload_kb": 32,
+              "response_ms": 95
+            }
+          ],
+          "xAccessor": "payload_kb",
+          "yAccessor": "response_ms",
+          "xLabel": "Payload size (KB)",
+          "yLabel": "Response time (ms)",
+          "title": "Response Time by Payload Size",
+          "description": "Scatterplot showing response time in milliseconds against payload size in kilobytes.",
+          "summary": "Response time increases as payload size increases. The chart supports additional observations through its ref-based push API."
+        }
+      },
+      "rawOutputSha256": "1e322895dbd9b68dfb33eb81f61c9ceb77f12bb906d76eff3470b25de33414ac"
+    },
+    {
+      "fixtureId": "bubble-static",
+      "proposal": {
+        "component": "BubbleChart",
+        "props": {
+          "data": [
+            {
+              "company": "A",
+              "growth": 12,
+              "retention": 86,
+              "customers": 300
+            },
+            {
+              "company": "B",
+              "growth": 18,
+              "retention": 78,
+              "customers": 180
+            },
+            {
+              "company": "C",
+              "growth": 9,
+              "retention": 92,
+              "customers": 420
+            }
+          ],
+          "xAccessor": "growth",
+          "yAccessor": "retention",
+          "sizeBy": "customers",
+          "colorBy": "company",
+          "sizeRange": [
+            8,
+            32
+          ],
+          "title": "Company Growth and Retention",
+          "description": "Bubble chart comparing company growth and retention, with bubble size representing customer count.",
+          "summary": "Company B has the highest growth, Company C has the highest retention and the most customers, and Company A falls between them.",
+          "xLabel": "Growth",
+          "yLabel": "Retention",
+          "showLegend": true,
+          "tooltip": true,
+          "width": 600,
+          "height": 400
+        }
+      },
+      "rawOutputSha256": "ad6bb8e6808f5175b6503a35aca24316c97e4fd9cf7c61de2e0fc77081528fa5"
+    },
+    {
+      "fixtureId": "gauge-static",
+      "proposal": {
+        "component": "BigNumber",
+        "props": {
+          "value": 97,
+          "label": "SLA attainment",
+          "format": "number",
+          "suffix": "%",
+          "target": {
+            "value": 99,
+            "label": "target",
+            "format": "number"
+          },
+          "thresholds": [
+            {
+              "at": 0,
+              "level": "warning",
+              "color": "#c7952f",
+              "label": "Below target"
+            },
+            {
+              "at": 99,
+              "level": "success",
+              "color": "#2a8f68",
+              "label": "Meets target"
+            }
+          ],
+          "description": "Current SLA attainment is 97%, against a 99% target.",
+          "summary": "SLA attainment is 2 percentage points below the 99% target."
+        }
+      },
+      "rawOutputSha256": "580455e5d7856fb4dc7b14e01885d94c43ff64b6c447e1babee67a219d17219a"
+    },
+    {
+      "fixtureId": "symbol-map-static",
+      "proposal": {
+        "component": "ProportionalSymbolMap",
+        "props": {
+          "points": [
+            {
+              "city": "A",
+              "longitude": -122.4,
+              "latitude": 37.8,
+              "incidents": 18
+            },
+            {
+              "city": "B",
+              "longitude": -74,
+              "latitude": 40.7,
+              "incidents": 31
+            },
+            {
+              "city": "C",
+              "longitude": -87.6,
+              "latitude": 41.9,
+              "incidents": 12
+            }
+          ],
+          "xAccessor": "longitude",
+          "yAccessor": "latitude",
+          "sizeBy": "incidents",
+          "sizeRange": [
+            5,
+            40
+          ],
+          "colorBy": "city",
+          "title": "Incident counts by location",
+          "description": "Proportional symbols map incident counts at three longitude and latitude locations.",
+          "summary": "City B has 31 incidents, City A has 18, and City C has 12.",
+          "showLegend": true
+        }
+      },
+      "rawOutputSha256": "dbab117f310c4763060d9400803cafb23e21318083065103c6f8914640819596"
+    },
+    {
+      "fixtureId": "galton-static",
+      "proposal": {
+        "component": "GaltonBoardChart",
+        "props": {
+          "data": [
+            {
+              "id": "a",
+              "value": 1
+            },
+            {
+              "id": "b",
+              "value": 2
+            },
+            {
+              "id": "c",
+              "value": 3
+            },
+            {
+              "id": "d",
+              "value": 4
+            }
+          ],
+          "valueAccessor": "value",
+          "seed": 42,
+          "bins": 4
+        }
+      },
+      "rawOutputSha256": "f0be851cfd0530c242a17a7798513abfadb5254721a66eb4f91f7680770b97b4"
+    },
+    {
+      "fixtureId": "unit-pile-push",
+      "proposal": {
+        "component": "UnitPileChart",
+        "props": {
+          "data": [
+            {
+              "id": "a",
+              "team": "Blue",
+              "value": 3
+            },
+            {
+              "id": "b",
+              "team": "Green",
+              "value": 2
+            }
+          ],
+          "categoryAccessor": "team",
+          "valueAccessor": "value",
+          "colorBy": "team",
+          "unitValue": 1
+        }
+      },
+      "rawOutputSha256": "8a53ec482310cbcd7c98b58fca71475bc9c5cd8ac356a1d5b8b64a6e1f670410"
+    }
+  ]
+}

--- a/evals/reports/openai-follow-up/trial-b/gpt-5.6-terra/grounding-results.json
+++ b/evals/reports/openai-follow-up/trial-b/gpt-5.6-terra/grounding-results.json
@@ -1,0 +1,310 @@
+{
+  "metadata": {
+    "modelId": "gpt-5.6-terra",
+    "clientVersion": "semiotic-openai-eval/1",
+    "fixtureRevision": "semiotic-grounding-2026-07-27-source-facts",
+    "date": "2026-07-27"
+  },
+  "responses": [
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "png-only",
+      "answer": "North has the highest revenue, with a value of 18."
+    },
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "png-plus-grounding",
+      "answer": "North has the highest revenue, at 18."
+    },
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "grounding-only",
+      "answer": "North has the highest revenue, at 18."
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "png-only",
+      "answer": "3 regions"
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "png-plus-grounding",
+      "answer": "3 regions"
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "grounding-only",
+      "answer": "3 regions."
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "png-only",
+      "answer": "165"
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "png-plus-grounding",
+      "answer": "Week 4: 165 users."
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "grounding-only",
+      "answer": "Week 4: 165 users."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "png-only",
+      "answer": "The series rises across the observed weeks, increasing from about 120 at week 1 to about 165 at week 4."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "png-plus-grounding",
+      "answer": "Rise: users increase from 120 at week 1 to 165 at week 4."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "grounding-only",
+      "answer": "The series rises across the observed weeks, from 120 users in week 1 to 165 users in week 4."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "png-only",
+      "answer": "The largest payload is 142, paired with a latency of 64."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "png-plus-grounding",
+      "answer": "At the largest payload, 64, the latency is 142."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "grounding-only",
+      "answer": "At the largest payload of 64, the latency is 142."
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "png-only",
+      "answer": "4 observations"
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "png-plus-grounding",
+      "answer": "4 observations are plotted."
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "grounding-only",
+      "answer": "4 observations are plotted."
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "png-only",
+      "answer": "API and Worker"
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "png-plus-grounding",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "grounding-only",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "png-only",
+      "answer": "160"
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "png-plus-grounding",
+      "answer": "160"
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "grounding-only",
+      "answer": "160"
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "png-only",
+      "answer": "Success"
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Success receives the largest flow: 78."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "grounding-only",
+      "answer": "Success receives the largest flow: 78."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "png-only",
+      "answer": "Cannot determine; the chart shows a flow to Failure but provides no numeric value."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "png-plus-grounding",
+      "answer": "Failure: 7 requests."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "grounding-only",
+      "answer": "7 requests flow to Failure."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "png-only",
+      "answer": "Cannot determine; the chart shows Images, Logs, and Backups but provides no values or relative sizes."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Images is the largest storage category, with a value of 48."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "grounding-only",
+      "answer": "Images is the largest storage category, with a value of 48."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "png-only",
+      "answer": "cannot determine"
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "png-plus-grounding",
+      "answer": "Backups: 20"
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "grounding-only",
+      "answer": "Backups: 20"
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "png-only",
+      "answer": "B has the most incidents, with 31."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "png-plus-grounding",
+      "answer": "City B has the most incidents: 31."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "grounding-only",
+      "answer": "City B has the most incidents: 31."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "png-only",
+      "answer": "3 locations are plotted."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "png-plus-grounding",
+      "answer": "3 locations are plotted."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "grounding-only",
+      "answer": "3 locations are plotted."
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "png-only",
+      "answer": "97 of 100"
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "png-plus-grounding",
+      "answer": "97"
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "grounding-only",
+      "answer": "97"
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "png-only",
+      "answer": "100"
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "png-plus-grounding",
+      "answer": "100"
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "grounding-only",
+      "answer": "100"
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "png-only",
+      "answer": "Purchases: 200 (20%)"
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "png-plus-grounding",
+      "answer": "Purchases: 200"
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "grounding-only",
+      "answer": "Purchases: 200"
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "png-only",
+      "answer": "Visits; Trials; Purchases."
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "png-plus-grounding",
+      "answer": "Visits; Trials; Purchases."
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "grounding-only",
+      "answer": "Visits; Trials; Purchases."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "png-only",
+      "answer": "Smallest observed value: cannot determine. Largest observed value: cannot determine."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "png-plus-grounding",
+      "answer": "Smallest observed value: 1. Largest observed value: 4."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "grounding-only",
+      "answer": "Smallest observed value: 1. Largest observed value: 4."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "png-only",
+      "answer": "4 observed rows"
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "png-plus-grounding",
+      "answer": "4 observed rows"
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "grounding-only",
+      "answer": "4 observed source rows feed the board."
+    }
+  ]
+}

--- a/evals/reports/openai-follow-up/trial-b/run-manifest.json
+++ b/evals/reports/openai-follow-up/trial-b/run-manifest.json
@@ -1,0 +1,4684 @@
+{
+  "version": 1,
+  "clientVersion": "semiotic-openai-eval/1",
+  "priceRevision": "openai-standard-2026-07-26",
+  "models": [
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna"
+  ],
+  "trialId": "postmerge-b",
+  "filters": {
+    "suites": [
+      "first-try",
+      "grounding"
+    ],
+    "firstTryFixtureIds": [
+      "gauge-static",
+      "line-push",
+      "scatter-push",
+      "bubble-static",
+      "symbol-map-static",
+      "unit-pile-push",
+      "galton-static"
+    ],
+    "groundingFixtureIds": [
+      "regional-revenue/highest",
+      "regional-revenue/count",
+      "weekly-users/last",
+      "weekly-users/direction",
+      "payload-latency/largest",
+      "payload-latency/count",
+      "service-latency/categories",
+      "service-latency/max",
+      "request-flow/largest",
+      "request-flow/failed",
+      "storage-tree/largest",
+      "storage-tree/backups",
+      "incident-map/largest",
+      "incident-map/count",
+      "sla-gauge/value",
+      "sla-gauge/maximum",
+      "conversion-funnel/purchases",
+      "conversion-funnel/stages",
+      "galton-values/range",
+      "galton-values/count"
+    ],
+    "groundingConditions": [
+      "png-only",
+      "png-plus-grounding",
+      "grounding-only"
+    ]
+  },
+  "projectFingerprint": "cc3c2be40c1f",
+  "maxUsd": 3,
+  "startedAt": "2026-07-27T20:26:28.009Z",
+  "completedAt": "2026-07-27T20:28:55.981Z",
+  "requests": [
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/png-only",
+      "responseId": "resp_038f8ce2279b5896016a67bef46da4819ba4a63d28a40f1db6",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 374,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 400
+      },
+      "estimatedUsd": 0.00265,
+      "latencyMs": 1401,
+      "rawOutputSha256": "88936eda3d8e7302c9379539aefd611e4bf5cb0034befd12025a91ca79f7d558"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/png-plus-grounding",
+      "responseId": "resp_05e0fe34c9682e7b016a67bef47168819ab7675bc361c2c8d2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 996,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1019
+      },
+      "estimatedUsd": 0.00567,
+      "latencyMs": 1326,
+      "rawOutputSha256": "e8097e8a1fab95b2e2feeb201aa95be0437944be071961969ffda4f2e85982c3"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/grounding-only",
+      "responseId": "resp_00b61757fa9fd1d6016a67bef58ac0819a8a40ea1c7b07cebf",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 699,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 722
+      },
+      "estimatedUsd": 0.004185,
+      "latencyMs": 1228,
+      "rawOutputSha256": "e8097e8a1fab95b2e2feeb201aa95be0437944be071961969ffda4f2e85982c3"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/png-only",
+      "responseId": "resp_0c2b84ff4906db97016a67bef5873c819bbefd238db1fed064",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 390
+      },
+      "estimatedUsd": 0.002525,
+      "latencyMs": 1274,
+      "rawOutputSha256": "fcf77bad7f39f8de12bdace68707c9dfe9fe18f3becb676f96507e56f2df4998"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/png-plus-grounding",
+      "responseId": "resp_04a8dc842366e969016a67bef6d170819892ff12337d46ff0b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 989,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1012
+      },
+      "estimatedUsd": 0.005635,
+      "latencyMs": 1152,
+      "rawOutputSha256": "fcf77bad7f39f8de12bdace68707c9dfe9fe18f3becb676f96507e56f2df4998"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/grounding-only",
+      "responseId": "resp_0afe886412a18f91016a67bef6cfb8819a900e27ae5cc8db1b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 692,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 708
+      },
+      "estimatedUsd": 0.00394,
+      "latencyMs": 1074,
+      "rawOutputSha256": "0f68b1bf58d9ad62e6fef8b78533bc3c7a29a4abd9c7f842c105da58f45e9b86"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/png-only",
+      "responseId": "resp_0093aa7cbe72cd5e016a67bef80394819b999173a6c8c52e32",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 390
+      },
+      "estimatedUsd": 0.002475,
+      "latencyMs": 1856,
+      "rawOutputSha256": "85cce93badae1de85397859ed39129cf3494801c67eb4459f746c389891739ad"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/png-plus-grounding",
+      "responseId": "resp_04b02e3a29f5b052016a67bef7fe6081988e40c9c69be9eac8",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1104,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1052
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1125
+      },
+      "estimatedUsd": 0.001416,
+      "latencyMs": 1522,
+      "rawOutputSha256": "75bbef3f8990abc3c267e7e306e775c6fc4f1435c7d19a2ddd81440f2019fa42"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/grounding-only",
+      "responseId": "resp_08c24ec689426812016a67bef9d94081988151fc9af4749a2d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 807,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 828
+      },
+      "estimatedUsd": 0.004665,
+      "latencyMs": 1136,
+      "rawOutputSha256": "75bbef3f8990abc3c267e7e306e775c6fc4f1435c7d19a2ddd81440f2019fa42"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/png-only",
+      "responseId": "resp_0964ba30e31b1e06016a67bef9db8c819aa76a5c77f389f8db",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 372,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 42,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 414
+      },
+      "estimatedUsd": 0.00312,
+      "latencyMs": 1539,
+      "rawOutputSha256": "7a511c1e18e52f0b8059f1736b86e5d86f85518cd1620145fd3a80b41eafe9be"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/png-plus-grounding",
+      "responseId": "resp_06597918dba454c8016a67befb651481999f5c3ea7857cf426",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1107,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1055
+        },
+        "output_tokens": 50,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1157
+      },
+      "estimatedUsd": 0.0022875,
+      "latencyMs": 2643,
+      "rawOutputSha256": "d8917ada7c49000fe18c35b6058cd7ea308f22f202f6e50b07b6d9fa662ff6c2"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/grounding-only",
+      "responseId": "resp_0d4575b96f1f1542016a67befb6a80819b9d2e17cce8bc6ada",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 810,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 50,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 860
+      },
+      "estimatedUsd": 0.00555,
+      "latencyMs": 1743,
+      "rawOutputSha256": "d8917ada7c49000fe18c35b6058cd7ea308f22f202f6e50b07b6d9fa662ff6c2"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/png-only",
+      "responseId": "resp_0eb49f9ff305c1ed016a67befe1728819ba84db1039818fdb7",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 370,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 396
+      },
+      "estimatedUsd": 0.00263,
+      "latencyMs": 1412,
+      "rawOutputSha256": "d9b4eb4774cf41dc65ddf9f4da5b6166ca4cdaae9cafe083cdd38e63b2ab1fee"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/png-plus-grounding",
+      "responseId": "resp_08ae8c24222e648e016a67befe0ad4819a88dad1727b86c250",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1077,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1025
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1105
+      },
+      "estimatedUsd": 0.0016125,
+      "latencyMs": 1232,
+      "rawOutputSha256": "f3f5d9ba945975d3f6c2276f3f6996a6ffcef411030dba19eeb47d91aaf7638a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/grounding-only",
+      "responseId": "resp_0687116410231b17016a67beff6f30819ba75b069af4f746f2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 780,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 29,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 809
+      },
+      "estimatedUsd": 0.00477,
+      "latencyMs": 1105,
+      "rawOutputSha256": "9a1005e108b19746a0b86f4bd0e4506d16407fa1d53e89dd7146c87139af541b"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/png-only",
+      "responseId": "resp_089d8cb5a6de74b4016a67beff6fa08199a7800d52acd82be7",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 383
+      },
+      "estimatedUsd": 0.002315,
+      "latencyMs": 1308,
+      "rawOutputSha256": "db581f71a007f0598a6a640bbb858c5256af62c79ae61f149233e32cce4679b2"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/png-plus-grounding",
+      "responseId": "resp_0f77459945a8db42016a67bf00d4d481989c8ca812c3ef6de0",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1074,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1092
+      },
+      "estimatedUsd": 0.00591,
+      "latencyMs": 1166,
+      "rawOutputSha256": "3c3eeaf75b600452370e78a739d4d431ba57064c98163b837081438f2c78873e"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/grounding-only",
+      "responseId": "resp_00b9e101e46cb600016a67bf00cfac819a9a847fa4130ef83c",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 777,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 795
+      },
+      "estimatedUsd": 0.004425,
+      "latencyMs": 1216,
+      "rawOutputSha256": "3c3eeaf75b600452370e78a739d4d431ba57064c98163b837081438f2c78873e"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/png-only",
+      "responseId": "resp_090132785dcf8f41016a67bf0200948198899acd2b8689b3b5",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 384
+      },
+      "estimatedUsd": 0.002345,
+      "latencyMs": 2228,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/png-plus-grounding",
+      "responseId": "resp_068c8e148512ff2f016a67bf01fb4081989aa02c450e245f87",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1061,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1078
+      },
+      "estimatedUsd": 0.005815,
+      "latencyMs": 1149,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/grounding-only",
+      "responseId": "resp_0833399ce01c81b5016a67bf0433d4819a9f442834211d4ea6",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 764,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 781
+      },
+      "estimatedUsd": 0.00433,
+      "latencyMs": 933,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/png-only",
+      "responseId": "resp_021ae21be1806175016a67bf044054819991e0e3bb90c08114",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 393
+      },
+      "estimatedUsd": 0.00259,
+      "latencyMs": 1244,
+      "rawOutputSha256": "2d0f53cd636e1c3f191638b15d1975a3545bf1ff33d256f66c2c59c26f1281d2"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/png-plus-grounding",
+      "responseId": "resp_0b914e7f1ded9ed5016a67bf057530819ab48a3b2c26bbef12",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1062,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1085
+      },
+      "estimatedUsd": 0.006,
+      "latencyMs": 1104,
+      "rawOutputSha256": "ba97bc35a0fe8024bdb3f8cd46fd4da5885a4226ed918e9c15bb482ea189c77a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/grounding-only",
+      "responseId": "resp_008d2559f84a4ab9016a67bf05725c8198a98691625742c990",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 765,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 786
+      },
+      "estimatedUsd": 0.004455,
+      "latencyMs": 1108,
+      "rawOutputSha256": "7295c9d5d6f4ea0ac2c58c12d63f39e12cb5f365069d19d9781948860e8a936b"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/png-only",
+      "responseId": "resp_0e2c2ac95793c2b3016a67bf06957c8199a8feef35a68e5e46",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 387
+      },
+      "estimatedUsd": 0.00241,
+      "latencyMs": 3985,
+      "rawOutputSha256": "8ce76a2cc90fce86f33856eb397f5d7929bd4c1c263686f1bda00c74e84c8b7f"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/png-plus-grounding",
+      "responseId": "resp_06098411e8834f5e016a67bf069b8481988cda68b00331fad7",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 674,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 700
+      },
+      "estimatedUsd": 0.00415,
+      "latencyMs": 1167,
+      "rawOutputSha256": "c713a07fb2312f9fff73682b5b1eb18f75e63d98269a17a174e5264d66821f61"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/grounding-only",
+      "responseId": "resp_099c4b6a2d9aa869016a67bf0a911c819a83d54647a1747d43",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 377,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 403
+      },
+      "estimatedUsd": 0.002665,
+      "latencyMs": 1271,
+      "rawOutputSha256": "c713a07fb2312f9fff73682b5b1eb18f75e63d98269a17a174e5264d66821f61"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/png-only",
+      "responseId": "resp_09067694dd343752016a67bf0a9670819993df5ee4d1a8ce02",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 386
+      },
+      "estimatedUsd": 0.00238,
+      "latencyMs": 1285,
+      "rawOutputSha256": "8a16f96e9ff361091a7339fdab4fc8951a30546c07ace96148a02f5f4dfee885"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/png-plus-grounding",
+      "responseId": "resp_0f56ccfc6f48f37e016a67bf0bf664819983d3978f215ad642",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 674,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 693
+      },
+      "estimatedUsd": 0.00394,
+      "latencyMs": 1701,
+      "rawOutputSha256": "5fa497f3f8106c6f31d32a111886afafa13772704cab1817afa1cace02f54dd1"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/grounding-only",
+      "responseId": "resp_0cb605bbcd04beaa016a67bf0be0b08198bbfaa2676a2a95e2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 377,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 396
+      },
+      "estimatedUsd": 0.002455,
+      "latencyMs": 1457,
+      "rawOutputSha256": "5fa497f3f8106c6f31d32a111886afafa13772704cab1817afa1cace02f54dd1"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/png-only",
+      "responseId": "resp_0cc4ad7584d039a9016a67bf0d92ec8199b95156f1da3296ae",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 39,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 406
+      },
+      "estimatedUsd": 0.003005,
+      "latencyMs": 1384,
+      "rawOutputSha256": "37da094514d7e2ee79266094cc424540b2d0ca3ff3b94ec10b9f37c8105564cb"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/png-plus-grounding",
+      "responseId": "resp_00796fb8f6d22ede016a67bf0d91dc819aa45e31252fb6efc4",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 592,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 610
+      },
+      "estimatedUsd": 0.0035,
+      "latencyMs": 1261,
+      "rawOutputSha256": "7f244ee40a26cd329aaa70e1417ed8be11e42081f387b637245500866fc408ab"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/grounding-only",
+      "responseId": "resp_0d8730e76a81bee7016a67bf0efbd4819b853c2aecdfdbe127",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 295,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 313
+      },
+      "estimatedUsd": 0.002015,
+      "latencyMs": 934,
+      "rawOutputSha256": "7f244ee40a26cd329aaa70e1417ed8be11e42081f387b637245500866fc408ab"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/png-only",
+      "responseId": "resp_019d51e6e612852f016a67bf0efc88819b9687298212206da7",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 388
+      },
+      "estimatedUsd": 0.002415,
+      "latencyMs": 1404,
+      "rawOutputSha256": "a8406cbafeff6310f2d3c7f58dbaf2fd9fccffe490afc3e7d50a2764cd1a36df"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/png-plus-grounding",
+      "responseId": "resp_0cb2ed2f5a5319d9016a67bf10689c8198875e8851d51a0510",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 594,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 613
+      },
+      "estimatedUsd": 0.00354,
+      "latencyMs": 1364,
+      "rawOutputSha256": "2bdcd2581a233eef2e3e19338bf56fe720108cbc0b5b30b13629abc2c519fb3f"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/grounding-only",
+      "responseId": "resp_05938ddc32385500016a67bf106244819aa3b7ebd0269b2563",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 297,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 315
+      },
+      "estimatedUsd": 0.002025,
+      "latencyMs": 3009,
+      "rawOutputSha256": "753f86bf4602c0d28bab029088ca178bb2f2e9959e70868f46aaf03ce6dd0d1a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/png-only",
+      "responseId": "resp_06abe2826b98f2b1016a67bf1364e48199988c50d51308a5bd",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 24,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 393
+      },
+      "estimatedUsd": 0.002565,
+      "latencyMs": 1177,
+      "rawOutputSha256": "0bfc9b74a5ecae617f08db8725ab35bc9ff9714491e643cb6710c85538500c7d"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/png-plus-grounding",
+      "responseId": "resp_03b54369e16e4eb1016a67bf137fd0819bba574ded25c7f513",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 991,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1014
+      },
+      "estimatedUsd": 0.005645,
+      "latencyMs": 1683,
+      "rawOutputSha256": "aab71f12b87d6c2de6eecc920195891341458434364ed59a0fac4c731b189e69"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/grounding-only",
+      "responseId": "resp_0232b478de3da300016a67bf1520608199bfa1eb1284206d7b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 694,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 24,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 718
+      },
+      "estimatedUsd": 0.00419,
+      "latencyMs": 1159,
+      "rawOutputSha256": "0bfc9b74a5ecae617f08db8725ab35bc9ff9714491e643cb6710c85538500c7d"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/png-only",
+      "responseId": "resp_0c0b049a803e02f7016a67bf1513208198ad3654ee35a4782a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 385
+      },
+      "estimatedUsd": 0.002375,
+      "latencyMs": 959,
+      "rawOutputSha256": "1760697eb73e58cde8936922849298389b6c393ec24bbd982ac84c7fb4682702"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/png-plus-grounding",
+      "responseId": "resp_06bc86a388710e5d016a67bf164944819aa27fae03eea92343",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 989,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1014
+      },
+      "estimatedUsd": 0.005695,
+      "latencyMs": 1368,
+      "rawOutputSha256": "acec872f2e5bca19e5e9c871a5e288699d213b7be49c8f3e24f524feab22b55d"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/grounding-only",
+      "responseId": "resp_06cf773d9dd3127d016a67bf164d5c819ba1c4148db1c325ac",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 692,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 717
+      },
+      "estimatedUsd": 0.00421,
+      "latencyMs": 1393,
+      "rawOutputSha256": "acec872f2e5bca19e5e9c871a5e288699d213b7be49c8f3e24f524feab22b55d"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/png-only",
+      "responseId": "resp_056086696fd445d3016a67bf17ab6481999125311e8aa6aaaf",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 391
+      },
+      "estimatedUsd": 0.00253,
+      "latencyMs": 1347,
+      "rawOutputSha256": "4c5c937a88b9b0c005d960dd07cb16d392de1e5460996191434a65c360e49896"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/png-plus-grounding",
+      "responseId": "resp_00076e93b937e570016a67bf17aa08819891644740b7ad8c36",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 559,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 579
+      },
+      "estimatedUsd": 0.003395,
+      "latencyMs": 1216,
+      "rawOutputSha256": "958f838b0bece7c1fc0719d53f1eed638c12159b3846f67c669f4ef9bb62a74a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/grounding-only",
+      "responseId": "resp_06b92d2d62e33a89016a67bf190020819a8f9e896f4d9ad6fc",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 262,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 282
+      },
+      "estimatedUsd": 0.00191,
+      "latencyMs": 1957,
+      "rawOutputSha256": "958f838b0bece7c1fc0719d53f1eed638c12159b3846f67c669f4ef9bb62a74a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/png-only",
+      "responseId": "resp_02510a32e4daabfe016a67bf1900348198b200e7b43f33a62a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 389
+      },
+      "estimatedUsd": 0.00247,
+      "latencyMs": 1253,
+      "rawOutputSha256": "d0c9d91e3bc79bfd1d1618e809ea049706a9ad55d3f130f3bf759deeb094e3b0"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/png-plus-grounding",
+      "responseId": "resp_0e9204e305e97f17016a67bf1b02d8819a8363d4340b469b17",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 559,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 580
+      },
+      "estimatedUsd": 0.003425,
+      "latencyMs": 1561,
+      "rawOutputSha256": "d0c9d91e3bc79bfd1d1618e809ea049706a9ad55d3f130f3bf759deeb094e3b0"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/grounding-only",
+      "responseId": "resp_0e590abc1d15b29c016a67bf1b010481989ce0a27f08c7938b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 262,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 283
+      },
+      "estimatedUsd": 0.00194,
+      "latencyMs": 1355,
+      "rawOutputSha256": "d0c9d91e3bc79bfd1d1618e809ea049706a9ad55d3f130f3bf759deeb094e3b0"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/png-only",
+      "responseId": "resp_017324927dccd04b016a67bf1c8820819a991b507086c6861e",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 388
+      },
+      "estimatedUsd": 0.002465,
+      "latencyMs": 1263,
+      "rawOutputSha256": "a2d6d0ce8f82c61b1439f5bf86afefe2c0cbf01d2a861b7f2fbf241b225895ef"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/png-plus-grounding",
+      "responseId": "resp_020f27d58151e9b1016a67bf1c885c8198afb901fa1e0d2a70",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 884,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 902
+      },
+      "estimatedUsd": 0.00496,
+      "latencyMs": 1238,
+      "rawOutputSha256": "53eb447c645b500ce3cf4152992e02c96d721a682101397aa0e4098ddeaf69b3"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/grounding-only",
+      "responseId": "resp_03937a319ea96ecd016a67bf1de9548198ac2803900c6d59dd",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 587,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 605
+      },
+      "estimatedUsd": 0.003475,
+      "latencyMs": 1321,
+      "rawOutputSha256": "53eb447c645b500ce3cf4152992e02c96d721a682101397aa0e4098ddeaf69b3"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/png-only",
+      "responseId": "resp_0bb44e097daacaf5016a67bf1dcd40819aa29bfa1c9ca90944",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 37,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 404
+      },
+      "estimatedUsd": 0.002945,
+      "latencyMs": 1566,
+      "rawOutputSha256": "2bfb7c196b56118add45c999a8b1a373ab62b3ee5484180456540f3ed6d70ea6"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/png-plus-grounding",
+      "responseId": "resp_09fae44b92e01634016a67bf1f7330819ba70c58c5b1c2a747",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 883,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 904
+      },
+      "estimatedUsd": 0.005045,
+      "latencyMs": 1580,
+      "rawOutputSha256": "c0b02428c60234d33e4d0d347ad3c6741abe7369711de8be4112974e7faf44b4"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/grounding-only",
+      "responseId": "resp_0cafdc7b471f5c6a016a67bf1f62508199b4fcf60061ac8848",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 586,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 29,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 615
+      },
+      "estimatedUsd": 0.0038,
+      "latencyMs": 1270,
+      "rawOutputSha256": "1cb421d25f1253a7b416fd987485d12bab37315b8f43e57690d1a37b32ceec8b"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/png-only",
+      "responseId": "resp_0801154054d86714016a67bf20f83081998c68e79df53c7bc2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 370,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 30,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 400
+      },
+      "estimatedUsd": 0.00275,
+      "latencyMs": 1431,
+      "rawOutputSha256": "3f144cfcfdefea4b6f8ddebc5f92d86a0442c71e265b1c76be474a7f783e2f1e"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/png-plus-grounding",
+      "responseId": "resp_0f2a5cfbf2155ba0016a67bf20fd60819ba5eb777bcd5c7b0e",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 653,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 681
+      },
+      "estimatedUsd": 0.004105,
+      "latencyMs": 1248,
+      "rawOutputSha256": "9d816351d2918a194334f4b04295830b941c93a77d064e761547fdc126976a7e"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/grounding-only",
+      "responseId": "resp_0213b80703b95242016a67bf2269fc819bb842ec5028f11db6",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 356,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 384
+      },
+      "estimatedUsd": 0.00262,
+      "latencyMs": 1137,
+      "rawOutputSha256": "9d816351d2918a194334f4b04295830b941c93a77d064e761547fdc126976a7e"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/png-only",
+      "responseId": "resp_0cb935560f86cb2a016a67bf226a5c819ab78a3db7097fad14",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 389
+      },
+      "estimatedUsd": 0.002445,
+      "latencyMs": 1360,
+      "rawOutputSha256": "fb94eb55341fccee3343d470b0e548617f76c367224a8e446d7334279a2aefc7"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/png-plus-grounding",
+      "responseId": "resp_0ed28a3caaef1795016a67bf23bfc08199967769bbda85c665",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 652,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 671
+      },
+      "estimatedUsd": 0.00383,
+      "latencyMs": 1419,
+      "rawOutputSha256": "d8a2e6ff8d390abc669f65f8dfff4a5bb11cf40bb73ff7cae1650e6fcf834d1e"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/grounding-only",
+      "responseId": "resp_0bcbb8739847a930016a67bf23c5788199945447d9096c6402",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 355,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 374
+      },
+      "estimatedUsd": 0.002345,
+      "latencyMs": 1336,
+      "rawOutputSha256": "d8a2e6ff8d390abc669f65f8dfff4a5bb11cf40bb73ff7cae1650e6fcf834d1e"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "line-push",
+      "responseId": "resp_0ff724e143add078016a67bf253dd48198bc49bdd5b8938dda",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27328,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27325
+        },
+        "output_tokens": 71,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27399
+      },
+      "estimatedUsd": 0.0158075,
+      "latencyMs": 1896,
+      "rawOutputSha256": "7fd2b49f954eefe2e1aec19faeb185907657c217797615e13a9862c0b40f8c41"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "scatter-push",
+      "responseId": "resp_00128c7eae87a79b016a67bf253674819996a5bf1205b42a89",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27334,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27331
+        },
+        "output_tokens": 136,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27470
+      },
+      "estimatedUsd": 0.0177605,
+      "latencyMs": 3643,
+      "rawOutputSha256": "4d58e8ec0db5608540a0299115dba7b04ffe173335336b1e430fc5db1577d297"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "bubble-static",
+      "responseId": "resp_079626b8e639e511016a67bf28e19881989ff7e1dcaaefd5bd",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27279,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27276
+        },
+        "output_tokens": 152,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27431
+      },
+      "estimatedUsd": 0.018213,
+      "latencyMs": 3634,
+      "rawOutputSha256": "33e281fcd90211daef28fdbd29f851e958b370f164ff088d90c2da4212b5b01c"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "gauge-static",
+      "responseId": "resp_02e6bc7612e45856016a67bf28e300819ba43e77ba26c0e9aa",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27281,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27278
+        },
+        "output_tokens": 127,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27408
+      },
+      "estimatedUsd": 0.017464,
+      "latencyMs": 2459,
+      "rawOutputSha256": "e2ee95a90654f0ceda37b676718fb5eafe15681e4efdff0d1596948061ead803"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "symbol-map-static",
+      "responseId": "resp_093c59f7090b4086016a67bf2c830c819bbed9488297e6a7e8",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27294,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27291
+        },
+        "output_tokens": 167,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27461
+      },
+      "estimatedUsd": 0.0186705,
+      "latencyMs": 2871,
+      "rawOutputSha256": "e2056506eb20d5faf0503bb50f25612615cf1a4b6063b6341ad53365d168145d"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "galton-static",
+      "responseId": "resp_05f4ade30f77399b016a67bf2c94188199adfe5eb8e38635db",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27260,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27257
+        },
+        "output_tokens": 66,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27326
+      },
+      "estimatedUsd": 0.0156235,
+      "latencyMs": 1583,
+      "rawOutputSha256": "cca21da3fc818855f93324ed9a2a7b2081c559ba52cead21a388968b5acf2df3"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "unit-pile-push",
+      "responseId": "resp_0c0c2831323e4949016a67bf2f5c248198b52a3e1d9ff9739a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27325,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27322
+        },
+        "output_tokens": 59,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27384
+      },
+      "estimatedUsd": 0.015446,
+      "latencyMs": 1628,
+      "rawOutputSha256": "add8e8477487c817bce0146d71d94720611ed4029bb7f902fc3ab25e9c086bfd"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/png-only",
+      "responseId": "resp_074126ee0a9d8d17016a67bf2f5fa48199bca8ac8eb9d8fc76",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 374,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 400
+      },
+      "estimatedUsd": 0.001325,
+      "latencyMs": 1295,
+      "rawOutputSha256": "88936eda3d8e7302c9379539aefd611e4bf5cb0034befd12025a91ca79f7d558"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/png-plus-grounding",
+      "responseId": "resp_0a085c8a92ca4e66016a67bf30fe8c8199b7abfe989db0174f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 996,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1019
+      },
+      "estimatedUsd": 0.002835,
+      "latencyMs": 845,
+      "rawOutputSha256": "e8097e8a1fab95b2e2feeb201aa95be0437944be071961969ffda4f2e85982c3"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/grounding-only",
+      "responseId": "resp_0a44d921ecc2ebea016a67bf3350e08198b2e6f81fff6ed0a4",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 699,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 722
+      },
+      "estimatedUsd": 0.0020925,
+      "latencyMs": 4369,
+      "rawOutputSha256": "e8097e8a1fab95b2e2feeb201aa95be0437944be071961969ffda4f2e85982c3"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/png-only",
+      "responseId": "resp_052253ece224c3ab016a67bf3560a8819baa6d2c5f92129827",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.0011425,
+      "latencyMs": 899,
+      "rawOutputSha256": "139191d99676236271ad7f49706a7bb8bfd33648dc4662402beed84cde5397af"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/png-plus-grounding",
+      "responseId": "resp_0c92f31089433bc3016a67bf355b588199a89352e17fe06984",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 989,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1004
+      },
+      "estimatedUsd": 0.0026975,
+      "latencyMs": 978,
+      "rawOutputSha256": "139191d99676236271ad7f49706a7bb8bfd33648dc4662402beed84cde5397af"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/grounding-only",
+      "responseId": "resp_055e6bf82341d1a0016a67bf3656a88198b2957b75cfe23db1",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 692,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 708
+      },
+      "estimatedUsd": 0.00197,
+      "latencyMs": 678,
+      "rawOutputSha256": "0f68b1bf58d9ad62e6fef8b78533bc3c7a29a4abd9c7f842c105da58f45e9b86"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/png-only",
+      "responseId": "resp_084220e64cf7b4fc016a67bf36583c8198a0cd263b67a5ab0d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 383
+      },
+      "estimatedUsd": 0.0011325,
+      "latencyMs": 961,
+      "rawOutputSha256": "55db033120bd8822d113989369c02fa976a8ff0f3b45b9e618b894612552bbc8"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/png-plus-grounding",
+      "responseId": "resp_0bf25ee69c9741aa016a67bf3755d4819b930da881c7099471",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1104,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1052
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1125
+      },
+      "estimatedUsd": 0.000708,
+      "latencyMs": 911,
+      "rawOutputSha256": "75bbef3f8990abc3c267e7e306e775c6fc4f1435c7d19a2ddd81440f2019fa42"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/grounding-only",
+      "responseId": "resp_03110bda36e4d882016a67bf375068819a974c630bc2840c97",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 807,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 828
+      },
+      "estimatedUsd": 0.0023325,
+      "latencyMs": 757,
+      "rawOutputSha256": "75bbef3f8990abc3c267e7e306e775c6fc4f1435c7d19a2ddd81440f2019fa42"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/png-only",
+      "responseId": "resp_005f81b410bd6db0016a67bf383bdc819b8cd0fdca0aa92acb",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 372,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 39,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 411
+      },
+      "estimatedUsd": 0.001515,
+      "latencyMs": 1060,
+      "rawOutputSha256": "4084052faa9237bb6fbe709bf521e551d3914244ccf5eaeda351258a16898326"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/png-plus-grounding",
+      "responseId": "resp_084db5590590c77d016a67bf3840748199bb451ef4999b2004",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1107,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1055
+        },
+        "output_tokens": 32,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1139
+      },
+      "estimatedUsd": 0.00087375,
+      "latencyMs": 1076,
+      "rawOutputSha256": "ed69e9050a684d8b0ff00ac74bbe5906d06184a852d12f916618b08509949147"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/grounding-only",
+      "responseId": "resp_0c7aaac3da034679016a67bf39502481989403ecafe5741d03",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 810,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 38,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 848
+      },
+      "estimatedUsd": 0.002595,
+      "latencyMs": 1073,
+      "rawOutputSha256": "e63981d0befbc36e4435c42e226f7c8fae71ca7f61d19d7624b11bacbf660b10"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/png-only",
+      "responseId": "resp_0b56fa903289a229016a67bf394fb881998a1f68609998e9c4",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 370,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 398
+      },
+      "estimatedUsd": 0.001345,
+      "latencyMs": 1119,
+      "rawOutputSha256": "0b05d0eb4395a488dce2d7b8e62baab2dfc47543b9e97a61b751bcb7f6f9800b"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/png-plus-grounding",
+      "responseId": "resp_0d9574e9c4b7bcfe016a67bf3a75548198a90d8be03c36b650",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1077,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1025
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1104
+      },
+      "estimatedUsd": 0.00079125,
+      "latencyMs": 923,
+      "rawOutputSha256": "fc3ca6ad038166d9cd095fb6a28b9e7975ee049aa75d7f44ed92dcd8d3017bbb"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/grounding-only",
+      "responseId": "resp_016cb6e2ee82eb2e016a67bf3a83dc819bab0f8385fbc053ae",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 780,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 807
+      },
+      "estimatedUsd": 0.002355,
+      "latencyMs": 1224,
+      "rawOutputSha256": "75c93f9baa9f8f99cb56dd2ea9a5f4f0f4ee6101f2b9a5c2884204dbf7747148"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/png-only",
+      "responseId": "resp_0defe9708c151b42016a67bf3bb04c819b9fd74db6dac5f56f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.0011425,
+      "latencyMs": 1000,
+      "rawOutputSha256": "162c22f13b349170282a67ca830479c3ab9bdd5c246da8847e3eb9602ab5bad0"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/png-plus-grounding",
+      "responseId": "resp_0dd924c72eb10c23016a67bf3bb284819b858f652ea48e2e89",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1074,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1092
+      },
+      "estimatedUsd": 0.002955,
+      "latencyMs": 1196,
+      "rawOutputSha256": "3c3eeaf75b600452370e78a739d4d431ba57064c98163b837081438f2c78873e"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/grounding-only",
+      "responseId": "resp_0cd833d2b0939440016a67bf3ce65c819bba057f9d0dea1b48",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 777,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 795
+      },
+      "estimatedUsd": 0.0022125,
+      "latencyMs": 923,
+      "rawOutputSha256": "3c3eeaf75b600452370e78a739d4d431ba57064c98163b837081438f2c78873e"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/png-only",
+      "responseId": "resp_06bb574fc913a4c5016a67bf3ce3e8819a9b4ba822c2894a12",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 383
+      },
+      "estimatedUsd": 0.0011575,
+      "latencyMs": 1075,
+      "rawOutputSha256": "6e33072acb074d489d6d31794e02ed7c874e350e0c9d69eaa92ad1527129276a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/png-plus-grounding",
+      "responseId": "resp_0fa21b3a8541acf5016a67bf3df8b0819baf2f8384ccd8bc3e",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1061,
+        "input_tokens_details": {
+          "cache_write_tokens": 1058,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1078
+      },
+      "estimatedUsd": 0.00356875,
+      "latencyMs": 887,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/grounding-only",
+      "responseId": "resp_0eb5557050f79650016a67bf3dfa808199987d3993b65893b9",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 764,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 781
+      },
+      "estimatedUsd": 0.002165,
+      "latencyMs": 887,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/png-only",
+      "responseId": "resp_04d5282ca786697d016a67bf3ee048819baea52a3121ebaa67",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.00113,
+      "latencyMs": 1065,
+      "rawOutputSha256": "4fa4c8e85fcec46fdf1c47a79beae825dd532385e6e9270997f377d80b2ef697"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/png-plus-grounding",
+      "responseId": "resp_043933c72946581b016a67bf3edec4819882c6b2009d533c18",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1062,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1076
+      },
+      "estimatedUsd": 0.002865,
+      "latencyMs": 1057,
+      "rawOutputSha256": "4fa4c8e85fcec46fdf1c47a79beae825dd532385e6e9270997f377d80b2ef697"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/grounding-only",
+      "responseId": "resp_019f939c84187525016a67bf4051ec8198a642b2a3f159bff2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 765,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 779
+      },
+      "estimatedUsd": 0.0021225,
+      "latencyMs": 1527,
+      "rawOutputSha256": "4fa4c8e85fcec46fdf1c47a79beae825dd532385e6e9270997f377d80b2ef697"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/png-only",
+      "responseId": "resp_0a06020704a30f28016a67bf3ff0b88198a04abbd873c0a2fb",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.00113,
+      "latencyMs": 1740,
+      "rawOutputSha256": "71fb75bf5fcc0e8b3636105dc27bb7b2dca95e74307b096680d0dcc6671b3865"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/png-plus-grounding",
+      "responseId": "resp_04cd341ea4225cd5016a67bf41b810819b83860a396b7cc316",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 674,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 22,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 696
+      },
+      "estimatedUsd": 0.002015,
+      "latencyMs": 976,
+      "rawOutputSha256": "3522e67ce72bcb303645530a065d780fa303860630b3a4c07d6ca105c11d4811"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/grounding-only",
+      "responseId": "resp_0290f5a33eeef3a7016a67bf41af8081988f52496609985f23",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 377,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 22,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 399
+      },
+      "estimatedUsd": 0.0012725,
+      "latencyMs": 1010,
+      "rawOutputSha256": "3522e67ce72bcb303645530a065d780fa303860630b3a4c07d6ca105c11d4811"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/png-only",
+      "responseId": "resp_0826f782157f293b016a67bf42b3c8819bb4dcaf45654077b8",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 29,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 397
+      },
+      "estimatedUsd": 0.001355,
+      "latencyMs": 1109,
+      "rawOutputSha256": "057b6d31341eca604142496a9a3d287b6370628be7a00342f4385ee3e0f2f481"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/png-plus-grounding",
+      "responseId": "resp_0befe47c4409a924016a67bf42b4dc81998d785c0ca4806dd4",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 674,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 693
+      },
+      "estimatedUsd": 0.00197,
+      "latencyMs": 883,
+      "rawOutputSha256": "5fa497f3f8106c6f31d32a111886afafa13772704cab1817afa1cace02f54dd1"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/grounding-only",
+      "responseId": "resp_0808939afbd696d1016a67bf43dce081988a9821c5465c1b0f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 377,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 396
+      },
+      "estimatedUsd": 0.0012275,
+      "latencyMs": 1233,
+      "rawOutputSha256": "eb476af13299bba6bf03ef2fc81f45f3f2fe4c5eb0baf9e0779c718d69891938"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/png-only",
+      "responseId": "resp_0b95b2a4a161fc9d016a67bf43d454819b96dbb1d6c886b4d6",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 34,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 401
+      },
+      "estimatedUsd": 0.0014275,
+      "latencyMs": 1209,
+      "rawOutputSha256": "7239b036c9900a563a807c70ea6f2a8f3ad4c95196cf2b24c6c04f35e2bba7c1"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/png-plus-grounding",
+      "responseId": "resp_0e92f5c30dcfa46f016a67bf451038819aa1f4d43dcf675e3e",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 592,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 619
+      },
+      "estimatedUsd": 0.001885,
+      "latencyMs": 1136,
+      "rawOutputSha256": "37ef39016a208daaa941288e460ec85c9c1c7fded730f6768e232b9cb9bcf20a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/grounding-only",
+      "responseId": "resp_0c578606cf05e54e016a67bf450ff8819bba2019e5f7e97e5b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 295,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 322
+      },
+      "estimatedUsd": 0.0011425,
+      "latencyMs": 1068,
+      "rawOutputSha256": "37ef39016a208daaa941288e460ec85c9c1c7fded730f6768e232b9cb9bcf20a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/png-only",
+      "responseId": "resp_0f0a60f53f6546bf016a67bf4639e88199ba55aa067eb1f2a0",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 384
+      },
+      "estimatedUsd": 0.0011475,
+      "latencyMs": 1132,
+      "rawOutputSha256": "19e5b23bbfe73715f941bcbbe902eef9c924ba2d6e268de396d0e5037f8e731b"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/png-plus-grounding",
+      "responseId": "resp_030691d7d5d26cb7016a67bf464fc081998b09a1a318f6559e",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 594,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 612
+      },
+      "estimatedUsd": 0.001755,
+      "latencyMs": 1388,
+      "rawOutputSha256": "753f86bf4602c0d28bab029088ca178bb2f2e9959e70868f46aaf03ce6dd0d1a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/grounding-only",
+      "responseId": "resp_0750b1c241633148016a67bf47948081988482829d8d19b76f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 297,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 315
+      },
+      "estimatedUsd": 0.0010125,
+      "latencyMs": 811,
+      "rawOutputSha256": "753f86bf4602c0d28bab029088ca178bb2f2e9959e70868f46aaf03ce6dd0d1a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/png-only",
+      "responseId": "resp_0c73f9960d47cb18016a67bf479b388199960f661f4928a1c6",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 392
+      },
+      "estimatedUsd": 0.0012675,
+      "latencyMs": 1093,
+      "rawOutputSha256": "1e93c437f100f8ac32ef1fa3498cf8e8f4aba9d88b7db79118d5eb3f79061fd8"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/png-plus-grounding",
+      "responseId": "resp_0dec3bd9df75214c016a67bf49e7d8819bbfc99a1e98d40cb2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 991,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1014
+      },
+      "estimatedUsd": 0.0028225,
+      "latencyMs": 2216,
+      "rawOutputSha256": "aab71f12b87d6c2de6eecc920195891341458434364ed59a0fac4c731b189e69"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/grounding-only",
+      "responseId": "resp_04b238105c11bcbb016a67bf48bee08199955997f4410af1a5",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 694,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 717
+      },
+      "estimatedUsd": 0.00208,
+      "latencyMs": 1078,
+      "rawOutputSha256": "aab71f12b87d6c2de6eecc920195891341458434364ed59a0fac4c731b189e69"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/png-only",
+      "responseId": "resp_0e9beb76ce6c71b9016a67bf4aea4481989bb968fd86bde8d7",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 385
+      },
+      "estimatedUsd": 0.0011875,
+      "latencyMs": 1080,
+      "rawOutputSha256": "1760697eb73e58cde8936922849298389b6c393ec24bbd982ac84c7fb4682702"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/png-plus-grounding",
+      "responseId": "resp_09e62968abe36f71016a67bf4aebfc819ba28bdb51447429f6",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 989,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1007
+      },
+      "estimatedUsd": 0.0027425,
+      "latencyMs": 964,
+      "rawOutputSha256": "1760697eb73e58cde8936922849298389b6c393ec24bbd982ac84c7fb4682702"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/grounding-only",
+      "responseId": "resp_08213527eb16c1a3016a67bf4c00a8819b9b66f9d8abd1929d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 692,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 710
+      },
+      "estimatedUsd": 0.002,
+      "latencyMs": 1086,
+      "rawOutputSha256": "1760697eb73e58cde8936922849298389b6c393ec24bbd982ac84c7fb4682702"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/png-only",
+      "responseId": "resp_03655fe331eb4eeb016a67bf4c02d4819a9c058f194d3788d7",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 385
+      },
+      "estimatedUsd": 0.001175,
+      "latencyMs": 961,
+      "rawOutputSha256": "39cc280018911ae5f39f958f625651a5ae5c3c61278dc6050d9cc96abf787705"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/png-plus-grounding",
+      "responseId": "resp_0d1b6c453ecbb86f016a67bf4d1e708199aa0c00e8c7da4cab",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 559,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 573
+      },
+      "estimatedUsd": 0.0016075,
+      "latencyMs": 1115,
+      "rawOutputSha256": "986f12b5b317b7b5c4efe40dbcfb3837e62bd0f229c257de1267cdf25a85b447"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/grounding-only",
+      "responseId": "resp_096cf900c030c0f8016a67bf4d1c24819aaf91e1e4fa765c32",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 262,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 276
+      },
+      "estimatedUsd": 0.000865,
+      "latencyMs": 958,
+      "rawOutputSha256": "986f12b5b317b7b5c4efe40dbcfb3837e62bd0f229c257de1267cdf25a85b447"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/png-only",
+      "responseId": "resp_042b9a94c795cd26016a67bf4e3fa88198a078ef54d4a49abc",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.00113,
+      "latencyMs": 884,
+      "rawOutputSha256": "37b714bd7f3ab357c8ff281f4f6e8d73b3247e72873c581e56dbb7c45cbc6b28"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/png-plus-grounding",
+      "responseId": "resp_0e31851b438382d0016a67bf4e3d2881988ab8b4bc4873f80b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 559,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 573
+      },
+      "estimatedUsd": 0.0016075,
+      "latencyMs": 974,
+      "rawOutputSha256": "37b714bd7f3ab357c8ff281f4f6e8d73b3247e72873c581e56dbb7c45cbc6b28"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/grounding-only",
+      "responseId": "resp_055d0ce0684fcde2016a67bf4f37fc81988d51025e6985e6db",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 262,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 276
+      },
+      "estimatedUsd": 0.000865,
+      "latencyMs": 778,
+      "rawOutputSha256": "37b714bd7f3ab357c8ff281f4f6e8d73b3247e72873c581e56dbb7c45cbc6b28"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/png-only",
+      "responseId": "resp_099c1d7c78479242016a67bf4f38d0819b8cb8df876a213908",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 388
+      },
+      "estimatedUsd": 0.0012325,
+      "latencyMs": 1064,
+      "rawOutputSha256": "a572446d27d5e9bd19fbde2f3c0aa584d3f2badd982189efa690127ffbc3c0ae"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/png-plus-grounding",
+      "responseId": "resp_0ad4e36b7eb767a9016a67bf504f00819b9e87c5de4488f0f4",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 884,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 902
+      },
+      "estimatedUsd": 0.00248,
+      "latencyMs": 958,
+      "rawOutputSha256": "53eb447c645b500ce3cf4152992e02c96d721a682101397aa0e4098ddeaf69b3"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/grounding-only",
+      "responseId": "resp_0f0766b608adba53016a67bf5048f48198ba570246bfff759c",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 587,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 605
+      },
+      "estimatedUsd": 0.0017375,
+      "latencyMs": 840,
+      "rawOutputSha256": "53eb447c645b500ce3cf4152992e02c96d721a682101397aa0e4098ddeaf69b3"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/png-only",
+      "responseId": "resp_075d196a7a0583ef016a67bf5146a881989f85753c7da98e37",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 387
+      },
+      "estimatedUsd": 0.0012175,
+      "latencyMs": 1231,
+      "rawOutputSha256": "cf17b012dc1a3efb89f8ae93a4e31c4c9d6a6a584d34cc26df4cae3c9f52830a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/png-plus-grounding",
+      "responseId": "resp_08d5647ab91690dc016a67bf5141f0819aa2b2953e5bbd7b9b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 883,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 903
+      },
+      "estimatedUsd": 0.0025075,
+      "latencyMs": 1111,
+      "rawOutputSha256": "cf17b012dc1a3efb89f8ae93a4e31c4c9d6a6a584d34cc26df4cae3c9f52830a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/grounding-only",
+      "responseId": "resp_0895055513062e6d016a67bf527eb8819bac43345375be3e40",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 586,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 606
+      },
+      "estimatedUsd": 0.001765,
+      "latencyMs": 912,
+      "rawOutputSha256": "cf17b012dc1a3efb89f8ae93a4e31c4c9d6a6a584d34cc26df4cae3c9f52830a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/png-only",
+      "responseId": "resp_0bdbc6e6ba72f5c1016a67bf527c84819a83eba480d4233000",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 370,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 398
+      },
+      "estimatedUsd": 0.001345,
+      "latencyMs": 1120,
+      "rawOutputSha256": "3a4ba5d60d8bd29ccae6c247f919c3a54cd039327d6d2314fbf99de359416f50"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/png-plus-grounding",
+      "responseId": "resp_0bdb96374992f503016a67bf539d5c819b88149e964c3fdc86",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 653,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 681
+      },
+      "estimatedUsd": 0.0020525,
+      "latencyMs": 832,
+      "rawOutputSha256": "9d816351d2918a194334f4b04295830b941c93a77d064e761547fdc126976a7e"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/grounding-only",
+      "responseId": "resp_0dfa0178a5a7111f016a67bf53994c8199814e1fc98fe340fa",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 356,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 384
+      },
+      "estimatedUsd": 0.00131,
+      "latencyMs": 845,
+      "rawOutputSha256": "9d816351d2918a194334f4b04295830b941c93a77d064e761547fdc126976a7e"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/png-only",
+      "responseId": "resp_0ad49fbad70adc6a016a67bf54796c819bb17294c6e4321ba7",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 385
+      },
+      "estimatedUsd": 0.0011625,
+      "latencyMs": 1160,
+      "rawOutputSha256": "4fc5fa4367adf5d671f36647483094920a174a9e10a32538442aafeb73c0946c"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/png-plus-grounding",
+      "responseId": "resp_0446e72cb2344fa2016a67bf5479c881999a27097b40872b4b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 652,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 668
+      },
+      "estimatedUsd": 0.00187,
+      "latencyMs": 1181,
+      "rawOutputSha256": "4fc5fa4367adf5d671f36647483094920a174a9e10a32538442aafeb73c0946c"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/grounding-only",
+      "responseId": "resp_09a0bec763dae554016a67bf55cf2c819abe092e6d5ed671fb",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 355,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 376
+      },
+      "estimatedUsd": 0.0012025,
+      "latencyMs": 1429,
+      "rawOutputSha256": "0e563cdddb6681902792286c59978e32cfce61d418efb2cfdf083d2c67276ae5"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "line-push",
+      "responseId": "resp_00ef6f47184ee919016a67bf55a91c81998da414ca7aa82f09",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27328,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27325
+        },
+        "output_tokens": 99,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27427
+      },
+      "estimatedUsd": 0.00832375,
+      "latencyMs": 1555,
+      "rawOutputSha256": "6e257e58ab4714382eb299dff2f6952b7262d83fe9d1bdaf177a892b57135980"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "scatter-push",
+      "responseId": "resp_0e62aed47a1a735e016a67bf573ec48199bab2de37b1d73eb6",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27334,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27331
+        },
+        "output_tokens": 131,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27465
+      },
+      "estimatedUsd": 0.00880525,
+      "latencyMs": 1804,
+      "rawOutputSha256": "1e322895dbd9b68dfb33eb81f61c9ceb77f12bb906d76eff3470b25de33414ac"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "bubble-static",
+      "responseId": "resp_0a0724ba921189f3016a67bf57412c8198a75370793cb71a3a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27279,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27276
+        },
+        "output_tokens": 177,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27456
+      },
+      "estimatedUsd": 0.0094815,
+      "latencyMs": 2389,
+      "rawOutputSha256": "ad6bb8e6808f5175b6503a35aca24316c97e4fd9cf7c61de2e0fc77081528fa5"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "gauge-static",
+      "responseId": "resp_0a9281ec19ac7a2f016a67bf59b02081989350eecbaec0bee0",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27281,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27278
+        },
+        "output_tokens": 131,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27412
+      },
+      "estimatedUsd": 0.008792,
+      "latencyMs": 2019,
+      "rawOutputSha256": "580455e5d7856fb4dc7b14e01885d94c43ff64b6c447e1babee67a219d17219a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "symbol-map-static",
+      "responseId": "resp_0d0d6c74f2f961c4016a67bf59b5f4819886d7f09e14b614a3",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27294,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27291
+        },
+        "output_tokens": 164,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27458
+      },
+      "estimatedUsd": 0.00929025,
+      "latencyMs": 2506,
+      "rawOutputSha256": "dbab117f310c4763060d9400803cafb23e21318083065103c6f8914640819596"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "galton-static",
+      "responseId": "resp_0de8be496b19c521016a67bf5c2690819a926f6759c656508b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27260,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27257
+        },
+        "output_tokens": 66,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27326
+      },
+      "estimatedUsd": 0.00781175,
+      "latencyMs": 3080,
+      "rawOutputSha256": "f0be851cfd0530c242a17a7798513abfadb5254721a66eb4f91f7680770b97b4"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "unit-pile-push",
+      "responseId": "resp_09588fabf733b433016a67bf5c29908198be5d5abc2327b54b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27325,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27322
+        },
+        "output_tokens": 64,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27389
+      },
+      "estimatedUsd": 0.007798,
+      "latencyMs": 1236,
+      "rawOutputSha256": "8a53ec482310cbcd7c98b58fca71475bc9c5cd8ac356a1d5b8b64a6e1f670410"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/png-only",
+      "responseId": "resp_04d2c30b32710111016a67bf5f35d081988ecfc4c4d7956952",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 374,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 397
+      },
+      "estimatedUsd": 0.000512,
+      "latencyMs": 622,
+      "rawOutputSha256": "e8097e8a1fab95b2e2feeb201aa95be0437944be071961969ffda4f2e85982c3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/png-plus-grounding",
+      "responseId": "resp_09a6f35f7bdcea65016a67bf5f3eec819ab9af0c131dd1ada3",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 996,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1019
+      },
+      "estimatedUsd": 0.001134,
+      "latencyMs": 704,
+      "rawOutputSha256": "e8097e8a1fab95b2e2feeb201aa95be0437944be071961969ffda4f2e85982c3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/grounding-only",
+      "responseId": "resp_08679d56ba695fb5016a67bf5fed9c8198bccec8494db25143",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 699,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 722
+      },
+      "estimatedUsd": 0.000837,
+      "latencyMs": 595,
+      "rawOutputSha256": "e8097e8a1fab95b2e2feeb201aa95be0437944be071961969ffda4f2e85982c3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/png-only",
+      "responseId": "resp_096782cec8bec4b2016a67bf5fef20819bb6365d91e7b4b65c",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.000457,
+      "latencyMs": 738,
+      "rawOutputSha256": "139191d99676236271ad7f49706a7bb8bfd33648dc4662402beed84cde5397af"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/png-plus-grounding",
+      "responseId": "resp_0fb791353a673253016a67bf60bbc881998f379928b90c3d60",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 989,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1005
+      },
+      "estimatedUsd": 0.001085,
+      "latencyMs": 754,
+      "rawOutputSha256": "0f68b1bf58d9ad62e6fef8b78533bc3c7a29a4abd9c7f842c105da58f45e9b86"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/grounding-only",
+      "responseId": "resp_03361d7162290fea016a67bf60b4c4819abe3635267e25d782",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 692,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 707
+      },
+      "estimatedUsd": 0.000782,
+      "latencyMs": 581,
+      "rawOutputSha256": "139191d99676236271ad7f49706a7bb8bfd33648dc4662402beed84cde5397af"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/png-only",
+      "responseId": "resp_0e7178422c8cb677016a67bf61a86c819ab137610a5e7dc683",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 384
+      },
+      "estimatedUsd": 0.000459,
+      "latencyMs": 1216,
+      "rawOutputSha256": "e2fecba5f95c02aae27d4e5d5644998931ac2a3061172afd22ba353217703c8f"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/png-plus-grounding",
+      "responseId": "resp_0a2869c8ba16365a016a67bf61751481989cdd5107b158d053",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1104,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1052
+        },
+        "output_tokens": 22,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1126
+      },
+      "estimatedUsd": 0.0002892,
+      "latencyMs": 1041,
+      "rawOutputSha256": "c0892d79ea92a2086eab960e4fd2936f64052d2371dd77c2b79d14b64ca6dd7e"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/grounding-only",
+      "responseId": "resp_033b7d152a76cd4a016a67bf62aaa0819ba4f9954bf1b59a74",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 807,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 834
+      },
+      "estimatedUsd": 0.000969,
+      "latencyMs": 1002,
+      "rawOutputSha256": "5783723d21b573997f5fce50ff0f31b115da63de8ad395fd96c032f59e0f06d5"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/png-only",
+      "responseId": "resp_0c174b9fc7861aea016a67bf653120819b9c94876a93c16d40",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 372,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 39,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 411
+      },
+      "estimatedUsd": 0.000606,
+      "latencyMs": 4700,
+      "rawOutputSha256": "de972e53523d89cdae1c0a8509e442a3bbdfc8e3349e495b0218aab744c63fd4"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/png-plus-grounding",
+      "responseId": "resp_0c477b7487b299ce016a67bf676750819a96ea7d7601fad48f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1107,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1055
+        },
+        "output_tokens": 38,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1145
+      },
+      "estimatedUsd": 0.0003855,
+      "latencyMs": 1101,
+      "rawOutputSha256": "e63981d0befbc36e4435c42e226f7c8fae71ca7f61d19d7624b11bacbf660b10"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/grounding-only",
+      "responseId": "resp_00f11b12d1dd91f0016a67bf676244819ba0cd78e1ef382d64",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 810,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 39,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 849
+      },
+      "estimatedUsd": 0.001044,
+      "latencyMs": 1105,
+      "rawOutputSha256": "daf7ef1c98d9cbc68403e9230501fb1ffde6e00d528d575b1f8d5c76583f2f5f"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/png-only",
+      "responseId": "resp_04befbc54166da88016a67bf687ffc819aabcba6749d619364",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 370,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 30,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 400
+      },
+      "estimatedUsd": 0.00055,
+      "latencyMs": 917,
+      "rawOutputSha256": "6c352dbb0ddb8f530853ef2e9e67374002c6ef8b6d1c8dbc5345ef315dbd87dd"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/png-plus-grounding",
+      "responseId": "resp_0ea5fccef0a4f5e9016a67bf68829881998e2a9e13e410d908",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1077,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1025
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1105
+      },
+      "estimatedUsd": 0.0003225,
+      "latencyMs": 1107,
+      "rawOutputSha256": "f3f5d9ba945975d3f6c2276f3f6996a6ffcef411030dba19eeb47d91aaf7638a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/grounding-only",
+      "responseId": "resp_03a5fb29c17be29b016a67bf699878819b8006011d3740e464",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 780,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 808
+      },
+      "estimatedUsd": 0.000948,
+      "latencyMs": 699,
+      "rawOutputSha256": "f3f5d9ba945975d3f6c2276f3f6996a6ffcef411030dba19eeb47d91aaf7638a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/png-only",
+      "responseId": "resp_03ad2d5dd0028bd4016a67bf699c988199bddf9a6ffc1d366f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.000457,
+      "latencyMs": 637,
+      "rawOutputSha256": "162c22f13b349170282a67ca830479c3ab9bdd5c246da8847e3eb9602ab5bad0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/png-plus-grounding",
+      "responseId": "resp_0a829842569303f6016a67bf6a51ac8199a70e437ec1d3a43e",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1074,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1089
+      },
+      "estimatedUsd": 0.001164,
+      "latencyMs": 730,
+      "rawOutputSha256": "162c22f13b349170282a67ca830479c3ab9bdd5c246da8847e3eb9602ab5bad0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/grounding-only",
+      "responseId": "resp_0ea65657c7b87799016a67bf6a4d4c8198bf22e31e44aaf9f9",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 777,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 792
+      },
+      "estimatedUsd": 0.000867,
+      "latencyMs": 644,
+      "rawOutputSha256": "162c22f13b349170282a67ca830479c3ab9bdd5c246da8847e3eb9602ab5bad0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/png-only",
+      "responseId": "resp_08f73142ffab8c65016a67bf6b114c819aa05c30062ce8623a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 383
+      },
+      "estimatedUsd": 0.000463,
+      "latencyMs": 1077,
+      "rawOutputSha256": "6e33072acb074d489d6d31794e02ed7c874e350e0c9d69eaa92ad1527129276a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/png-plus-grounding",
+      "responseId": "resp_0e366a5438c108f3016a67bf6b0f0c819a9877b7444850edaf",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1061,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1078
+      },
+      "estimatedUsd": 0.001163,
+      "latencyMs": 787,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/grounding-only",
+      "responseId": "resp_07c160426891dddc016a67bf6c1e00819a9b788354b900c65e",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 764,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 781
+      },
+      "estimatedUsd": 0.000866,
+      "latencyMs": 725,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/png-only",
+      "responseId": "resp_0253d508ec0ff718016a67bf6c2600819a80d0df5d1cff2379",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 24,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 392
+      },
+      "estimatedUsd": 0.000512,
+      "latencyMs": 946,
+      "rawOutputSha256": "1c44bb694fa4d64adc6868677a74cb932ae6f3572416f8b3dfe2e899b516b23a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/png-plus-grounding",
+      "responseId": "resp_06baea74ffd32bf5016a67bf6d13788199af720141da1c2e57",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1062,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1083
+      },
+      "estimatedUsd": 0.001188,
+      "latencyMs": 713,
+      "rawOutputSha256": "7295c9d5d6f4ea0ac2c58c12d63f39e12cb5f365069d19d9781948860e8a936b"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/grounding-only",
+      "responseId": "resp_02f2d719cd8fe665016a67bf6d16ec819a89dd21a54e71299b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 765,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 786
+      },
+      "estimatedUsd": 0.000891,
+      "latencyMs": 731,
+      "rawOutputSha256": "7295c9d5d6f4ea0ac2c58c12d63f39e12cb5f365069d19d9781948860e8a936b"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/png-only",
+      "responseId": "resp_07a1155e3ca929c0016a67bf6ddef0819aae05781f7e85da87",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 387
+      },
+      "estimatedUsd": 0.000482,
+      "latencyMs": 903,
+      "rawOutputSha256": "8ce76a2cc90fce86f33856eb397f5d7929bd4c1c263686f1bda00c74e84c8b7f"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/png-plus-grounding",
+      "responseId": "resp_06f9fec3c8cd78f8016a67bf6dd2a8819a9d31766e3ec3e639",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 674,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 700
+      },
+      "estimatedUsd": 0.00083,
+      "latencyMs": 777,
+      "rawOutputSha256": "c713a07fb2312f9fff73682b5b1eb18f75e63d98269a17a174e5264d66821f61"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/grounding-only",
+      "responseId": "resp_097f0330ecda2bc7016a67bf6eb7a0819b91150a5888ff1497",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 377,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 403
+      },
+      "estimatedUsd": 0.000533,
+      "latencyMs": 810,
+      "rawOutputSha256": "c713a07fb2312f9fff73682b5b1eb18f75e63d98269a17a174e5264d66821f61"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/png-only",
+      "responseId": "resp_0b39e65cfdca5a8d016a67bf6eb9048198a3d6dfb973e433c0",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 29,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 397
+      },
+      "estimatedUsd": 0.000542,
+      "latencyMs": 866,
+      "rawOutputSha256": "17b7ef7fa005ffa1bc8f43ac1dd7c594464c0edcfe4795a88f8b26ff287fab63"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/png-plus-grounding",
+      "responseId": "resp_0d0cb513fcd7136e016a67bf6f98a4819882136cb3d38a85cf",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 674,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 693
+      },
+      "estimatedUsd": 0.000788,
+      "latencyMs": 671,
+      "rawOutputSha256": "eb476af13299bba6bf03ef2fc81f45f3f2fe4c5eb0baf9e0779c718d69891938"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/grounding-only",
+      "responseId": "resp_0cb10cc56403b6a3016a67bf6f97f48198b0698164777a17c9",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 377,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 396
+      },
+      "estimatedUsd": 0.000491,
+      "latencyMs": 798,
+      "rawOutputSha256": "5fa497f3f8106c6f31d32a111886afafa13772704cab1817afa1cace02f54dd1"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/png-only",
+      "responseId": "resp_05f56c3fd949fb0c016a67bf7067508199bb1b52c047fbc876",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 33,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 400
+      },
+      "estimatedUsd": 0.000565,
+      "latencyMs": 1143,
+      "rawOutputSha256": "b6c51e96df8e9e148c15fe12c110aea6b0571cc98f717662c3f8b67f573bd791"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/png-plus-grounding",
+      "responseId": "resp_0c053598ae3d6522016a67bf706b948198a8ba85a75822e21e",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 592,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 619
+      },
+      "estimatedUsd": 0.000754,
+      "latencyMs": 700,
+      "rawOutputSha256": "37ef39016a208daaa941288e460ec85c9c1c7fded730f6768e232b9cb9bcf20a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/grounding-only",
+      "responseId": "resp_0c9bf16e89cb19cc016a67bf718b1c819bb0e201792715a1ba",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 295,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 322
+      },
+      "estimatedUsd": 0.000457,
+      "latencyMs": 616,
+      "rawOutputSha256": "37ef39016a208daaa941288e460ec85c9c1c7fded730f6768e232b9cb9bcf20a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/png-only",
+      "responseId": "resp_0cd3fc2f524eb8c8016a67bf718b648199a990edbe398aabed",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 394
+      },
+      "estimatedUsd": 0.000519,
+      "latencyMs": 816,
+      "rawOutputSha256": "138c4a6fd13c9348524e7671ab23f8021a63d5409f413df8545c2787f8f94dc3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/png-plus-grounding",
+      "responseId": "resp_0bd90df587946a6d016a67bf7272c8819ab3bc8e4c7191eee9",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 594,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 617
+      },
+      "estimatedUsd": 0.000732,
+      "latencyMs": 851,
+      "rawOutputSha256": "5131dbca7f7ac689da5a1c1b58bd92d072b459dc8826474b2af4c5c203d401d3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/grounding-only",
+      "responseId": "resp_0c4fa9d7c7e6de03016a67bf728a98819bb5d43d3cc67aa0fa",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 297,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 320
+      },
+      "estimatedUsd": 0.000435,
+      "latencyMs": 1330,
+      "rawOutputSha256": "5131dbca7f7ac689da5a1c1b58bd92d072b459dc8826474b2af4c5c203d401d3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/png-only",
+      "responseId": "resp_0b110fa28fb2aee1016a67bf73b5a0819b9d167c1ba825e505",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 389
+      },
+      "estimatedUsd": 0.000489,
+      "latencyMs": 1112,
+      "rawOutputSha256": "51f69ab11ed275154b484b6933fadd14bb4eb722ce8ea58bd175466d785d3173"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/png-plus-grounding",
+      "responseId": "resp_036eb6dfef4856c4016a67bf73b7b4819bb5be7922ef43bd53",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 991,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 24,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1015
+      },
+      "estimatedUsd": 0.001135,
+      "latencyMs": 1182,
+      "rawOutputSha256": "0bfc9b74a5ecae617f08db8725ab35bc9ff9714491e643cb6710c85538500c7d"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/grounding-only",
+      "responseId": "resp_0cdd93331237d07e016a67bf74e19c819b998afff496d7ff47",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 694,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 24,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 718
+      },
+      "estimatedUsd": 0.000838,
+      "latencyMs": 608,
+      "rawOutputSha256": "0bfc9b74a5ecae617f08db8725ab35bc9ff9714491e643cb6710c85538500c7d"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/png-only",
+      "responseId": "resp_0e9bf643d5fc18b5016a67bf74e998819bba8d28af7c3b617a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.000457,
+      "latencyMs": 1161,
+      "rawOutputSha256": "57713459e8dc9d76ffd769bdeab211636e28289bd04732040ff557176131a96f"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/png-plus-grounding",
+      "responseId": "resp_0c9a18fcc4c0cd63016a67bf761454819bb2849b2bfe683e88",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 989,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1004
+      },
+      "estimatedUsd": 0.001079,
+      "latencyMs": 582,
+      "rawOutputSha256": "57713459e8dc9d76ffd769bdeab211636e28289bd04732040ff557176131a96f"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/grounding-only",
+      "responseId": "resp_080cd85b33fba650016a67bf7611a48198942dfea556684f2a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 692,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 710
+      },
+      "estimatedUsd": 0.0008,
+      "latencyMs": 753,
+      "rawOutputSha256": "1760697eb73e58cde8936922849298389b6c393ec24bbd982ac84c7fb4682702"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/png-only",
+      "responseId": "resp_0a5e42b6df7f48e0016a67bf76f8bc819ba7e571a93690ded0",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 386
+      },
+      "estimatedUsd": 0.000476,
+      "latencyMs": 1303,
+      "rawOutputSha256": "82a0f474f977156cdc2cb38abe0992d98f14cdf2d136c4f820cbf9bcc61373b1"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/png-plus-grounding",
+      "responseId": "resp_0bacb18819097bfc016a67bf76df148199be3958c230ccfb6d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 559,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 580
+      },
+      "estimatedUsd": 0.000685,
+      "latencyMs": 1011,
+      "rawOutputSha256": "65587e2cd4ae5cab44b4f6f934a0efc040ed33c3a514fb306ebae4207950e5e8"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/grounding-only",
+      "responseId": "resp_0fda35604f9029cb016a67bf783304819a8900172b30b4da68",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 262,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 282
+      },
+      "estimatedUsd": 0.000382,
+      "latencyMs": 1236,
+      "rawOutputSha256": "958f838b0bece7c1fc0719d53f1eed638c12159b3846f67c669f4ef9bb62a74a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/png-only",
+      "responseId": "resp_02c800f8f5881528016a67bf78264c8198809b92de5b0e4c33",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 389
+      },
+      "estimatedUsd": 0.000494,
+      "latencyMs": 834,
+      "rawOutputSha256": "d0c9d91e3bc79bfd1d1618e809ea049706a9ad55d3f130f3bf759deeb094e3b0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/png-plus-grounding",
+      "responseId": "resp_0d64b894ae7dfcfa016a67bf7962388199bae02139b1ae3a5a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 559,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 582
+      },
+      "estimatedUsd": 0.000697,
+      "latencyMs": 947,
+      "rawOutputSha256": "9242d26cbe64ba1e16898ad431b3dc65bbacdac88bd38a0a1aa8a45832381946"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/grounding-only",
+      "responseId": "resp_0567596cf618a09f016a67bf796084819886f5a70b2f3b55b8",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 262,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 283
+      },
+      "estimatedUsd": 0.000388,
+      "latencyMs": 794,
+      "rawOutputSha256": "d0c9d91e3bc79bfd1d1618e809ea049706a9ad55d3f130f3bf759deeb094e3b0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/png-only",
+      "responseId": "resp_092397a42200dc4c016a67bf7a57748198b921719f9ae30ba7",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.000457,
+      "latencyMs": 932,
+      "rawOutputSha256": "efcba35e14732082a5e790b33de76bcff89418a04ba5a31c7d7002bbfac85d52"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/png-plus-grounding",
+      "responseId": "resp_03d45a8af3d51b2d016a67bf7a5c3481988cf85f48780fb6d9",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 884,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 902
+      },
+      "estimatedUsd": 0.000992,
+      "latencyMs": 959,
+      "rawOutputSha256": "53eb447c645b500ce3cf4152992e02c96d721a682101397aa0e4098ddeaf69b3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/grounding-only",
+      "responseId": "resp_06f3969856f53018016a67bf7b4b7c819aa34716d2ac104f4b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 587,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 605
+      },
+      "estimatedUsd": 0.000695,
+      "latencyMs": 710,
+      "rawOutputSha256": "53eb447c645b500ce3cf4152992e02c96d721a682101397aa0e4098ddeaf69b3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/png-only",
+      "responseId": "resp_0144ca316b1e75ad016a67bf7b59cc8198b43f345a42870e4a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 386
+      },
+      "estimatedUsd": 0.000481,
+      "latencyMs": 894,
+      "rawOutputSha256": "478c4a4c7da2c142e990688964e6e5a62235d8a57a9d8a3ca4e79a7d2b29c929"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/png-plus-grounding",
+      "responseId": "resp_07053cf530abbec0016a67bf7c3a4c819881ea3985aa872f9c",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 883,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 904
+      },
+      "estimatedUsd": 0.001009,
+      "latencyMs": 883,
+      "rawOutputSha256": "c0b02428c60234d33e4d0d347ad3c6741abe7369711de8be4112974e7faf44b4"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/grounding-only",
+      "responseId": "resp_0cfc0de5e7be4347016a67bf7c3af8819a9f54ff5fb20217c1",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 586,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 607
+      },
+      "estimatedUsd": 0.000712,
+      "latencyMs": 974,
+      "rawOutputSha256": "c0b02428c60234d33e4d0d347ad3c6741abe7369711de8be4112974e7faf44b4"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/png-only",
+      "responseId": "resp_089ded6e7b64a823016a67bf7d30c0819abdd3d437c26b4057",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 370,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 398
+      },
+      "estimatedUsd": 0.000538,
+      "latencyMs": 1142,
+      "rawOutputSha256": "3a4ba5d60d8bd29ccae6c247f919c3a54cd039327d6d2314fbf99de359416f50"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/png-plus-grounding",
+      "responseId": "resp_016aaf09d3f7a906016a67bf7d343c8199ae4ae6342a3e3d0e",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 653,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 681
+      },
+      "estimatedUsd": 0.000821,
+      "latencyMs": 999,
+      "rawOutputSha256": "9d816351d2918a194334f4b04295830b941c93a77d064e761547fdc126976a7e"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/grounding-only",
+      "responseId": "resp_0c14e05f5a8564f6016a67bf7e595881989270dd9f09423d5c",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 356,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 384
+      },
+      "estimatedUsd": 0.000524,
+      "latencyMs": 982,
+      "rawOutputSha256": "9d816351d2918a194334f4b04295830b941c93a77d064e761547fdc126976a7e"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/png-only",
+      "responseId": "resp_053341dd91769ace016a67bf7e53448198961b90580016c1ec",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 389
+      },
+      "estimatedUsd": 0.000489,
+      "latencyMs": 1283,
+      "rawOutputSha256": "470007836843b9cfe29cfc694eb3c9eb62911e9d635043fa066bad769948d069"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/png-plus-grounding",
+      "responseId": "resp_0173c49bc3df8b78016a67bf7fa2f8819b9f62ed9602cada5a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 652,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 668
+      },
+      "estimatedUsd": 0.000748,
+      "latencyMs": 890,
+      "rawOutputSha256": "4fc5fa4367adf5d671f36647483094920a174a9e10a32538442aafeb73c0946c"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/grounding-only",
+      "responseId": "resp_0bfe0b156b25b05a016a67bf7fa1308198beb8f603cc415418",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 355,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 375
+      },
+      "estimatedUsd": 0.000475,
+      "latencyMs": 823,
+      "rawOutputSha256": "fb94eb55341fccee3343d470b0e548617f76c367224a8e446d7334279a2aefc7"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "line-push",
+      "responseId": "resp_00c0b430128409d4016a67bf808d6c819abb54b0308aeaf7db",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27328,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27325
+        },
+        "output_tokens": 81,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27409
+      },
+      "estimatedUsd": 0.0032215,
+      "latencyMs": 1403,
+      "rawOutputSha256": "e8553d6ce8393ed59002b752cf08b251b03c0ec6843d0c94c1eeebd80979e16f"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "scatter-push",
+      "responseId": "resp_0f04539990d3b0fb016a67bf808e58819aa84e284e3f1c0768",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27334,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27331
+        },
+        "output_tokens": 140,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27474
+      },
+      "estimatedUsd": 0.0035761,
+      "latencyMs": 1770,
+      "rawOutputSha256": "0592f943d7c32ddfbdc7dba770b07fffde7b49133ed6101b22db6c5421b3da4f"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "bubble-static",
+      "responseId": "resp_0c4e4def1785da18016a67bf82556c8199bcdd12b7cfc5888d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27279,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27276
+        },
+        "output_tokens": 127,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27406
+      },
+      "estimatedUsd": 0.0034926,
+      "latencyMs": 1608,
+      "rawOutputSha256": "19d26b70da99222ddc3e79327d029c9c2eea2f5669c9dc86a12e7b668a0253ce"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "gauge-static",
+      "responseId": "resp_0d714957d246fb37016a67bf8253fc81999a468ea6fdc25190",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27281,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27278
+        },
+        "output_tokens": 90,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27371
+      },
+      "estimatedUsd": 0.0032708,
+      "latencyMs": 1260,
+      "rawOutputSha256": "02739cc93a57217400b1df8ec32957027d8b0abe3dc29e5896762633f956ff57"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "symbol-map-static",
+      "responseId": "resp_0fe0dceb80cfb395016a67bf83ee848199bb43f5ed67e0769f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27294,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27291
+        },
+        "output_tokens": 102,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27396
+      },
+      "estimatedUsd": 0.0033441,
+      "latencyMs": 1249,
+      "rawOutputSha256": "ad24651613cc32bb1d985f9b720d7709628bca2d19c4ffee0240543e78d278c4"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "galton-static",
+      "responseId": "resp_0dbef061e9177fb4016a67bf83f2308199afe41d5944881ce1",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27260,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27257
+        },
+        "output_tokens": 62,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27322
+      },
+      "estimatedUsd": 0.0031007,
+      "latencyMs": 1131,
+      "rawOutputSha256": "991ca987758a3d66c30df0a4dd882b4635a3245c7651c0c03e15f5cc707ab4a9"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "unit-pile-push",
+      "responseId": "resp_0e508705f3d46413016a67bf8534e8819892b737ac1ba6fe09",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27325,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27322
+        },
+        "output_tokens": 125,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27450
+      },
+      "estimatedUsd": 0.0034852,
+      "latencyMs": 2908,
+      "rawOutputSha256": "2bf05605b03998a82ef6fe4990c35825b72ffa55af86832cfbc24535fb6e11ab"
+    }
+  ],
+  "estimatedUsd": 0.55227145,
+  "requestCount": 201
+}

--- a/evals/reports/openai-follow-up/trial-c/gpt-5.6-luna/first-try-results.json
+++ b/evals/reports/openai-follow-up/trial-c/gpt-5.6-luna/first-try-results.json
@@ -1,0 +1,222 @@
+{
+  "metadata": {
+    "modelId": "gpt-5.6-luna",
+    "clientVersion": "semiotic-openai-eval/1",
+    "fixtureRevision": "semiotic-first-try-2026-07-27-contracts",
+    "date": "2026-07-27",
+    "context": [
+      "CLAUDE.md",
+      "docs/public/llms.txt"
+    ]
+  },
+  "results": [
+    {
+      "fixtureId": "line-push",
+      "proposal": {
+        "component": "LineChart",
+        "props": {
+          "data": [
+            {
+              "week": 1,
+              "users": 120
+            },
+            {
+              "week": 2,
+              "users": 138
+            },
+            {
+              "week": 3,
+              "users": 151
+            }
+          ],
+          "xAccessor": "week",
+          "yAccessor": "users",
+          "title": "Active users by week",
+          "description": "A line chart showing active users across weeks.",
+          "accessibleTable": true
+        }
+      },
+      "rawOutputSha256": "adbe5eb93fae232f64471799bd44d15f845a3d8fc6eacd5a2e895d29d9861732"
+    },
+    {
+      "fixtureId": "scatter-push",
+      "proposal": {
+        "component": "Scatterplot",
+        "props": {
+          "data": [
+            {
+              "payload_kb": 8,
+              "response_ms": 42
+            },
+            {
+              "payload_kb": 16,
+              "response_ms": 61
+            },
+            {
+              "payload_kb": 32,
+              "response_ms": 95
+            }
+          ],
+          "xAccessor": "payload_kb",
+          "yAccessor": "response_ms",
+          "title": "Response time vs. payload size",
+          "description": "Scatterplot of response time in milliseconds against payload size in kilobytes.",
+          "summary": "Response time increases as payload size increases. The chart supports additional observations through its ref-based push API.",
+          "accessibleTable": true,
+          "width": 600,
+          "height": 400,
+          "enableHover": true,
+          "tooltip": true
+        }
+      },
+      "rawOutputSha256": "6c7b1155823d8695afef1d6670766e7a45e27571ebd32ba406f748f1a12a6967"
+    },
+    {
+      "fixtureId": "bubble-static",
+      "proposal": {
+        "component": "BubbleChart",
+        "props": {
+          "data": [
+            {
+              "company": "A",
+              "growth": 12,
+              "retention": 86,
+              "customers": 300
+            },
+            {
+              "company": "B",
+              "growth": 18,
+              "retention": 78,
+              "customers": 180
+            },
+            {
+              "company": "C",
+              "growth": 9,
+              "retention": 92,
+              "customers": 420
+            }
+          ],
+          "xAccessor": "growth",
+          "yAccessor": "retention",
+          "sizeBy": "customers",
+          "colorBy": "company",
+          "title": "Company growth, retention, and customer base",
+          "description": "Companies compared by growth and retention, with bubble size representing customers.",
+          "summary": "Company B has the highest growth, company C has the highest retention and largest customer base.",
+          "accessibleTable": true,
+          "width": 600,
+          "height": 400,
+          "showLegend": true,
+          "tooltip": true
+        }
+      },
+      "rawOutputSha256": "987c556777683533d03c2cbad1fa5a278f8bfe68c20becc86f266089abfd2b3b"
+    },
+    {
+      "fixtureId": "gauge-static",
+      "proposal": {
+        "component": "BigNumber",
+        "props": {
+          "value": 97,
+          "label": "SLA attainment",
+          "format": "number",
+          "suffix": "%",
+          "target": {
+            "value": 99,
+            "label": "target",
+            "format": "number",
+            "suffix": "%"
+          },
+          "description": "Current SLA attainment is 97 percent against a 99 percent target.",
+          "summary": "SLA attainment is 2 percentage points below the 99 percent target.",
+          "accessibleTable": false
+        }
+      },
+      "rawOutputSha256": "2768e6be348aa0e12f3b0ab8f1ec948ad657495c4a37937d3b97e3f90dbf63a4"
+    },
+    {
+      "fixtureId": "symbol-map-static",
+      "proposal": {
+        "component": "ProportionalSymbolMap",
+        "props": {
+          "points": [
+            {
+              "city": "A",
+              "longitude": -122.4,
+              "latitude": 37.8,
+              "incidents": 18
+            },
+            {
+              "city": "B",
+              "longitude": -74,
+              "latitude": 40.7,
+              "incidents": 31
+            },
+            {
+              "city": "C",
+              "longitude": -87.6,
+              "latitude": 41.9,
+              "incidents": 12
+            }
+          ],
+          "xAccessor": "longitude",
+          "yAccessor": "latitude",
+          "sizeBy": "incidents"
+        }
+      },
+      "rawOutputSha256": "ad24651613cc32bb1d985f9b720d7709628bca2d19c4ffee0240543e78d278c4"
+    },
+    {
+      "fixtureId": "galton-static",
+      "proposal": {
+        "component": "GaltonBoardChart",
+        "props": {
+          "data": [
+            {
+              "id": "a",
+              "value": 1
+            },
+            {
+              "id": "b",
+              "value": 2
+            },
+            {
+              "id": "c",
+              "value": 3
+            },
+            {
+              "id": "d",
+              "value": 4
+            }
+          ],
+          "valueAccessor": "value",
+          "seed": 42
+        }
+      },
+      "rawOutputSha256": "991ca987758a3d66c30df0a4dd882b4635a3245c7651c0c03e15f5cc707ab4a9"
+    },
+    {
+      "fixtureId": "unit-pile-push",
+      "proposal": {
+        "component": "UnitPileChart",
+        "props": {
+          "data": [
+            {
+              "id": "a",
+              "team": "Blue",
+              "value": 3
+            },
+            {
+              "id": "b",
+              "team": "Green",
+              "value": 2
+            }
+          ],
+          "categoryAccessor": "team",
+          "valueAccessor": "value"
+        }
+      },
+      "rawOutputSha256": "7d33cb5803e4071baf8ff03cd5e7bcf04d43b41e1b104dd5d94091b2341df0e9"
+    }
+  ]
+}

--- a/evals/reports/openai-follow-up/trial-c/gpt-5.6-luna/grounding-results.json
+++ b/evals/reports/openai-follow-up/trial-c/gpt-5.6-luna/grounding-results.json
@@ -1,0 +1,310 @@
+{
+  "metadata": {
+    "modelId": "gpt-5.6-luna",
+    "clientVersion": "semiotic-openai-eval/1",
+    "fixtureRevision": "semiotic-grounding-2026-07-27-source-facts",
+    "date": "2026-07-27"
+  },
+  "responses": [
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "png-only",
+      "answer": "North has the highest revenue, with a value of 18."
+    },
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "png-plus-grounding",
+      "answer": "North has the highest revenue, at 18."
+    },
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "grounding-only",
+      "answer": "North has the highest revenue, with a value of 18."
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "png-only",
+      "answer": "3 regions"
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "png-plus-grounding",
+      "answer": "3 regions"
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "grounding-only",
+      "answer": "3 regions"
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "png-only",
+      "answer": "165"
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "png-plus-grounding",
+      "answer": "The last observed user count is 165."
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "grounding-only",
+      "answer": "The last observed user count is 165 users (week 4)."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "png-only",
+      "answer": "The series rises across the observed weeks."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "png-plus-grounding",
+      "answer": "The series rises across the observed weeks, increasing from 120 users in week 1 to 165 users in week 4."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "grounding-only",
+      "answer": "The series rises across the observed weeks, increasing from 120 users in week 1 to 165 users in week 4."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "png-only",
+      "answer": "Cannot determine—the chart does not provide explicit payload and latency labels or values."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Latency 142 is paired with the largest payload, 64."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "grounding-only",
+      "answer": "The largest payload is 64, paired with a latency of 142."
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "png-only",
+      "answer": "4 observations"
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "png-plus-grounding",
+      "answer": "4 observations"
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "grounding-only",
+      "answer": "4 observations"
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "png-only",
+      "answer": "API and Worker"
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "png-plus-grounding",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "grounding-only",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "png-only",
+      "answer": "The largest observed latency is 160 ms (API)."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "png-plus-grounding",
+      "answer": "The largest observed latency is 160."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "grounding-only",
+      "answer": "The largest observed latency is 160."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "png-only",
+      "answer": "Success receives the largest flow."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Success receives the largest flow, with a value of 78."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "grounding-only",
+      "answer": "Success receives the largest flow, with a value of 78."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "png-only",
+      "answer": "Cannot determine from the chart."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "png-plus-grounding",
+      "answer": "7 requests flow to Failure."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "grounding-only",
+      "answer": "Failure: 7 requests."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "png-only",
+      "answer": "Cannot determine from the chart; it shows Logs, Images, and Backups but provides no values or visibly distinct category sizes."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Images is the largest storage category, with a value of 48."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "grounding-only",
+      "answer": "Images is the largest storage category, with a value of 48."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "png-only",
+      "answer": "Cannot determine the value assigned to Backups from the chart."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "png-plus-grounding",
+      "answer": "Backups is assigned a value of 20."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "grounding-only",
+      "answer": "Backups is assigned a value of 20."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "png-only",
+      "answer": "B, with 31 incidents."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "png-plus-grounding",
+      "answer": "City B, with 31 incidents."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "grounding-only",
+      "answer": "City B has the most incidents, with 31."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "png-only",
+      "answer": "3 locations"
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "png-plus-grounding",
+      "answer": "3 locations"
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "grounding-only",
+      "answer": "3 locations"
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "png-only",
+      "answer": "97 out of 100"
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "png-plus-grounding",
+      "answer": "The current gauge value is 97."
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "grounding-only",
+      "answer": "Current gauge value: 97"
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "png-only",
+      "answer": "The gauge maximum is 100."
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "png-plus-grounding",
+      "answer": "The maximum defining the gauge scale is 100."
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "grounding-only",
+      "answer": "The gauge scale maximum is 100."
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "png-only",
+      "answer": "200 purchases"
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "png-plus-grounding",
+      "answer": "Purchases: 200"
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "grounding-only",
+      "answer": "Purchases: 200"
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "png-only",
+      "answer": "Visits; Trials; Purchases"
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "png-plus-grounding",
+      "answer": "Visits, Trials, and Purchases."
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "grounding-only",
+      "answer": "Visits, Trials, Purchases"
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "png-only",
+      "answer": "Smallest observed value: cannot determine. Largest observed value: cannot determine."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "png-plus-grounding",
+      "answer": "Smallest observed value: 1. Largest observed value: 4."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "grounding-only",
+      "answer": "Smallest observed value: 1. Largest observed value: 4."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "png-only",
+      "answer": "Cannot determine; the chart does not show a board or observed-row count."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "png-plus-grounding",
+      "answer": "4 observed rows"
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "grounding-only",
+      "answer": "4 observed rows"
+    }
+  ]
+}

--- a/evals/reports/openai-follow-up/trial-c/gpt-5.6-sol/first-try-results.json
+++ b/evals/reports/openai-follow-up/trial-c/gpt-5.6-sol/first-try-results.json
@@ -1,0 +1,230 @@
+{
+  "metadata": {
+    "modelId": "gpt-5.6-sol",
+    "clientVersion": "semiotic-openai-eval/1",
+    "fixtureRevision": "semiotic-first-try-2026-07-27-contracts",
+    "date": "2026-07-27",
+    "context": [
+      "CLAUDE.md",
+      "docs/public/llms.txt"
+    ]
+  },
+  "results": [
+    {
+      "fixtureId": "line-push",
+      "proposal": {
+        "component": "LineChart",
+        "props": {
+          "data": [
+            {
+              "week": 1,
+              "users": 120
+            },
+            {
+              "week": 2,
+              "users": 138
+            },
+            {
+              "week": 3,
+              "users": 151
+            }
+          ],
+          "xAccessor": "week",
+          "yAccessor": "users"
+        }
+      },
+      "rawOutputSha256": "aa45c1a9bc81bd075f976a9d2867a77f43a85fada4beb75edd44baa972fad878"
+    },
+    {
+      "fixtureId": "scatter-push",
+      "proposal": {
+        "component": "Scatterplot",
+        "props": {
+          "data": [
+            {
+              "payload_kb": 8,
+              "response_ms": 42
+            },
+            {
+              "payload_kb": 16,
+              "response_ms": 61
+            },
+            {
+              "payload_kb": 32,
+              "response_ms": 95
+            }
+          ],
+          "xAccessor": "payload_kb",
+          "yAccessor": "response_ms",
+          "xLabel": "Payload size (KB)",
+          "yLabel": "Response time (ms)",
+          "title": "Response Time by Payload Size",
+          "description": "Scatterplot of response time in milliseconds against payload size in kilobytes.",
+          "summary": "Response time rises as payload size increases. The chart supports adding future observations through its ref-based push API.",
+          "accessibleTable": true,
+          "enableHover": true
+        }
+      },
+      "rawOutputSha256": "32a7c58796e0249e71c8382e2c342d55b0ce1b504df188af095c0bed4b3e155a"
+    },
+    {
+      "fixtureId": "bubble-static",
+      "proposal": {
+        "component": "BubbleChart",
+        "props": {
+          "data": [
+            {
+              "company": "A",
+              "growth": 12,
+              "retention": 86,
+              "customers": 300
+            },
+            {
+              "company": "B",
+              "growth": 18,
+              "retention": 78,
+              "customers": 180
+            },
+            {
+              "company": "C",
+              "growth": 9,
+              "retention": 92,
+              "customers": 420
+            }
+          ],
+          "xAccessor": "growth",
+          "yAccessor": "retention",
+          "sizeBy": "customers",
+          "colorBy": "company",
+          "title": "Company Growth and Retention",
+          "description": "Bubble chart comparing company growth and retention, with bubble size representing customers.",
+          "summary": "Company C has the highest retention and largest customer base, while Company B has the highest growth and lowest retention.",
+          "showLegend": true,
+          "showGrid": true,
+          "tooltip": true,
+          "accessibleTable": true
+        }
+      },
+      "rawOutputSha256": "be7d77551e68201bf41cb20131b61f3473e82e3aed66f223ed47f137efd285c2"
+    },
+    {
+      "fixtureId": "gauge-static",
+      "proposal": {
+        "component": "BigNumber",
+        "props": {
+          "value": 97,
+          "label": "SLA attainment",
+          "format": "number",
+          "suffix": "%",
+          "target": {
+            "value": 99,
+            "label": "target",
+            "format": "number"
+          },
+          "thresholds": [
+            {
+              "at": 0,
+              "level": "warning",
+              "color": "#c7952f",
+              "label": "Below target"
+            },
+            {
+              "at": 99,
+              "level": "success",
+              "color": "#2a8f68",
+              "label": "Meets target"
+            }
+          ],
+          "description": "Current SLA attainment is 97 percent against a target of 99 percent.",
+          "summary": "SLA attainment is 2 percentage points below target."
+        }
+      },
+      "rawOutputSha256": "3fa4c48ad1be59cbf31e4e3733b940b425c8e7a6f24c9d2de292af67732e82b8"
+    },
+    {
+      "fixtureId": "symbol-map-static",
+      "proposal": {
+        "component": "ProportionalSymbolMap",
+        "props": {
+          "points": [
+            {
+              "city": "A",
+              "longitude": -122.4,
+              "latitude": 37.8,
+              "incidents": 18
+            },
+            {
+              "city": "B",
+              "longitude": -74,
+              "latitude": 40.7,
+              "incidents": 31
+            },
+            {
+              "city": "C",
+              "longitude": -87.6,
+              "latitude": 41.9,
+              "incidents": 12
+            }
+          ],
+          "xAccessor": "longitude",
+          "yAccessor": "latitude",
+          "sizeBy": "incidents"
+        }
+      },
+      "rawOutputSha256": "ad24651613cc32bb1d985f9b720d7709628bca2d19c4ffee0240543e78d278c4"
+    },
+    {
+      "fixtureId": "galton-static",
+      "proposal": {
+        "component": "GaltonBoardChart",
+        "props": {
+          "data": [
+            {
+              "id": "a",
+              "value": 1
+            },
+            {
+              "id": "b",
+              "value": 2
+            },
+            {
+              "id": "c",
+              "value": 3
+            },
+            {
+              "id": "d",
+              "value": 4
+            }
+          ],
+          "valueAccessor": "value",
+          "seed": 42
+        }
+      },
+      "rawOutputSha256": "991ca987758a3d66c30df0a4dd882b4635a3245c7651c0c03e15f5cc707ab4a9"
+    },
+    {
+      "fixtureId": "unit-pile-push",
+      "proposal": {
+        "component": "UnitPileChart",
+        "props": {
+          "data": [
+            {
+              "id": "a",
+              "team": "Blue",
+              "value": 3
+            },
+            {
+              "id": "b",
+              "team": "Green",
+              "value": 2
+            }
+          ],
+          "categoryAccessor": "team",
+          "valueAccessor": "value",
+          "unitValue": 1
+        }
+      },
+      "rawOutputSha256": "add8e8477487c817bce0146d71d94720611ed4029bb7f902fc3ab25e9c086bfd"
+    }
+  ]
+}

--- a/evals/reports/openai-follow-up/trial-c/gpt-5.6-sol/grounding-results.json
+++ b/evals/reports/openai-follow-up/trial-c/gpt-5.6-sol/grounding-results.json
@@ -1,0 +1,310 @@
+{
+  "metadata": {
+    "modelId": "gpt-5.6-sol",
+    "clientVersion": "semiotic-openai-eval/1",
+    "fixtureRevision": "semiotic-grounding-2026-07-27-source-facts",
+    "date": "2026-07-27"
+  },
+  "responses": [
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "png-only",
+      "answer": "North has the highest revenue, with a value of 18."
+    },
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "png-plus-grounding",
+      "answer": "North has the highest revenue, at 18."
+    },
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "grounding-only",
+      "answer": "North has the highest revenue, at 18."
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "png-only",
+      "answer": "3 regions: North, South, and West."
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "png-plus-grounding",
+      "answer": "3 regions: North, South, and West."
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "grounding-only",
+      "answer": "3 regions: North, South, and West."
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "png-only",
+      "answer": "The last observed user count is 165 weekly active users."
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "png-plus-grounding",
+      "answer": "Week 4: 165 users."
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "grounding-only",
+      "answer": "Week 4: 165 users."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "png-only",
+      "answer": "The series rises across the observed weeks, increasing from 120 weekly active users in week 1 to 165 in week 4."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "png-plus-grounding",
+      "answer": "The series rises across the observed weeks: users increase from 120 in week 1 to 138 in week 2, 151 in week 3, and 165 in week 4."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "grounding-only",
+      "answer": "The series rises across the observed weeks: Week 1: 120 users; Week 2: 138; Week 3: 151; Week 4: 165."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "png-only",
+      "answer": "The largest payload (about 64) is paired with a latency of about 142."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "png-plus-grounding",
+      "answer": "The largest payload is 64, paired with a latency of 142."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "grounding-only",
+      "answer": "The largest payload, 64, is paired with a latency of 142."
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "png-only",
+      "answer": "4 observations are plotted."
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "png-plus-grounding",
+      "answer": "4 observations."
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "grounding-only",
+      "answer": "4 observations are plotted."
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "png-only",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "png-plus-grounding",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "grounding-only",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "png-only",
+      "answer": "API: 160 ms"
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "png-plus-grounding",
+      "answer": "The largest observed latency is 160 (API)."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "grounding-only",
+      "answer": "The largest observed latency is 160."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "png-only",
+      "answer": "Success receives the largest flow."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Success receives the largest flow: 78."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "grounding-only",
+      "answer": "Success receives the largest flow: 78."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "png-only",
+      "answer": "Failure: 15 requests"
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "png-plus-grounding",
+      "answer": "Failure: 7 requests."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "grounding-only",
+      "answer": "Failure: 7 requests."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "png-only",
+      "answer": "Cannot determine; the chart labels Images, Logs, and Backups but does not show distinguishable category sizes or values."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Images is the largest storage category, with a value of 48."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "grounding-only",
+      "answer": "Images — 48."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "png-only",
+      "answer": "Backups: cannot determine."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "png-plus-grounding",
+      "answer": "Backups: 20"
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "grounding-only",
+      "answer": "Backups: 20"
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "png-only",
+      "answer": "B — 31 incidents."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "png-plus-grounding",
+      "answer": "City B has the most incidents, with 31."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "grounding-only",
+      "answer": "City B has the most incidents: 31."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "png-only",
+      "answer": "3 locations are plotted."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "png-plus-grounding",
+      "answer": "3 locations are plotted: A, B, and C."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "grounding-only",
+      "answer": "3 locations are plotted: A, B, and C."
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "png-only",
+      "answer": "Current gauge value: 97 of 100."
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "png-plus-grounding",
+      "answer": "Current gauge value: 97."
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "grounding-only",
+      "answer": "Current gauge value: 97."
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "png-only",
+      "answer": "The gauge scale maximum is 100."
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "png-plus-grounding",
+      "answer": "The gauge scale maximum is 100."
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "grounding-only",
+      "answer": "The gauge scale maximum is 100."
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "png-only",
+      "answer": "Purchases: 200 (20%)."
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "png-plus-grounding",
+      "answer": "Purchases: 200"
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "grounding-only",
+      "answer": "Purchases: 200"
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "png-only",
+      "answer": "Visits — 1.0K; Trials — 400 (40%); Purchases — 200 (20%)."
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "png-plus-grounding",
+      "answer": "Visits, Trials, and Purchases."
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "grounding-only",
+      "answer": "Visits (1,000), Trials (400), and Purchases (200)."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "png-only",
+      "answer": "Cannot determine: the chart shows four points but provides no axis labels or values."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "png-plus-grounding",
+      "answer": "Smallest observed value: 1. Largest observed value: 4."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "grounding-only",
+      "answer": "Smallest observed value: 1. Largest observed value: 4."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "png-only",
+      "answer": "4 observed rows feed the board."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "png-plus-grounding",
+      "answer": "Observed rows: 4."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "grounding-only",
+      "answer": "Observed rows: 4."
+    }
+  ]
+}

--- a/evals/reports/openai-follow-up/trial-c/gpt-5.6-terra/first-try-results.json
+++ b/evals/reports/openai-follow-up/trial-c/gpt-5.6-terra/first-try-results.json
@@ -1,0 +1,246 @@
+{
+  "metadata": {
+    "modelId": "gpt-5.6-terra",
+    "clientVersion": "semiotic-openai-eval/1",
+    "fixtureRevision": "semiotic-first-try-2026-07-27-contracts",
+    "date": "2026-07-27",
+    "context": [
+      "CLAUDE.md",
+      "docs/public/llms.txt"
+    ]
+  },
+  "results": [
+    {
+      "fixtureId": "line-push",
+      "proposal": {
+        "component": "LineChart",
+        "props": {
+          "data": [
+            {
+              "week": 1,
+              "users": 120
+            },
+            {
+              "week": 2,
+              "users": 138
+            },
+            {
+              "week": 3,
+              "users": 151
+            }
+          ],
+          "xAccessor": "week",
+          "yAccessor": "users",
+          "title": "Active Users by Week",
+          "description": "Line chart showing active users by week.",
+          "xLabel": "Week",
+          "yLabel": "Active users"
+        }
+      },
+      "rawOutputSha256": "786981104cf3b91e2866d01fb06293e7bb45b3470013a291dac861d62b125765"
+    },
+    {
+      "fixtureId": "scatter-push",
+      "proposal": {
+        "component": "Scatterplot",
+        "props": {
+          "data": [
+            {
+              "payload_kb": 8,
+              "response_ms": 42
+            },
+            {
+              "payload_kb": 16,
+              "response_ms": 61
+            },
+            {
+              "payload_kb": 32,
+              "response_ms": 95
+            }
+          ],
+          "xAccessor": "payload_kb",
+          "yAccessor": "response_ms",
+          "xLabel": "Payload size (KB)",
+          "yLabel": "Response time (ms)",
+          "title": "Response Time by Payload Size",
+          "description": "Scatterplot of response time in milliseconds against payload size in kilobytes.",
+          "summary": "Response time increases as payload size grows. The chart supports ref-based push observations in React usage."
+        }
+      },
+      "rawOutputSha256": "8010f12d1d64b6e273b5fcdbfa8701594f1cb2a74a45a7895f471d303b3ccf9a"
+    },
+    {
+      "fixtureId": "bubble-static",
+      "proposal": {
+        "component": "BubbleChart",
+        "props": {
+          "data": [
+            {
+              "company": "A",
+              "growth": 12,
+              "retention": 86,
+              "customers": 300
+            },
+            {
+              "company": "B",
+              "growth": 18,
+              "retention": 78,
+              "customers": 180
+            },
+            {
+              "company": "C",
+              "growth": 9,
+              "retention": 92,
+              "customers": 420
+            }
+          ],
+          "xAccessor": "growth",
+          "yAccessor": "retention",
+          "sizeBy": "customers",
+          "colorBy": "company",
+          "sizeRange": [
+            8,
+            36
+          ],
+          "xLabel": "Growth",
+          "yLabel": "Retention",
+          "title": "Growth and retention by company",
+          "description": "Bubble chart comparing company growth and retention, with bubble size representing customers.",
+          "summary": "Company C has the highest retention and customer count; Company B has the highest growth.",
+          "showLegend": true,
+          "tooltip": true
+        }
+      },
+      "rawOutputSha256": "bdb8918a77637bfee9925185cb3593ae9da9897c4e1c59ad658eb94c954a8db1"
+    },
+    {
+      "fixtureId": "gauge-static",
+      "proposal": {
+        "component": "BigNumber",
+        "props": {
+          "value": 97,
+          "label": "SLA attainment",
+          "format": "number",
+          "suffix": "%",
+          "target": {
+            "value": 99,
+            "label": "target",
+            "format": "number"
+          },
+          "description": "Current SLA attainment is 97 percent against a 99 percent target.",
+          "summary": "SLA attainment is 2 percentage points below the 99 percent target.",
+          "thresholds": [
+            {
+              "at": 0,
+              "level": "warning",
+              "color": "#c7952f",
+              "label": "Below target"
+            },
+            {
+              "at": 99,
+              "level": "success",
+              "color": "#2a8f68",
+              "label": "Meets target"
+            }
+          ]
+        }
+      },
+      "rawOutputSha256": "8bbc6df250a3bb8c8b77a5cb43d7ed7ffe8d9c643c50771dc630fc1a0f299761"
+    },
+    {
+      "fixtureId": "symbol-map-static",
+      "proposal": {
+        "component": "ProportionalSymbolMap",
+        "props": {
+          "points": [
+            {
+              "city": "A",
+              "longitude": -122.4,
+              "latitude": 37.8,
+              "incidents": 18
+            },
+            {
+              "city": "B",
+              "longitude": -74,
+              "latitude": 40.7,
+              "incidents": 31
+            },
+            {
+              "city": "C",
+              "longitude": -87.6,
+              "latitude": 41.9,
+              "incidents": 12
+            }
+          ],
+          "xAccessor": "longitude",
+          "yAccessor": "latitude",
+          "sizeBy": "incidents",
+          "sizeRange": [
+            5,
+            40
+          ],
+          "title": "Incident counts by location",
+          "description": "Proportional symbols map incident counts at three longitude and latitude locations."
+        }
+      },
+      "rawOutputSha256": "bbcf200ddb0c2b5aed955bffc6fa4987d24c2d7c4ec287de449154d9b97a932f"
+    },
+    {
+      "fixtureId": "galton-static",
+      "proposal": {
+        "component": "GaltonBoardChart",
+        "props": {
+          "data": [
+            {
+              "id": "a",
+              "value": 1
+            },
+            {
+              "id": "b",
+              "value": 2
+            },
+            {
+              "id": "c",
+              "value": 3
+            },
+            {
+              "id": "d",
+              "value": 4
+            }
+          ],
+          "valueAccessor": "value",
+          "bins": 4,
+          "seed": 42
+        }
+      },
+      "rawOutputSha256": "a2cd7e9c911fc269d1fce6f111b3f6c27dc9f3059a7186b6645992cf9933b087"
+    },
+    {
+      "fixtureId": "unit-pile-push",
+      "proposal": {
+        "component": "UnitPileChart",
+        "props": {
+          "data": [
+            {
+              "id": "a",
+              "team": "Blue",
+              "value": 3
+            },
+            {
+              "id": "b",
+              "team": "Green",
+              "value": 2
+            }
+          ],
+          "categoryAccessor": "team",
+          "valueAccessor": "value",
+          "colorBy": "team",
+          "unitValue": 1,
+          "title": "Queued work by team",
+          "description": "A unit pile showing queued work units by team."
+        }
+      },
+      "rawOutputSha256": "d78b44ed1f4c5deb2845017a1f7a2d1eab3014bc5674f080be98cc6952ad1a1d"
+    }
+  ]
+}

--- a/evals/reports/openai-follow-up/trial-c/gpt-5.6-terra/grounding-results.json
+++ b/evals/reports/openai-follow-up/trial-c/gpt-5.6-terra/grounding-results.json
@@ -1,0 +1,310 @@
+{
+  "metadata": {
+    "modelId": "gpt-5.6-terra",
+    "clientVersion": "semiotic-openai-eval/1",
+    "fixtureRevision": "semiotic-grounding-2026-07-27-source-facts",
+    "date": "2026-07-27"
+  },
+  "responses": [
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "png-only",
+      "answer": "North has the highest revenue, with a value of 18."
+    },
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "png-plus-grounding",
+      "answer": "North has the highest revenue, at 18."
+    },
+    {
+      "fixtureId": "regional-revenue/highest",
+      "condition": "grounding-only",
+      "answer": "North has the highest revenue: 18."
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "png-only",
+      "answer": "3 regions"
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "png-plus-grounding",
+      "answer": "3 regions"
+    },
+    {
+      "fixtureId": "regional-revenue/count",
+      "condition": "grounding-only",
+      "answer": "3 regions."
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "png-only",
+      "answer": "165"
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "png-plus-grounding",
+      "answer": "Last observed user count (week 4): 165."
+    },
+    {
+      "fixtureId": "weekly-users/last",
+      "condition": "grounding-only",
+      "answer": "Week 4: 165 users."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "png-only",
+      "answer": "The series rises across the observed weeks, increasing from about 120 at week 1 to about 165 at week 4."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "png-plus-grounding",
+      "answer": "The series rises across the observed weeks, from 120 users in week 1 to 165 users in week 4."
+    },
+    {
+      "fixtureId": "weekly-users/direction",
+      "condition": "grounding-only",
+      "answer": "The series rises across the observed weeks, from 120 users in week 1 to 165 users in week 4."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "png-only",
+      "answer": "The largest payload is 142, paired with a latency of 64."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Payload 64 is paired with a latency of 142."
+    },
+    {
+      "fixtureId": "payload-latency/largest",
+      "condition": "grounding-only",
+      "answer": "At the largest payload (64), the latency is 142."
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "png-only",
+      "answer": "4 observations"
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "png-plus-grounding",
+      "answer": "4 observations."
+    },
+    {
+      "fixtureId": "payload-latency/count",
+      "condition": "grounding-only",
+      "answer": "4 observations are plotted."
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "png-only",
+      "answer": "API and Worker"
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "png-plus-grounding",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/categories",
+      "condition": "grounding-only",
+      "answer": "API and Worker."
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "png-only",
+      "answer": "160"
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "png-plus-grounding",
+      "answer": "160"
+    },
+    {
+      "fixtureId": "service-latency/max",
+      "condition": "grounding-only",
+      "answer": "160"
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "png-only",
+      "answer": "Success receives the largest flow."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Success receives the largest flow: 78."
+    },
+    {
+      "fixtureId": "request-flow/largest",
+      "condition": "grounding-only",
+      "answer": "Success receives the largest flow: 78."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "png-only",
+      "answer": "Cannot determine: the chart shows flow to Failure but provides no numeric value."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "png-plus-grounding",
+      "answer": "Failure: 7 requests."
+    },
+    {
+      "fixtureId": "request-flow/failed",
+      "condition": "grounding-only",
+      "answer": "Failure: 7 requests."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "png-only",
+      "answer": "Cannot determine; the chart labels Images, Logs, and Backups but provides no sizes or values."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "png-plus-grounding",
+      "answer": "Images is the largest storage category, with a value of 48."
+    },
+    {
+      "fixtureId": "storage-tree/largest",
+      "condition": "grounding-only",
+      "answer": "Images is the largest storage category, with a value of 48."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "png-only",
+      "answer": "cannot determine"
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "png-plus-grounding",
+      "answer": "Backups: 20."
+    },
+    {
+      "fixtureId": "storage-tree/backups",
+      "condition": "grounding-only",
+      "answer": "Backups: 20"
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "png-only",
+      "answer": "B has the most incidents, with 31."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "png-plus-grounding",
+      "answer": "City B has the most incidents: 31."
+    },
+    {
+      "fixtureId": "incident-map/largest",
+      "condition": "grounding-only",
+      "answer": "City B has the most incidents: 31."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "png-only",
+      "answer": "3 locations"
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "png-plus-grounding",
+      "answer": "3 locations are plotted: A, B, and C."
+    },
+    {
+      "fixtureId": "incident-map/count",
+      "condition": "grounding-only",
+      "answer": "3 locations are plotted."
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "png-only",
+      "answer": "97 of 100"
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "png-plus-grounding",
+      "answer": "Current gauge value: 97."
+    },
+    {
+      "fixtureId": "sla-gauge/value",
+      "condition": "grounding-only",
+      "answer": "97"
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "png-only",
+      "answer": "100"
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "png-plus-grounding",
+      "answer": "The gauge scale maximum is 100."
+    },
+    {
+      "fixtureId": "sla-gauge/maximum",
+      "condition": "grounding-only",
+      "answer": "100"
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "png-only",
+      "answer": "Purchases: 200 (20%)"
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "png-plus-grounding",
+      "answer": "Purchases: 200"
+    },
+    {
+      "fixtureId": "conversion-funnel/purchases",
+      "condition": "grounding-only",
+      "answer": "Purchases: 200"
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "png-only",
+      "answer": "Visits; Trials; Purchases."
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "png-plus-grounding",
+      "answer": "Visits; Trials; Purchases."
+    },
+    {
+      "fixtureId": "conversion-funnel/stages",
+      "condition": "grounding-only",
+      "answer": "Visits; Trials; Purchases."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "png-only",
+      "answer": "Smallest observed value: cannot determine. Largest observed value: cannot determine."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "png-plus-grounding",
+      "answer": "Smallest observed value: 1. Largest observed value: 4."
+    },
+    {
+      "fixtureId": "galton-values/range",
+      "condition": "grounding-only",
+      "answer": "Smallest observed value: 1. Largest observed value: 4."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "png-only",
+      "answer": "4 observed rows"
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "png-plus-grounding",
+      "answer": "4 observed rows feed the board."
+    },
+    {
+      "fixtureId": "galton-values/count",
+      "condition": "grounding-only",
+      "answer": "4 observed source rows."
+    }
+  ]
+}

--- a/evals/reports/openai-follow-up/trial-c/run-manifest.json
+++ b/evals/reports/openai-follow-up/trial-c/run-manifest.json
@@ -1,0 +1,4684 @@
+{
+  "version": 1,
+  "clientVersion": "semiotic-openai-eval/1",
+  "priceRevision": "openai-standard-2026-07-26",
+  "models": [
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna"
+  ],
+  "trialId": "postmerge-c",
+  "filters": {
+    "suites": [
+      "first-try",
+      "grounding"
+    ],
+    "firstTryFixtureIds": [
+      "gauge-static",
+      "line-push",
+      "scatter-push",
+      "bubble-static",
+      "symbol-map-static",
+      "unit-pile-push",
+      "galton-static"
+    ],
+    "groundingFixtureIds": [
+      "regional-revenue/highest",
+      "regional-revenue/count",
+      "weekly-users/last",
+      "weekly-users/direction",
+      "payload-latency/largest",
+      "payload-latency/count",
+      "service-latency/categories",
+      "service-latency/max",
+      "request-flow/largest",
+      "request-flow/failed",
+      "storage-tree/largest",
+      "storage-tree/backups",
+      "incident-map/largest",
+      "incident-map/count",
+      "sla-gauge/value",
+      "sla-gauge/maximum",
+      "conversion-funnel/purchases",
+      "conversion-funnel/stages",
+      "galton-values/range",
+      "galton-values/count"
+    ],
+    "groundingConditions": [
+      "png-only",
+      "png-plus-grounding",
+      "grounding-only"
+    ]
+  },
+  "projectFingerprint": "cc3c2be40c1f",
+  "maxUsd": 3,
+  "startedAt": "2026-07-27T20:30:39.896Z",
+  "completedAt": "2026-07-27T20:33:03.991Z",
+  "requests": [
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/png-only",
+      "responseId": "resp_09314a28c5cc5a67016a67bff049188199bb1e737b6bc73880",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 374,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 400
+      },
+      "estimatedUsd": 0.00265,
+      "latencyMs": 1246,
+      "rawOutputSha256": "88936eda3d8e7302c9379539aefd611e4bf5cb0034befd12025a91ca79f7d558"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/png-plus-grounding",
+      "responseId": "resp_07213eeef96d389b016a67bff0479481999f1d62853843c4d4",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 996,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1019
+      },
+      "estimatedUsd": 0.00567,
+      "latencyMs": 1400,
+      "rawOutputSha256": "e8097e8a1fab95b2e2feeb201aa95be0437944be071961969ffda4f2e85982c3"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/grounding-only",
+      "responseId": "resp_0d388df30d5214e6016a67bff175048198acfa6429ae3f1490",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 699,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 722
+      },
+      "estimatedUsd": 0.004185,
+      "latencyMs": 1033,
+      "rawOutputSha256": "e8097e8a1fab95b2e2feeb201aa95be0437944be071961969ffda4f2e85982c3"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/png-only",
+      "responseId": "resp_016a8428162a4c4f016a67bff170ac819aa2004b29067b3fb2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 390
+      },
+      "estimatedUsd": 0.002525,
+      "latencyMs": 1330,
+      "rawOutputSha256": "fcf77bad7f39f8de12bdace68707c9dfe9fe18f3becb676f96507e56f2df4998"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/png-plus-grounding",
+      "responseId": "resp_0f6459c9e03bc3e8016a67bff2cacc819b96887c503368b08c",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 989,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1012
+      },
+      "estimatedUsd": 0.005635,
+      "latencyMs": 1129,
+      "rawOutputSha256": "fcf77bad7f39f8de12bdace68707c9dfe9fe18f3becb676f96507e56f2df4998"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/grounding-only",
+      "responseId": "resp_0c53a547f43408b0016a67bff2c8e4819aa9cfdb6c5c325197",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 692,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 715
+      },
+      "estimatedUsd": 0.00415,
+      "latencyMs": 1129,
+      "rawOutputSha256": "fcf77bad7f39f8de12bdace68707c9dfe9fe18f3becb676f96507e56f2df4998"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/png-only",
+      "responseId": "resp_0ad4e348d2747deb016a67bff3eae08198ad68c082477e7992",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 394
+      },
+      "estimatedUsd": 0.002595,
+      "latencyMs": 1322,
+      "rawOutputSha256": "9536770b6303f30b4aa672f0fa53b7ededfd2d33a82308857ce927bae9c1c046"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/png-plus-grounding",
+      "responseId": "resp_0bc5b780b6fdc2fb016a67bff3f12c8198915c589f9bbeda33",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1104,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1052
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1125
+      },
+      "estimatedUsd": 0.001416,
+      "latencyMs": 1322,
+      "rawOutputSha256": "75bbef3f8990abc3c267e7e306e775c6fc4f1435c7d19a2ddd81440f2019fa42"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/grounding-only",
+      "responseId": "resp_0411e50d354f1469016a67bff53f18819b84ebf253364bd952",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 807,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 828
+      },
+      "estimatedUsd": 0.004665,
+      "latencyMs": 1532,
+      "rawOutputSha256": "75bbef3f8990abc3c267e7e306e775c6fc4f1435c7d19a2ddd81440f2019fa42"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/png-only",
+      "responseId": "resp_055270174b352250016a67bff62e18819aa2fc88d6ed5e222d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 372,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 40,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 412
+      },
+      "estimatedUsd": 0.00306,
+      "latencyMs": 3143,
+      "rawOutputSha256": "df8e06b22606f8264705d33456ce6c2afb82debed3c5cb06111b724f87183a55"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/png-plus-grounding",
+      "responseId": "resp_0f3d23bd64728a9f016a67bff8634081989f0022da5efd926f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1107,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1055
+        },
+        "output_tokens": 53,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1160
+      },
+      "estimatedUsd": 0.0023775,
+      "latencyMs": 1219,
+      "rawOutputSha256": "dc6ff18716d3119e48dc01facb5e5f7fed2f924bcaf29fcc6de080024d70daf5"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/grounding-only",
+      "responseId": "resp_031863aa189fa570016a67bff8675081998761ae8e9f064077",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 810,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 50,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 860
+      },
+      "estimatedUsd": 0.00555,
+      "latencyMs": 1348,
+      "rawOutputSha256": "d8917ada7c49000fe18c35b6058cd7ea308f22f202f6e50b07b6d9fa662ff6c2"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/png-only",
+      "responseId": "resp_008842df35d51147016a67bff9c008819b9b7f0ebf82beccb2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 370,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 31,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 401
+      },
+      "estimatedUsd": 0.00278,
+      "latencyMs": 1486,
+      "rawOutputSha256": "4ef001742783e392a91dc9b905524c98c5fb1b2ca48dc0d699528861d0b090ee"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/png-plus-grounding",
+      "responseId": "resp_0979be714641e9d1016a67bff9bf10819ab6b2964f6fa5a62f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1077,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1025
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1105
+      },
+      "estimatedUsd": 0.0016125,
+      "latencyMs": 1155,
+      "rawOutputSha256": "f3f5d9ba945975d3f6c2276f3f6996a6ffcef411030dba19eeb47d91aaf7638a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/grounding-only",
+      "responseId": "resp_003b8c50b5b7981b016a67bffb3adc8198aa6a29626f415fc4",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 780,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 29,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 809
+      },
+      "estimatedUsd": 0.00477,
+      "latencyMs": 1089,
+      "rawOutputSha256": "9a1005e108b19746a0b86f4bd0e4506d16407fa1d53e89dd7146c87139af541b"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/png-only",
+      "responseId": "resp_0ff75357a889fcb3016a67bffb449c819a8c35d8f87195031d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 385
+      },
+      "estimatedUsd": 0.002375,
+      "latencyMs": 1318,
+      "rawOutputSha256": "3c3eeaf75b600452370e78a739d4d431ba57064c98163b837081438f2c78873e"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/png-plus-grounding",
+      "responseId": "resp_01e861dd8167c93c016a67bffc94788198949d8c3b79498fe2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1074,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1090
+      },
+      "estimatedUsd": 0.00585,
+      "latencyMs": 1060,
+      "rawOutputSha256": "db581f71a007f0598a6a640bbb858c5256af62c79ae61f149233e32cce4679b2"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/grounding-only",
+      "responseId": "resp_06a1c683b98210fd016a67bffc924c819bad6366cb06116e56",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 777,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 795
+      },
+      "estimatedUsd": 0.004425,
+      "latencyMs": 1210,
+      "rawOutputSha256": "3c3eeaf75b600452370e78a739d4d431ba57064c98163b837081438f2c78873e"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/png-only",
+      "responseId": "resp_08f0924fd6c157d0016a67bffdc6788199baf877111f9949b4",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 384
+      },
+      "estimatedUsd": 0.002345,
+      "latencyMs": 1024,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/png-plus-grounding",
+      "responseId": "resp_0be04e2773b40d42016a67bffdc8b88199a0eeeb5c46f26e37",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1061,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1078
+      },
+      "estimatedUsd": 0.005815,
+      "latencyMs": 1136,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/grounding-only",
+      "responseId": "resp_067a75c5050fc30e016a67bffeedcc819ba7568ba77fa53992",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 764,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 781
+      },
+      "estimatedUsd": 0.00433,
+      "latencyMs": 968,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/png-only",
+      "responseId": "resp_0e547f396ffadff7016a67bffeeb20819893dd1ad2b56fd7fc",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 386
+      },
+      "estimatedUsd": 0.00238,
+      "latencyMs": 1333,
+      "rawOutputSha256": "f8f750f56ebc43275799f8e643b1c8822d80567510e5f3e64506baeae185c346"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/png-plus-grounding",
+      "responseId": "resp_06698ad3f4ada233016a67c000407c819884999ee897383516",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1062,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1085
+      },
+      "estimatedUsd": 0.006,
+      "latencyMs": 995,
+      "rawOutputSha256": "ba97bc35a0fe8024bdb3f8cd46fd4da5885a4226ed918e9c15bb482ea189c77a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/grounding-only",
+      "responseId": "resp_014d1190de6eb0d2016a67c00040dc8199a3ad71c8a63f437d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 765,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 786
+      },
+      "estimatedUsd": 0.004455,
+      "latencyMs": 914,
+      "rawOutputSha256": "7295c9d5d6f4ea0ac2c58c12d63f39e12cb5f365069d19d9781948860e8a936b"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/png-only",
+      "responseId": "resp_0de922779995aa47016a67c00142148198942a98f4519adaf1",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 387
+      },
+      "estimatedUsd": 0.00241,
+      "latencyMs": 2148,
+      "rawOutputSha256": "8ce76a2cc90fce86f33856eb397f5d7929bd4c1c263686f1bda00c74e84c8b7f"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/png-plus-grounding",
+      "responseId": "resp_038206fc068d7799016a67c0014224819aa9a3c014fd6756b5",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 674,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 22,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 696
+      },
+      "estimatedUsd": 0.00403,
+      "latencyMs": 944,
+      "rawOutputSha256": "3522e67ce72bcb303645530a065d780fa303860630b3a4c07d6ca105c11d4811"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/grounding-only",
+      "responseId": "resp_0f9afbb73454fcdc016a67c0036708819b863c67faf9ebd636",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 377,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 22,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 399
+      },
+      "estimatedUsd": 0.002545,
+      "latencyMs": 1030,
+      "rawOutputSha256": "3522e67ce72bcb303645530a065d780fa303860630b3a4c07d6ca105c11d4811"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/png-only",
+      "responseId": "resp_059b5eda39b52153016a67c00367f4819a8b76b27e676fa0d4",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 386
+      },
+      "estimatedUsd": 0.00238,
+      "latencyMs": 1254,
+      "rawOutputSha256": "debe6ccf52c32597057522a4cfb3ab36c7663217dec05d4c4171ed553de1dfc0"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/png-plus-grounding",
+      "responseId": "resp_0089d99bc73f8ea1016a67c004abd4819baf87083d850e99db",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 674,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 693
+      },
+      "estimatedUsd": 0.00394,
+      "latencyMs": 964,
+      "rawOutputSha256": "5fa497f3f8106c6f31d32a111886afafa13772704cab1817afa1cace02f54dd1"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/grounding-only",
+      "responseId": "resp_0468e8960c2b5691016a67c004a9788198a8342a36935ed9ca",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 377,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 396
+      },
+      "estimatedUsd": 0.002455,
+      "latencyMs": 1375,
+      "rawOutputSha256": "5fa497f3f8106c6f31d32a111886afafa13772704cab1817afa1cace02f54dd1"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/png-only",
+      "responseId": "resp_0dd98bd1990a6b49016a67c0060bfc819b856c25b6a3c1d6f1",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 37,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 404
+      },
+      "estimatedUsd": 0.002945,
+      "latencyMs": 2433,
+      "rawOutputSha256": "ee1bb64c526c237fbc8a836ea13b5b9e5f2f163d169a32e6bf1b02a3de4bbbfd"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/png-plus-grounding",
+      "responseId": "resp_0ecc6f9c1ffc67d9016a67c0060b90819a86c213c2f7ba88e4",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 592,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 619
+      },
+      "estimatedUsd": 0.00377,
+      "latencyMs": 1149,
+      "rawOutputSha256": "37ef39016a208daaa941288e460ec85c9c1c7fded730f6768e232b9cb9bcf20a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/grounding-only",
+      "responseId": "resp_0da4c6dcf356d8bb016a67c0087e3481988b30032a8288207f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 295,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 313
+      },
+      "estimatedUsd": 0.002015,
+      "latencyMs": 811,
+      "rawOutputSha256": "7f244ee40a26cd329aaa70e1417ed8be11e42081f387b637245500866fc408ab"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/png-only",
+      "responseId": "resp_01af7a7dc5392266016a67c0087c2c8198b9f61b5cd904c18f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 388
+      },
+      "estimatedUsd": 0.002415,
+      "latencyMs": 1039,
+      "rawOutputSha256": "a8406cbafeff6310f2d3c7f58dbaf2fd9fccffe490afc3e7d50a2764cd1a36df"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/png-plus-grounding",
+      "responseId": "resp_03239b386e9ca3cc016a67c0098894819a8275ffad3344a2df",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 594,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 612
+      },
+      "estimatedUsd": 0.00351,
+      "latencyMs": 1075,
+      "rawOutputSha256": "753f86bf4602c0d28bab029088ca178bb2f2e9959e70868f46aaf03ce6dd0d1a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/grounding-only",
+      "responseId": "resp_029e6e36dae80f8a016a67c0098634819a917ba3c0a9d248d3",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 297,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 315
+      },
+      "estimatedUsd": 0.002025,
+      "latencyMs": 1123,
+      "rawOutputSha256": "753f86bf4602c0d28bab029088ca178bb2f2e9959e70868f46aaf03ce6dd0d1a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/png-only",
+      "responseId": "resp_07184a0291aa1310016a67c00aae5c81999de73b67aa18ade3",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 388
+      },
+      "estimatedUsd": 0.002415,
+      "latencyMs": 1444,
+      "rawOutputSha256": "0c9c97491e4024c714a808207040a1070510d5f5e53704625751f41e91c6fa43"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/png-plus-grounding",
+      "responseId": "resp_05722fd885f4a50c016a67c00aa8ec819990e28b7c76a3d8e1",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 991,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 24,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1015
+      },
+      "estimatedUsd": 0.005675,
+      "latencyMs": 1491,
+      "rawOutputSha256": "0bfc9b74a5ecae617f08db8725ab35bc9ff9714491e643cb6710c85538500c7d"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/grounding-only",
+      "responseId": "resp_0bcc3a34c423a056016a67c00c279881998830d3cd166bc7c1",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 694,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 717
+      },
+      "estimatedUsd": 0.00416,
+      "latencyMs": 849,
+      "rawOutputSha256": "aab71f12b87d6c2de6eecc920195891341458434364ed59a0fac4c731b189e69"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/png-only",
+      "responseId": "resp_0e7a406047bed8b9016a67c00c2a408198a56bbaa93dc0cd76",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 385
+      },
+      "estimatedUsd": 0.002375,
+      "latencyMs": 1552,
+      "rawOutputSha256": "1760697eb73e58cde8936922849298389b6c393ec24bbd982ac84c7fb4682702"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/png-plus-grounding",
+      "responseId": "resp_05a37ca36c3586c9016a67c00e41ac819ba6b0562d7e2ccd85",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 989,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1014
+      },
+      "estimatedUsd": 0.005695,
+      "latencyMs": 1682,
+      "rawOutputSha256": "acec872f2e5bca19e5e9c871a5e288699d213b7be49c8f3e24f524feab22b55d"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/grounding-only",
+      "responseId": "resp_0483fe0fffe7ea66016a67c00dbaf48199b35b0850e03a99bf",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 692,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 717
+      },
+      "estimatedUsd": 0.00421,
+      "latencyMs": 1569,
+      "rawOutputSha256": "acec872f2e5bca19e5e9c871a5e288699d213b7be49c8f3e24f524feab22b55d"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/png-only",
+      "responseId": "resp_0c5a8546f30b773d016a67c00f7b58819886e45244634c5558",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 391
+      },
+      "estimatedUsd": 0.00253,
+      "latencyMs": 1415,
+      "rawOutputSha256": "4c5c937a88b9b0c005d960dd07cb16d392de1e5460996191434a65c360e49896"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/png-plus-grounding",
+      "responseId": "resp_01cdff4bed5032e6016a67c00f6ebc81988de850248167454b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 559,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 579
+      },
+      "estimatedUsd": 0.003395,
+      "latencyMs": 1810,
+      "rawOutputSha256": "958f838b0bece7c1fc0719d53f1eed638c12159b3846f67c669f4ef9bb62a74a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/grounding-only",
+      "responseId": "resp_0d5c768d57f0b6fb016a67c01136f4819aabeb8b471a9fbb56",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 262,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 282
+      },
+      "estimatedUsd": 0.00191,
+      "latencyMs": 3089,
+      "rawOutputSha256": "958f838b0bece7c1fc0719d53f1eed638c12159b3846f67c669f4ef9bb62a74a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/png-only",
+      "responseId": "resp_0972f32552b61dcb016a67c0113ea0819ab905703d75416692",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 389
+      },
+      "estimatedUsd": 0.00247,
+      "latencyMs": 977,
+      "rawOutputSha256": "d0c9d91e3bc79bfd1d1618e809ea049706a9ad55d3f130f3bf759deeb094e3b0"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/png-plus-grounding",
+      "responseId": "resp_0e627f3383450b70016a67c014562c8199acb2252b397fe4ce",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 559,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 580
+      },
+      "estimatedUsd": 0.003425,
+      "latencyMs": 988,
+      "rawOutputSha256": "d0c9d91e3bc79bfd1d1618e809ea049706a9ad55d3f130f3bf759deeb094e3b0"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/grounding-only",
+      "responseId": "resp_0d14dc3f3505dbb1016a67c014580481999313351ba19904d3",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 262,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 283
+      },
+      "estimatedUsd": 0.00194,
+      "latencyMs": 923,
+      "rawOutputSha256": "d0c9d91e3bc79bfd1d1618e809ea049706a9ad55d3f130f3bf759deeb094e3b0"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/png-only",
+      "responseId": "resp_0d49e49d64c8e58a016a67c0155108819ba6c275afbe94b7cf",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 388
+      },
+      "estimatedUsd": 0.002465,
+      "latencyMs": 984,
+      "rawOutputSha256": "a2d6d0ce8f82c61b1439f5bf86afefe2c0cbf01d2a861b7f2fbf241b225895ef"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/png-plus-grounding",
+      "responseId": "resp_0dcd764fef367365016a67c015570c8199a854f31e2689e337",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 884,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 902
+      },
+      "estimatedUsd": 0.00496,
+      "latencyMs": 1374,
+      "rawOutputSha256": "53eb447c645b500ce3cf4152992e02c96d721a682101397aa0e4098ddeaf69b3"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/grounding-only",
+      "responseId": "resp_0f560084405c884a016a67c016ae1c8199bac3f52b807191c2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 587,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 605
+      },
+      "estimatedUsd": 0.003475,
+      "latencyMs": 860,
+      "rawOutputSha256": "53eb447c645b500ce3cf4152992e02c96d721a682101397aa0e4098ddeaf69b3"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/png-only",
+      "responseId": "resp_0c0deed9cfce3161016a67c016b578819b9da20a8665e5672b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 37,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 404
+      },
+      "estimatedUsd": 0.002945,
+      "latencyMs": 1797,
+      "rawOutputSha256": "2bfb7c196b56118add45c999a8b1a373ab62b3ee5484180456540f3ed6d70ea6"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/png-plus-grounding",
+      "responseId": "resp_036732aa43e5a766016a67c01887b481998d44a139132afecf",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 883,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 904
+      },
+      "estimatedUsd": 0.005045,
+      "latencyMs": 1149,
+      "rawOutputSha256": "c0b02428c60234d33e4d0d347ad3c6741abe7369711de8be4112974e7faf44b4"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/grounding-only",
+      "responseId": "resp_01f5bcfc80bdcb17016a67c0188400819ba5c23f6372046efe",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 586,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 29,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 615
+      },
+      "estimatedUsd": 0.0038,
+      "latencyMs": 1295,
+      "rawOutputSha256": "1cb421d25f1253a7b416fd987485d12bab37315b8f43e57690d1a37b32ceec8b"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/png-only",
+      "responseId": "resp_082ddae399c0b755016a67c019d0008199849c79a64ebda799",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 370,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 29,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 399
+      },
+      "estimatedUsd": 0.00272,
+      "latencyMs": 1362,
+      "rawOutputSha256": "96e361436023a008c51b2c84133bc4a1d52ecc0ffedc41c2eaa7f77a3cadb199"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/png-plus-grounding",
+      "responseId": "resp_05b1493b1d8d49e2016a67c019d3b48199922877634d787826",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 653,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 681
+      },
+      "estimatedUsd": 0.004105,
+      "latencyMs": 1101,
+      "rawOutputSha256": "9d816351d2918a194334f4b04295830b941c93a77d064e761547fdc126976a7e"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/grounding-only",
+      "responseId": "resp_0ea21ae178606c3a016a67c01b41f0819abf2b3e7aef9c900d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 356,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 384
+      },
+      "estimatedUsd": 0.00262,
+      "latencyMs": 1970,
+      "rawOutputSha256": "9d816351d2918a194334f4b04295830b941c93a77d064e761547fdc126976a7e"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/png-only",
+      "responseId": "resp_09115bb5749113cd016a67c01b2f408198ab739d8038792919",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 389
+      },
+      "estimatedUsd": 0.002445,
+      "latencyMs": 1630,
+      "rawOutputSha256": "fb94eb55341fccee3343d470b0e548617f76c367224a8e446d7334279a2aefc7"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/png-plus-grounding",
+      "responseId": "resp_08805917e224697a016a67c01d2d888198936d7bb301dece5f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 652,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 671
+      },
+      "estimatedUsd": 0.00383,
+      "latencyMs": 1334,
+      "rawOutputSha256": "d8a2e6ff8d390abc669f65f8dfff4a5bb11cf40bb73ff7cae1650e6fcf834d1e"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/grounding-only",
+      "responseId": "resp_095020bc6173d844016a67c01d28808199a2d5b545b42fdc84",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 355,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 374
+      },
+      "estimatedUsd": 0.002345,
+      "latencyMs": 1236,
+      "rawOutputSha256": "d8a2e6ff8d390abc669f65f8dfff4a5bb11cf40bb73ff7cae1650e6fcf834d1e"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "line-push",
+      "responseId": "resp_084069ad6322c08c016a67c01e835081999807f1d4fe6fd3f7",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27328,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27325
+        },
+        "output_tokens": 53,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27381
+      },
+      "estimatedUsd": 0.0152675,
+      "latencyMs": 1568,
+      "rawOutputSha256": "aa45c1a9bc81bd075f976a9d2867a77f43a85fada4beb75edd44baa972fad878"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "scatter-push",
+      "responseId": "resp_0cd5f836d6fc363b016a67c01e8e808198b92ec56e896ea7c9",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27334,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27331
+        },
+        "output_tokens": 141,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27475
+      },
+      "estimatedUsd": 0.0179105,
+      "latencyMs": 2486,
+      "rawOutputSha256": "32a7c58796e0249e71c8382e2c342d55b0ce1b504df188af095c0bed4b3e155a"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "bubble-static",
+      "responseId": "resp_0168df1c838ed91a016a67c02104c0819a9bf17a3532e592cc",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27279,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27276
+        },
+        "output_tokens": 158,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27437
+      },
+      "estimatedUsd": 0.018393,
+      "latencyMs": 3431,
+      "rawOutputSha256": "be7d77551e68201bf41cb20131b61f3473e82e3aed66f223ed47f137efd285c2"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "gauge-static",
+      "responseId": "resp_004ff407b4f329d1016a67c02104d4819b9aeb9a02e0ef0de2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27281,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27278
+        },
+        "output_tokens": 128,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27409
+      },
+      "estimatedUsd": 0.017494,
+      "latencyMs": 3024,
+      "rawOutputSha256": "3fa4c48ad1be59cbf31e4e3733b940b425c8e7a6f24c9d2de292af67732e82b8"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "symbol-map-static",
+      "responseId": "resp_0078bdd8f99f1668016a67c0247aa48199ae8a5af4529bccb3",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27294,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27291
+        },
+        "output_tokens": 102,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27396
+      },
+      "estimatedUsd": 0.0167205,
+      "latencyMs": 2278,
+      "rawOutputSha256": "ad24651613cc32bb1d985f9b720d7709628bca2d19c4ffee0240543e78d278c4"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "galton-static",
+      "responseId": "resp_08b45b4f35597294016a67c02476c0819b9f7caf7153fd7eac",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27260,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27257
+        },
+        "output_tokens": 62,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27322
+      },
+      "estimatedUsd": 0.0155035,
+      "latencyMs": 2822,
+      "rawOutputSha256": "991ca987758a3d66c30df0a4dd882b4635a3245c7651c0c03e15f5cc707ab4a9"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "resolvedModel": "gpt-5.6-sol",
+      "suite": "first-try",
+      "fixtureId": "unit-pile-push",
+      "responseId": "resp_03329a74b23bbf05016a67c0274b908198a2624790b8616b67",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27325,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27322
+        },
+        "output_tokens": 59,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27384
+      },
+      "estimatedUsd": 0.015446,
+      "latencyMs": 1792,
+      "rawOutputSha256": "add8e8477487c817bce0146d71d94720611ed4029bb7f902fc3ab25e9c086bfd"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/png-only",
+      "responseId": "resp_0bddd0da3af1bc52016a67c0274568819a8f88d4fae6471605",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 374,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 400
+      },
+      "estimatedUsd": 0.001325,
+      "latencyMs": 878,
+      "rawOutputSha256": "88936eda3d8e7302c9379539aefd611e4bf5cb0034befd12025a91ca79f7d558"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/png-plus-grounding",
+      "responseId": "resp_00d36bb5e2fa316e016a67c0291190819aaf642f8c16e132f7",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 996,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1019
+      },
+      "estimatedUsd": 0.002835,
+      "latencyMs": 1005,
+      "rawOutputSha256": "e8097e8a1fab95b2e2feeb201aa95be0437944be071961969ffda4f2e85982c3"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/grounding-only",
+      "responseId": "resp_0f9df389cebaa182016a67c02914808199b1f0451d01e713d3",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 699,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 22,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 721
+      },
+      "estimatedUsd": 0.0020775,
+      "latencyMs": 1114,
+      "rawOutputSha256": "cd4ef3f1e4072ea28e5471281eb179b49d68f9fda6bcd769f617a957517727a6"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/png-only",
+      "responseId": "resp_020bcfa3e6690d60016a67c02a313081998085dcb22a5f9dc2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.0011425,
+      "latencyMs": 1029,
+      "rawOutputSha256": "139191d99676236271ad7f49706a7bb8bfd33648dc4662402beed84cde5397af"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/png-plus-grounding",
+      "responseId": "resp_098ca1539d8d45e3016a67c02a30fc819a87f61e39b83f33c2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 989,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1004
+      },
+      "estimatedUsd": 0.0026975,
+      "latencyMs": 1074,
+      "rawOutputSha256": "139191d99676236271ad7f49706a7bb8bfd33648dc4662402beed84cde5397af"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/grounding-only",
+      "responseId": "resp_07f10740de6449d9016a67c02b471081989c78f6fe50b25469",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 692,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 708
+      },
+      "estimatedUsd": 0.00197,
+      "latencyMs": 1048,
+      "rawOutputSha256": "0f68b1bf58d9ad62e6fef8b78533bc3c7a29a4abd9c7f842c105da58f45e9b86"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/png-only",
+      "responseId": "resp_08db5f86439ef63a016a67c02b454c819ba440720be5cc3e2e",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 383
+      },
+      "estimatedUsd": 0.0011325,
+      "latencyMs": 1204,
+      "rawOutputSha256": "55db033120bd8822d113989369c02fa976a8ff0f3b45b9e618b894612552bbc8"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/png-plus-grounding",
+      "responseId": "resp_09a43ea2731d4436016a67c02c9c50819984e3cce3f6085708",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1104,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1052
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1129
+      },
+      "estimatedUsd": 0.000768,
+      "latencyMs": 1462,
+      "rawOutputSha256": "46fd471bcd0762a2c4836a2e0d0532bc47131190f74435bd7c1688ea3d2a6d98"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/grounding-only",
+      "responseId": "resp_0265eba53beb866c016a67c02c7ca48198805badfbb815c8bd",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 807,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 828
+      },
+      "estimatedUsd": 0.0023325,
+      "latencyMs": 790,
+      "rawOutputSha256": "75bbef3f8990abc3c267e7e306e775c6fc4f1435c7d19a2ddd81440f2019fa42"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/png-only",
+      "responseId": "resp_08c289ce50b5c94f016a67c02df460819999b771ea1786c19b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 372,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 39,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 411
+      },
+      "estimatedUsd": 0.001515,
+      "latencyMs": 996,
+      "rawOutputSha256": "4084052faa9237bb6fbe709bf521e551d3914244ccf5eaeda351258a16898326"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/png-plus-grounding",
+      "responseId": "resp_0a570bf906b6f70a016a67c02df720819a98130a30f06f14f9",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1107,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1055
+        },
+        "output_tokens": 38,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1145
+      },
+      "estimatedUsd": 0.00096375,
+      "latencyMs": 1077,
+      "rawOutputSha256": "e63981d0befbc36e4435c42e226f7c8fae71ca7f61d19d7624b11bacbf660b10"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/grounding-only",
+      "responseId": "resp_0a3491c82b4c553b016a67c02f08b0819895d22ab434fdc8cb",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 810,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 38,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 848
+      },
+      "estimatedUsd": 0.002595,
+      "latencyMs": 1507,
+      "rawOutputSha256": "e63981d0befbc36e4435c42e226f7c8fae71ca7f61d19d7624b11bacbf660b10"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/png-only",
+      "responseId": "resp_0d9a3e2ee0435011016a67c02f085481998b737c20c49fe706",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 370,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 398
+      },
+      "estimatedUsd": 0.001345,
+      "latencyMs": 874,
+      "rawOutputSha256": "0b05d0eb4395a488dce2d7b8e62baab2dfc47543b9e97a61b751bcb7f6f9800b"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/png-plus-grounding",
+      "responseId": "resp_05c1d624a65455c2016a67c0308d4081998450cd184dff0304",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1077,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1025
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1102
+      },
+      "estimatedUsd": 0.00076125,
+      "latencyMs": 897,
+      "rawOutputSha256": "37c99b96029cca8f3b1619449820d1c8c857cdba2a52080463bf36890a0679ea"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/grounding-only",
+      "responseId": "resp_0f2a52e27d965f78016a67c0308d0c819a9d075e840103a179",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 780,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 806
+      },
+      "estimatedUsd": 0.00234,
+      "latencyMs": 896,
+      "rawOutputSha256": "f68d54a40a8fcb05dbe54c4b40cc1395bbe7b1872bc5f3542591f843ec404c99"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/png-only",
+      "responseId": "resp_0b4d82de05a1d9c5016a67c03172988199a0f9f321c9b48929",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.0011425,
+      "latencyMs": 823,
+      "rawOutputSha256": "162c22f13b349170282a67ca830479c3ab9bdd5c246da8847e3eb9602ab5bad0"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/png-plus-grounding",
+      "responseId": "resp_0f0e2ac5e18bd110016a67c0317258819aba47e89a2bd54363",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1074,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1090
+      },
+      "estimatedUsd": 0.002925,
+      "latencyMs": 808,
+      "rawOutputSha256": "db581f71a007f0598a6a640bbb858c5256af62c79ae61f149233e32cce4679b2"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/grounding-only",
+      "responseId": "resp_0c842ea73b4f4bb9016a67c03257ac819a94728c8471d7fed6",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 777,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 795
+      },
+      "estimatedUsd": 0.0022125,
+      "latencyMs": 960,
+      "rawOutputSha256": "3c3eeaf75b600452370e78a739d4d431ba57064c98163b837081438f2c78873e"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/png-only",
+      "responseId": "resp_02d61d3948fac444016a67c032496c819890d72ee0ceac6367",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 383
+      },
+      "estimatedUsd": 0.0011575,
+      "latencyMs": 924,
+      "rawOutputSha256": "6e33072acb074d489d6d31794e02ed7c874e350e0c9d69eaa92ad1527129276a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/png-plus-grounding",
+      "responseId": "resp_0d1d3c4fd4bf5026016a67c03341a081999a45a3309b7a4c57",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1061,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1078
+      },
+      "estimatedUsd": 0.0029075,
+      "latencyMs": 835,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/grounding-only",
+      "responseId": "resp_04d2a78109c4cdaf016a67c0334294819980d3d6b37767ffec",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 764,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 781
+      },
+      "estimatedUsd": 0.002165,
+      "latencyMs": 893,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/png-only",
+      "responseId": "resp_0020f9cd8b0741bc016a67c034288c819884b2587453a32ede",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.00113,
+      "latencyMs": 1016,
+      "rawOutputSha256": "4fa4c8e85fcec46fdf1c47a79beae825dd532385e6e9270997f377d80b2ef697"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/png-plus-grounding",
+      "responseId": "resp_0f3b47e777eeada9016a67c0342564819892b9c5a608749f38",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1062,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1076
+      },
+      "estimatedUsd": 0.002865,
+      "latencyMs": 790,
+      "rawOutputSha256": "4fa4c8e85fcec46fdf1c47a79beae825dd532385e6e9270997f377d80b2ef697"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/grounding-only",
+      "responseId": "resp_0f78ed858aa4badd016a67c0352e5c819996cbe4fbb902cbae",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 765,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 779
+      },
+      "estimatedUsd": 0.0021225,
+      "latencyMs": 788,
+      "rawOutputSha256": "4fa4c8e85fcec46fdf1c47a79beae825dd532385e6e9270997f377d80b2ef697"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/png-only",
+      "responseId": "resp_043a58b8ffca8721016a67c0353094819aac9b96b3fa9eb044",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 387
+      },
+      "estimatedUsd": 0.001205,
+      "latencyMs": 813,
+      "rawOutputSha256": "8ce76a2cc90fce86f33856eb397f5d7929bd4c1c263686f1bda00c74e84c8b7f"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/png-plus-grounding",
+      "responseId": "resp_0a08040414b708ca016a67c03609a48199a92b8298d2519901",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 674,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 22,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 696
+      },
+      "estimatedUsd": 0.002015,
+      "latencyMs": 1168,
+      "rawOutputSha256": "3522e67ce72bcb303645530a065d780fa303860630b3a4c07d6ca105c11d4811"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/grounding-only",
+      "responseId": "resp_02246d26b4d5625e016a67c035ffec819a8a2ace0bcc7d8de9",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 377,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 22,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 399
+      },
+      "estimatedUsd": 0.0012725,
+      "latencyMs": 771,
+      "rawOutputSha256": "3522e67ce72bcb303645530a065d780fa303860630b3a4c07d6ca105c11d4811"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/png-only",
+      "responseId": "resp_002372d9e6d43b96016a67c037908c81989944e3a598073427",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 396
+      },
+      "estimatedUsd": 0.00134,
+      "latencyMs": 4546,
+      "rawOutputSha256": "a04f4c44cab2f2c4e77d8089c33a7899a6cad49d8a2cdc0ac8bdea97656e59f1"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/png-plus-grounding",
+      "responseId": "resp_0d64d29573003a52016a67c0372f98819a96340516c269d000",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 674,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 693
+      },
+      "estimatedUsd": 0.00197,
+      "latencyMs": 819,
+      "rawOutputSha256": "5fa497f3f8106c6f31d32a111886afafa13772704cab1817afa1cace02f54dd1"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/grounding-only",
+      "responseId": "resp_0ab8ac16713fb46b016a67c03bba08819ba6197d5ac9a1a2b2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 377,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 396
+      },
+      "estimatedUsd": 0.0012275,
+      "latencyMs": 879,
+      "rawOutputSha256": "5fa497f3f8106c6f31d32a111886afafa13772704cab1817afa1cace02f54dd1"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/png-only",
+      "responseId": "resp_0a4b87ec58663f72016a67c03bb8348199ad40483509ed562b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 33,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 400
+      },
+      "estimatedUsd": 0.0014125,
+      "latencyMs": 1287,
+      "rawOutputSha256": "b970c9f4f3d1f648f824236e5a0e020b225f1f3e0fc8d2d043f2f746c079d8e4"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/png-plus-grounding",
+      "responseId": "resp_0aebf8131ba915d3016a67c03d06f48199a78a6e723125bb77",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 592,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 619
+      },
+      "estimatedUsd": 0.001885,
+      "latencyMs": 1066,
+      "rawOutputSha256": "37ef39016a208daaa941288e460ec85c9c1c7fded730f6768e232b9cb9bcf20a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/grounding-only",
+      "responseId": "resp_045cd54523efa23f016a67c03d048c819b872f739a25bf0712",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 295,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 322
+      },
+      "estimatedUsd": 0.0011425,
+      "latencyMs": 1086,
+      "rawOutputSha256": "37ef39016a208daaa941288e460ec85c9c1c7fded730f6768e232b9cb9bcf20a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/png-only",
+      "responseId": "resp_02f561c85f3a1755016a67c03e1a3081998d4f625eea6e8070",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 384
+      },
+      "estimatedUsd": 0.0011475,
+      "latencyMs": 737,
+      "rawOutputSha256": "19e5b23bbfe73715f941bcbbe902eef9c924ba2d6e268de396d0e5037f8e731b"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/png-plus-grounding",
+      "responseId": "resp_0cfe318adf1ed4c8016a67c03e198c8199b24499d22473828d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 594,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 613
+      },
+      "estimatedUsd": 0.00177,
+      "latencyMs": 1196,
+      "rawOutputSha256": "2bdcd2581a233eef2e3e19338bf56fe720108cbc0b5b30b13629abc2c519fb3f"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/grounding-only",
+      "responseId": "resp_02c1556524867b44016a67c03f4f8c8198a03f5892dffd0a2a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 297,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 315
+      },
+      "estimatedUsd": 0.0010125,
+      "latencyMs": 775,
+      "rawOutputSha256": "753f86bf4602c0d28bab029088ca178bb2f2e9959e70868f46aaf03ce6dd0d1a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/png-only",
+      "responseId": "resp_0a8e1d26aa5989b1016a67c03f4e74819998fd35af1c09e697",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 392
+      },
+      "estimatedUsd": 0.0012675,
+      "latencyMs": 837,
+      "rawOutputSha256": "1e93c437f100f8ac32ef1fa3498cf8e8f4aba9d88b7db79118d5eb3f79061fd8"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/png-plus-grounding",
+      "responseId": "resp_05a7fae139a6d6d3016a67c0402ac0819ba46a764f895d9c96",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 991,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1014
+      },
+      "estimatedUsd": 0.0028225,
+      "latencyMs": 815,
+      "rawOutputSha256": "aab71f12b87d6c2de6eecc920195891341458434364ed59a0fac4c731b189e69"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/grounding-only",
+      "responseId": "resp_030e1ff221989444016a67c0402538819aa985f5140661683f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 694,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 717
+      },
+      "estimatedUsd": 0.00208,
+      "latencyMs": 650,
+      "rawOutputSha256": "aab71f12b87d6c2de6eecc920195891341458434364ed59a0fac4c731b189e69"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/png-only",
+      "responseId": "resp_053de09678c7fb36016a67c0413668819aae9b985ed0ac4587",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.0011425,
+      "latencyMs": 2093,
+      "rawOutputSha256": "57713459e8dc9d76ffd769bdeab211636e28289bd04732040ff557176131a96f"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/png-plus-grounding",
+      "responseId": "resp_060412ac48b9c8da016a67c040ff1481998c4b0805096e9bc9",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 989,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1014
+      },
+      "estimatedUsd": 0.0028475,
+      "latencyMs": 932,
+      "rawOutputSha256": "acec872f2e5bca19e5e9c871a5e288699d213b7be49c8f3e24f524feab22b55d"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/grounding-only",
+      "responseId": "resp_084e7b712fcc1178016a67c04313f8819a8d94d878f14d79c5",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 692,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 710
+      },
+      "estimatedUsd": 0.002,
+      "latencyMs": 922,
+      "rawOutputSha256": "1760697eb73e58cde8936922849298389b6c393ec24bbd982ac84c7fb4682702"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/png-only",
+      "responseId": "resp_056ea9ee66dd6624016a67c0431418819981b613cef1247a25",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 385
+      },
+      "estimatedUsd": 0.001175,
+      "latencyMs": 689,
+      "rawOutputSha256": "39cc280018911ae5f39f958f625651a5ae5c3c61278dc6050d9cc96abf787705"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/png-plus-grounding",
+      "responseId": "resp_0dde5202606be34b016a67c0440488819aa5e264d264f57138",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 559,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 579
+      },
+      "estimatedUsd": 0.0016975,
+      "latencyMs": 978,
+      "rawOutputSha256": "958f838b0bece7c1fc0719d53f1eed638c12159b3846f67c669f4ef9bb62a74a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/grounding-only",
+      "responseId": "resp_096b9ca779d5bf3c016a67c04401c881999b5d24063d6c8afd",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 262,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 276
+      },
+      "estimatedUsd": 0.000865,
+      "latencyMs": 814,
+      "rawOutputSha256": "986f12b5b317b7b5c4efe40dbcfb3837e62bd0f229c257de1267cdf25a85b447"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/png-only",
+      "responseId": "resp_00a1a6f5cafc8db8016a67c04502a8819ab9db66fab313aad0",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.00113,
+      "latencyMs": 1059,
+      "rawOutputSha256": "37b714bd7f3ab357c8ff281f4f6e8d73b3247e72873c581e56dbb7c45cbc6b28"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/png-plus-grounding",
+      "responseId": "resp_007026630055cbbc016a67c04503608199893544580967339c",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 559,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 580
+      },
+      "estimatedUsd": 0.0017125,
+      "latencyMs": 891,
+      "rawOutputSha256": "d0c9d91e3bc79bfd1d1618e809ea049706a9ad55d3f130f3bf759deeb094e3b0"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/grounding-only",
+      "responseId": "resp_095d96dde9125a9e016a67c0461144819bbcf362ebb8374a79",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 262,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 276
+      },
+      "estimatedUsd": 0.000865,
+      "latencyMs": 2496,
+      "rawOutputSha256": "37b714bd7f3ab357c8ff281f4f6e8d73b3247e72873c581e56dbb7c45cbc6b28"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/png-only",
+      "responseId": "resp_0b6ea778d8ae3ff9016a67c046107c819983b61397d99a38ba",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 388
+      },
+      "estimatedUsd": 0.0012325,
+      "latencyMs": 737,
+      "rawOutputSha256": "a572446d27d5e9bd19fbde2f3c0aa584d3f2badd982189efa690127ffbc3c0ae"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/png-plus-grounding",
+      "responseId": "resp_0ee15a52cc908121016a67c04899208198acbb4080d4569366",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 884,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 902
+      },
+      "estimatedUsd": 0.00248,
+      "latencyMs": 1637,
+      "rawOutputSha256": "53eb447c645b500ce3cf4152992e02c96d721a682101397aa0e4098ddeaf69b3"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/grounding-only",
+      "responseId": "resp_0cdc8b1584656a44016a67c04894088198a61fe490c870ac68",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 587,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 605
+      },
+      "estimatedUsd": 0.0017375,
+      "latencyMs": 763,
+      "rawOutputSha256": "53eb447c645b500ce3cf4152992e02c96d721a682101397aa0e4098ddeaf69b3"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/png-only",
+      "responseId": "resp_04c54dd349e6713b016a67c04a3a60819996230fb15bae4966",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 387
+      },
+      "estimatedUsd": 0.0012175,
+      "latencyMs": 1014,
+      "rawOutputSha256": "cf17b012dc1a3efb89f8ae93a4e31c4c9d6a6a584d34cc26df4cae3c9f52830a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/png-plus-grounding",
+      "responseId": "resp_00c87025cbc7c58c016a67c04a3afc8198aacdd4a00a490cdc",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 883,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 903
+      },
+      "estimatedUsd": 0.0025075,
+      "latencyMs": 1083,
+      "rawOutputSha256": "cf17b012dc1a3efb89f8ae93a4e31c4c9d6a6a584d34cc26df4cae3c9f52830a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/grounding-only",
+      "responseId": "resp_045d1d4dd3080d43016a67c04b527c8198aba8077638d5a5fa",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 586,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 606
+      },
+      "estimatedUsd": 0.001765,
+      "latencyMs": 867,
+      "rawOutputSha256": "cf17b012dc1a3efb89f8ae93a4e31c4c9d6a6a584d34cc26df4cae3c9f52830a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/png-only",
+      "responseId": "resp_01be1b48784b82dc016a67c04b4ee0819b92074cefc68f84ef",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 370,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 398
+      },
+      "estimatedUsd": 0.001345,
+      "latencyMs": 889,
+      "rawOutputSha256": "3a4ba5d60d8bd29ccae6c247f919c3a54cd039327d6d2314fbf99de359416f50"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/png-plus-grounding",
+      "responseId": "resp_0b9a86c635210f6a016a67c04c338481988013257f9d4a2931",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 653,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 681
+      },
+      "estimatedUsd": 0.0020525,
+      "latencyMs": 786,
+      "rawOutputSha256": "9d816351d2918a194334f4b04295830b941c93a77d064e761547fdc126976a7e"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/grounding-only",
+      "responseId": "resp_01d30022cc7b1b6a016a67c04c37f48199a1727c2442df5b6a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 356,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 384
+      },
+      "estimatedUsd": 0.00131,
+      "latencyMs": 824,
+      "rawOutputSha256": "9d816351d2918a194334f4b04295830b941c93a77d064e761547fdc126976a7e"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/png-only",
+      "responseId": "resp_0a960b84582acda2016a67c04d09ac8199b1461fb18a4c30ba",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 385
+      },
+      "estimatedUsd": 0.0011625,
+      "latencyMs": 1025,
+      "rawOutputSha256": "4fc5fa4367adf5d671f36647483094920a174a9e10a32538442aafeb73c0946c"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/png-plus-grounding",
+      "responseId": "resp_035e2733e0c465af016a67c04d7e58819b804701947f9a1345",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 652,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 672
+      },
+      "estimatedUsd": 0.00193,
+      "latencyMs": 1782,
+      "rawOutputSha256": "fb94eb55341fccee3343d470b0e548617f76c367224a8e446d7334279a2aefc7"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/grounding-only",
+      "responseId": "resp_095adcb1286557fa016a67c04ed41c8199bb54e1bafbdcde53",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 355,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 373
+      },
+      "estimatedUsd": 0.0011575,
+      "latencyMs": 967,
+      "rawOutputSha256": "9c5287081a10e946aa1795b095de727550b5d6bc040547a00a527ed4f1ae4492"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "line-push",
+      "responseId": "resp_04632c9c21af1365016a67c04ed89c819abc35379d317181b3",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27328,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27325
+        },
+        "output_tokens": 81,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27409
+      },
+      "estimatedUsd": 0.00805375,
+      "latencyMs": 2125,
+      "rawOutputSha256": "786981104cf3b91e2866d01fb06293e7bb45b3470013a291dac861d62b125765"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "scatter-push",
+      "responseId": "resp_02e1bb4e77bb41f2016a67c050fc68819995c296e84fca1d01",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27334,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27331
+        },
+        "output_tokens": 130,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27464
+      },
+      "estimatedUsd": 0.00879025,
+      "latencyMs": 1973,
+      "rawOutputSha256": "8010f12d1d64b6e273b5fcdbfa8701594f1cb2a74a45a7895f471d303b3ccf9a"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "bubble-static",
+      "responseId": "resp_09023c75ca301d04016a67c050fedc819aacca0640723b8748",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27279,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27276
+        },
+        "output_tokens": 160,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27439
+      },
+      "estimatedUsd": 0.0092265,
+      "latencyMs": 1879,
+      "rawOutputSha256": "bdb8918a77637bfee9925185cb3593ae9da9897c4e1c59ad658eb94c954a8db1"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "gauge-static",
+      "responseId": "resp_0f98f5b24b183dee016a67c052f574819a95abae49d02aca3b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27281,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27278
+        },
+        "output_tokens": 131,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27412
+      },
+      "estimatedUsd": 0.008792,
+      "latencyMs": 2013,
+      "rawOutputSha256": "8bbc6df250a3bb8c8b77a5cb43d7ed7ffe8d9c643c50771dc630fc1a0f299761"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "symbol-map-static",
+      "responseId": "resp_023498045d78cb67016a67c0530f9881989ce7b316a21f69bc",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27294,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27291
+        },
+        "output_tokens": 133,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27427
+      },
+      "estimatedUsd": 0.00882525,
+      "latencyMs": 1934,
+      "rawOutputSha256": "bbcf200ddb0c2b5aed955bffc6fa4987d24c2d7c4ec287de449154d9b97a932f"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "galton-static",
+      "responseId": "resp_0f2bee21ab472b1b016a67c0550cdc819aa47732546be9de0f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27260,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27257
+        },
+        "output_tokens": 66,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27326
+      },
+      "estimatedUsd": 0.00781175,
+      "latencyMs": 1375,
+      "rawOutputSha256": "a2cd7e9c911fc269d1fce6f111b3f6c27dc9f3059a7186b6645992cf9933b087"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "resolvedModel": "gpt-5.6-terra",
+      "suite": "first-try",
+      "fixtureId": "unit-pile-push",
+      "responseId": "resp_0b8affa1f6e2d653016a67c054fdec819aae0194dc7ccb4a59",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27325,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27322
+        },
+        "output_tokens": 84,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27409
+      },
+      "estimatedUsd": 0.008098,
+      "latencyMs": 1753,
+      "rawOutputSha256": "d78b44ed1f4c5deb2845017a1f7a2d1eab3014bc5674f080be98cc6952ad1a1d"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/png-only",
+      "responseId": "resp_016823c87b15d4d7016a67c056bbcc819a845b511b7fda78df",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 374,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 400
+      },
+      "estimatedUsd": 0.00053,
+      "latencyMs": 981,
+      "rawOutputSha256": "88936eda3d8e7302c9379539aefd611e4bf5cb0034befd12025a91ca79f7d558"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/png-plus-grounding",
+      "responseId": "resp_04e055c793314d41016a67c056c4a0819ba1a47ef51cb0b2ea",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 996,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1019
+      },
+      "estimatedUsd": 0.001134,
+      "latencyMs": 1027,
+      "rawOutputSha256": "e8097e8a1fab95b2e2feeb201aa95be0437944be071961969ffda4f2e85982c3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/highest/grounding-only",
+      "responseId": "resp_0af820c1b38a49ee016a67c057c8c8819ba25196441a90cc80",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 699,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 725
+      },
+      "estimatedUsd": 0.000855,
+      "latencyMs": 696,
+      "rawOutputSha256": "88936eda3d8e7302c9379539aefd611e4bf5cb0034befd12025a91ca79f7d558"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/png-only",
+      "responseId": "resp_00231dfe2607c3ba016a67c057ec00819ba11dcf212973c9ae",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.000457,
+      "latencyMs": 970,
+      "rawOutputSha256": "139191d99676236271ad7f49706a7bb8bfd33648dc4662402beed84cde5397af"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/png-plus-grounding",
+      "responseId": "resp_03d0900270955757016a67c058d598819ba75f5eaa93ec6600",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 989,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1004
+      },
+      "estimatedUsd": 0.001079,
+      "latencyMs": 729,
+      "rawOutputSha256": "139191d99676236271ad7f49706a7bb8bfd33648dc4662402beed84cde5397af"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "regional-revenue/count/grounding-only",
+      "responseId": "resp_0563d8f06d70a96d016a67c058bbc88199a841ea5a36f6bd05",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 692,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 707
+      },
+      "estimatedUsd": 0.000782,
+      "latencyMs": 500,
+      "rawOutputSha256": "139191d99676236271ad7f49706a7bb8bfd33648dc4662402beed84cde5397af"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/png-only",
+      "responseId": "resp_07f3f3e610b73bb2016a67c05978ec819895656ca575de4454",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 383
+      },
+      "estimatedUsd": 0.000453,
+      "latencyMs": 564,
+      "rawOutputSha256": "55db033120bd8822d113989369c02fa976a8ff0f3b45b9e618b894612552bbc8"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/png-plus-grounding",
+      "responseId": "resp_08f624967bec8990016a67c0597ac481998a22a257699c450e",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1104,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1052
+        },
+        "output_tokens": 22,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1126
+      },
+      "estimatedUsd": 0.0002892,
+      "latencyMs": 819,
+      "rawOutputSha256": "c0892d79ea92a2086eab960e4fd2936f64052d2371dd77c2b79d14b64ca6dd7e"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/last/grounding-only",
+      "responseId": "resp_0e4851584b010f84016a67c05b542c81988271466db1d6fb46",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 807,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 834
+      },
+      "estimatedUsd": 0.000969,
+      "latencyMs": 2194,
+      "rawOutputSha256": "473c8acbad47fb201d0c060181ded0fde0549e8ea92d45c74727ad9c4671b3fd"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/png-only",
+      "responseId": "resp_08a8ac10d72c985f016a67c05a57c0819b9c169ef832bd44ec",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 372,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 393
+      },
+      "estimatedUsd": 0.000498,
+      "latencyMs": 962,
+      "rawOutputSha256": "a33e91662e062d45c342220c9104277fec6a4f6c4f479b9d1399ba4f1a29534c"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/png-plus-grounding",
+      "responseId": "resp_08a32d40253dc32f016a67c05c7fbc8199832344fad23efd14",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1107,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1055
+        },
+        "output_tokens": 39,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1146
+      },
+      "estimatedUsd": 0.0003915,
+      "latencyMs": 789,
+      "rawOutputSha256": "daf7ef1c98d9cbc68403e9230501fb1ffde6e00d528d575b1f8d5c76583f2f5f"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "weekly-users/direction/grounding-only",
+      "responseId": "resp_022e08d25b70b890016a67c05c831881999c4e78cbe6356266",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 810,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 39,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 849
+      },
+      "estimatedUsd": 0.001044,
+      "latencyMs": 994,
+      "rawOutputSha256": "daf7ef1c98d9cbc68403e9230501fb1ffde6e00d528d575b1f8d5c76583f2f5f"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/png-only",
+      "responseId": "resp_0f13e8e476367b6c016a67c05d81b0819ab0853d65d367d3fe",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 370,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 398
+      },
+      "estimatedUsd": 0.000538,
+      "latencyMs": 924,
+      "rawOutputSha256": "ec2724a6598c3748d22cde3f47f6d037a18c8801829c4dd151c4ce53346a61b7"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/png-plus-grounding",
+      "responseId": "resp_037b803eeafb95b0016a67c05d84f48198b191f7a42e586a84",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1077,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1025
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1103
+      },
+      "estimatedUsd": 0.0003105,
+      "latencyMs": 1029,
+      "rawOutputSha256": "f117f35663901e19fac64bdaf0e4dc84898ff245808008edd50df2cd7a4cddaa"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/largest/grounding-only",
+      "responseId": "resp_03ba9a7619a191ec016a67c05e8e1c8198aa3e72edee6052db",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 780,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 808
+      },
+      "estimatedUsd": 0.000948,
+      "latencyMs": 964,
+      "rawOutputSha256": "f3f5d9ba945975d3f6c2276f3f6996a6ffcef411030dba19eeb47d91aaf7638a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/png-only",
+      "responseId": "resp_032e5577272e37bf016a67c05e88a8819bbe12914cc288f919",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.000457,
+      "latencyMs": 600,
+      "rawOutputSha256": "162c22f13b349170282a67ca830479c3ab9bdd5c246da8847e3eb9602ab5bad0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/png-plus-grounding",
+      "responseId": "resp_076e0648402cb5b8016a67c05f81f4819a9d56466a2bf4894c",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1074,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1089
+      },
+      "estimatedUsd": 0.001164,
+      "latencyMs": 701,
+      "rawOutputSha256": "162c22f13b349170282a67ca830479c3ab9bdd5c246da8847e3eb9602ab5bad0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "payload-latency/count/grounding-only",
+      "responseId": "resp_080735ac8658c39e016a67c05f830c819ba7e83a01c61da57d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 777,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 792
+      },
+      "estimatedUsd": 0.000867,
+      "latencyMs": 967,
+      "rawOutputSha256": "162c22f13b349170282a67ca830479c3ab9bdd5c246da8847e3eb9602ab5bad0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/png-only",
+      "responseId": "resp_02384db993a66d12016a67c0609954819b9353751818ca586f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 383
+      },
+      "estimatedUsd": 0.000463,
+      "latencyMs": 1302,
+      "rawOutputSha256": "6e33072acb074d489d6d31794e02ed7c874e350e0c9d69eaa92ad1527129276a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/png-plus-grounding",
+      "responseId": "resp_0889eaf4dfb83014016a67c06082308199857ce2abd92b8b2a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1061,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1078
+      },
+      "estimatedUsd": 0.001163,
+      "latencyMs": 893,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "service-latency/categories/grounding-only",
+      "responseId": "resp_0552a14582656ba7016a67c061c98481998c6734232e0e5594",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 764,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 17,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 781
+      },
+      "estimatedUsd": 0.000866,
+      "latencyMs": 693,
+      "rawOutputSha256": "31e26555e6b8ab1d563881fa9dc075cee1a0eedd745a8e796133c097084261a0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/png-only",
+      "responseId": "resp_0849750343edc8b0016a67c061cfac8198a593d4a8827c3820",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 24,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 392
+      },
+      "estimatedUsd": 0.000512,
+      "latencyMs": 943,
+      "rawOutputSha256": "78f401d475d923634bab3bdf4e980e982a26261d3b7d1f48f0f2d6c00f3beb8c"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/png-plus-grounding",
+      "responseId": "resp_083e93ddeddb0ee3016a67c062c688819bba42b87320a0ef42",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 1062,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1083
+      },
+      "estimatedUsd": 0.001188,
+      "latencyMs": 1071,
+      "rawOutputSha256": "7295c9d5d6f4ea0ac2c58c12d63f39e12cb5f365069d19d9781948860e8a936b"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "service-latency/max/grounding-only",
+      "responseId": "resp_08eb658a5d3e90e4016a67c062c1a0819b907d7e9a9930b566",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 765,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 786
+      },
+      "estimatedUsd": 0.000891,
+      "latencyMs": 689,
+      "rawOutputSha256": "7295c9d5d6f4ea0ac2c58c12d63f39e12cb5f365069d19d9781948860e8a936b"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/png-only",
+      "responseId": "resp_07b39b2941cd0aa4016a67c063d6ac81988cbce1fc11c5ce8a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 387
+      },
+      "estimatedUsd": 0.000482,
+      "latencyMs": 758,
+      "rawOutputSha256": "8ce76a2cc90fce86f33856eb397f5d7929bd4c1c263686f1bda00c74e84c8b7f"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/png-plus-grounding",
+      "responseId": "resp_0e49d4ebbd6becbe016a67c063d2bc819baa722360404399c7",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 674,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 700
+      },
+      "estimatedUsd": 0.00083,
+      "latencyMs": 680,
+      "rawOutputSha256": "c713a07fb2312f9fff73682b5b1eb18f75e63d98269a17a174e5264d66821f61"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "request-flow/largest/grounding-only",
+      "responseId": "resp_0c00f0d337bafd0b016a67c0649c24819a9a20fc316b4f0d08",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 377,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 26,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 403
+      },
+      "estimatedUsd": 0.000533,
+      "latencyMs": 769,
+      "rawOutputSha256": "c713a07fb2312f9fff73682b5b1eb18f75e63d98269a17a174e5264d66821f61"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/png-only",
+      "responseId": "resp_004bf43636cdaac2016a67c06498b48199a7809b3c32a63eec",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 389
+      },
+      "estimatedUsd": 0.000494,
+      "latencyMs": 3306,
+      "rawOutputSha256": "081d33a72b95bfe52fea9e4bb20d314289774ca115a765b13e0712294a68bf04"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/png-plus-grounding",
+      "responseId": "resp_0272c827c341919f016a67c067f438819bb0c7d959b92d0d1e",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 674,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 693
+      },
+      "estimatedUsd": 0.000788,
+      "latencyMs": 969,
+      "rawOutputSha256": "eb476af13299bba6bf03ef2fc81f45f3f2fe4c5eb0baf9e0779c718d69891938"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "request-flow/failed/grounding-only",
+      "responseId": "resp_05a9b8ab689dd137016a67c067e6a4819a8a548e1a59c3d1df",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 377,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 396
+      },
+      "estimatedUsd": 0.000491,
+      "latencyMs": 716,
+      "rawOutputSha256": "5fa497f3f8106c6f31d32a111886afafa13772704cab1817afa1cace02f54dd1"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/png-only",
+      "responseId": "resp_0866f8781aacf581016a67c068e3b8819aa5ca32b89952f100",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 38,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 405
+      },
+      "estimatedUsd": 0.000595,
+      "latencyMs": 1119,
+      "rawOutputSha256": "434f87553d02a4be6d4a7499075d38c9ea648bb9ef8cb9b870ef9e9db400e5a9"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/png-plus-grounding",
+      "responseId": "resp_0ee8f31c8d9c07f6016a67c068e80c819b95cc42212fd24d25",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 592,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 619
+      },
+      "estimatedUsd": 0.000754,
+      "latencyMs": 785,
+      "rawOutputSha256": "37ef39016a208daaa941288e460ec85c9c1c7fded730f6768e232b9cb9bcf20a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/largest/grounding-only",
+      "responseId": "resp_0d30069105fad777016a67c06a0234819985c057bb421b8769",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 295,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 27,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 322
+      },
+      "estimatedUsd": 0.000457,
+      "latencyMs": 692,
+      "rawOutputSha256": "37ef39016a208daaa941288e460ec85c9c1c7fded730f6768e232b9cb9bcf20a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/png-only",
+      "responseId": "resp_063d48f5265a1aef016a67c06a09c08198ba3b208af00e25e1",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 394
+      },
+      "estimatedUsd": 0.000519,
+      "latencyMs": 2463,
+      "rawOutputSha256": "138c4a6fd13c9348524e7671ab23f8021a63d5409f413df8545c2787f8f94dc3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/png-plus-grounding",
+      "responseId": "resp_08149d1a954be5c8016a67c06c832c8198b6ed96ab1d1135c2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 594,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 617
+      },
+      "estimatedUsd": 0.000732,
+      "latencyMs": 676,
+      "rawOutputSha256": "5131dbca7f7ac689da5a1c1b58bd92d072b459dc8826474b2af4c5c203d401d3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "storage-tree/backups/grounding-only",
+      "responseId": "resp_0214db3ce4d0ced7016a67c06c7d2c819aaa5241157d934385",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 297,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 320
+      },
+      "estimatedUsd": 0.000435,
+      "latencyMs": 584,
+      "rawOutputSha256": "5131dbca7f7ac689da5a1c1b58bd92d072b459dc8826474b2af4c5c203d401d3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/png-only",
+      "responseId": "resp_01b9246a56fe9185016a67c06d2ab4819881446c8aaf8c6ea4",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 389
+      },
+      "estimatedUsd": 0.000489,
+      "latencyMs": 872,
+      "rawOutputSha256": "51f69ab11ed275154b484b6933fadd14bb4eb722ce8ea58bd175466d785d3173"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/png-plus-grounding",
+      "responseId": "resp_06d515a47b189c8d016a67c06d3498819a90328bf5c60a63e5",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 991,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1012
+      },
+      "estimatedUsd": 0.001117,
+      "latencyMs": 1303,
+      "rawOutputSha256": "258fea48f12214410f8f979f8f24c6471e2d9696ae2fadf36ce60a7eeb8f3b7e"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "incident-map/largest/grounding-only",
+      "responseId": "resp_01b8f59c96208936016a67c06e7b50819888835c1f6a7af65d",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 694,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 24,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 718
+      },
+      "estimatedUsd": 0.000838,
+      "latencyMs": 615,
+      "rawOutputSha256": "0bfc9b74a5ecae617f08db8725ab35bc9ff9714491e643cb6710c85538500c7d"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/png-only",
+      "responseId": "resp_0cce46ccb069f7a9016a67c06e7c70819996c091da2eb1929f",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.000457,
+      "latencyMs": 865,
+      "rawOutputSha256": "57713459e8dc9d76ffd769bdeab211636e28289bd04732040ff557176131a96f"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/png-plus-grounding",
+      "responseId": "resp_0a4e8fc225ae063b016a67c06f5d988198a577d7ab5176cd73",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 989,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1004
+      },
+      "estimatedUsd": 0.001079,
+      "latencyMs": 655,
+      "rawOutputSha256": "57713459e8dc9d76ffd769bdeab211636e28289bd04732040ff557176131a96f"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "incident-map/count/grounding-only",
+      "responseId": "resp_0fb6d2d08110c6e6016a67c06f5a7081998af495a29ffc8b11",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 692,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 707
+      },
+      "estimatedUsd": 0.000782,
+      "latencyMs": 654,
+      "rawOutputSha256": "57713459e8dc9d76ffd769bdeab211636e28289bd04732040ff557176131a96f"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/png-only",
+      "responseId": "resp_061e45d414a2a271016a67c0700558819ba4dcf6a1ef011883",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 386
+      },
+      "estimatedUsd": 0.000476,
+      "latencyMs": 602,
+      "rawOutputSha256": "82a0f474f977156cdc2cb38abe0992d98f14cdf2d136c4f820cbf9bcc61373b1"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/png-plus-grounding",
+      "responseId": "resp_0338fad23e27d4bf016a67c07007088199b898c95bf9e15f72",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 559,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 580
+      },
+      "estimatedUsd": 0.000685,
+      "latencyMs": 736,
+      "rawOutputSha256": "65587e2cd4ae5cab44b4f6f934a0efc040ed33c3a514fb306ebae4207950e5e8"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/value/grounding-only",
+      "responseId": "resp_0ccace591723a879016a67c070c398819a8722bfdae2edb5e5",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 262,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 281
+      },
+      "estimatedUsd": 0.000376,
+      "latencyMs": 886,
+      "rawOutputSha256": "66ec984f75fcce61dcbc812ecf7fe618ed7917a11381e17aeb919d16cb37f612"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/png-only",
+      "responseId": "resp_0ba154d6992add0e016a67c070c17c819a88912dab81c73870",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 368,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 20,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 388
+      },
+      "estimatedUsd": 0.000488,
+      "latencyMs": 1197,
+      "rawOutputSha256": "5ed64282336dcb1c5ba87650a75b0fddd7f03b81a0cf69262846e7162cf5bb1a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/png-plus-grounding",
+      "responseId": "resp_0e7192f668d14d20016a67c071f6b48199abaec633a7c9f614",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 559,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 23,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 582
+      },
+      "estimatedUsd": 0.000697,
+      "latencyMs": 701,
+      "rawOutputSha256": "9242d26cbe64ba1e16898ad431b3dc65bbacdac88bd38a0a1aa8a45832381946"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "sla-gauge/maximum/grounding-only",
+      "responseId": "resp_060c2699c5cae6ef016a67c071f9408199aa7b204f69cb97d5",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 262,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 283
+      },
+      "estimatedUsd": 0.000388,
+      "latencyMs": 920,
+      "rawOutputSha256": "d0c9d91e3bc79bfd1d1618e809ea049706a9ad55d3f130f3bf759deeb094e3b0"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/png-only",
+      "responseId": "resp_0366dd6999481224016a67c072e60881989e465bdf01a1510b",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 15,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 382
+      },
+      "estimatedUsd": 0.000457,
+      "latencyMs": 799,
+      "rawOutputSha256": "efcba35e14732082a5e790b33de76bcff89418a04ba5a31c7d7002bbfac85d52"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/png-plus-grounding",
+      "responseId": "resp_09510efa0cf95c47016a67c072e5a8819889c09912664a2ab0",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 884,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 902
+      },
+      "estimatedUsd": 0.000992,
+      "latencyMs": 832,
+      "rawOutputSha256": "53eb447c645b500ce3cf4152992e02c96d721a682101397aa0e4098ddeaf69b3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/purchases/grounding-only",
+      "responseId": "resp_06b790224e4d9f2b016a67c073c384819bb69837c614241d04",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 587,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 18,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 605
+      },
+      "estimatedUsd": 0.000695,
+      "latencyMs": 725,
+      "rawOutputSha256": "53eb447c645b500ce3cf4152992e02c96d721a682101397aa0e4098ddeaf69b3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/png-only",
+      "responseId": "resp_027d2d42ca7a2e28016a67c073c0508199b6bd6b09bef75b7a",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 367,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 386
+      },
+      "estimatedUsd": 0.000481,
+      "latencyMs": 2414,
+      "rawOutputSha256": "a3bfb81b76092b3531f6c71ecc9cb21017cd97f78d1c3bc918c981a267895e05"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/png-plus-grounding",
+      "responseId": "resp_07773d11d8432eb6016a67c0762824819a811fdca67c8abc04",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 883,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 21,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 904
+      },
+      "estimatedUsd": 0.001009,
+      "latencyMs": 838,
+      "rawOutputSha256": "c0b02428c60234d33e4d0d347ad3c6741abe7369711de8be4112974e7faf44b4"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "conversion-funnel/stages/grounding-only",
+      "responseId": "resp_08da47d063f1b49e016a67c0762708819bba2c6cb83c223968",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 586,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 19,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 605
+      },
+      "estimatedUsd": 0.0007,
+      "latencyMs": 680,
+      "rawOutputSha256": "478c4a4c7da2c142e990688964e6e5a62235d8a57a9d8a3ca4e79a7d2b29c929"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/png-only",
+      "responseId": "resp_00ad3da57439c6a2016a67c077014c8199aa991cb8ab416763",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 370,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 398
+      },
+      "estimatedUsd": 0.000538,
+      "latencyMs": 901,
+      "rawOutputSha256": "3a4ba5d60d8bd29ccae6c247f919c3a54cd039327d6d2314fbf99de359416f50"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/png-plus-grounding",
+      "responseId": "resp_0fd6831d31b40479016a67c076ff9c8199af63bff9859e4cbf",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 653,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 681
+      },
+      "estimatedUsd": 0.000821,
+      "latencyMs": 1097,
+      "rawOutputSha256": "9d816351d2918a194334f4b04295830b941c93a77d064e761547fdc126976a7e"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "galton-values/range/grounding-only",
+      "responseId": "resp_03049c0705835ef3016a67c0784e2881999818b71b46b783d3",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 356,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 384
+      },
+      "estimatedUsd": 0.000524,
+      "latencyMs": 1034,
+      "rawOutputSha256": "9d816351d2918a194334f4b04295830b941c93a77d064e761547fdc126976a7e"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/png-only",
+      "responseId": "resp_0972c66656395805016a67c0781b248199bbf5b517cc23a314",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 369,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 28,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 397
+      },
+      "estimatedUsd": 0.000537,
+      "latencyMs": 894,
+      "rawOutputSha256": "36e9c0d64862a27a49a62c88085410809dacf3c0ded21616e3ab73dc215f262c"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/png-plus-grounding",
+      "responseId": "resp_0652e24733ec7bc0016a67c07934688199b279610fd02f7531",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 652,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 668
+      },
+      "estimatedUsd": 0.000748,
+      "latencyMs": 980,
+      "rawOutputSha256": "4fc5fa4367adf5d671f36647483094920a174a9e10a32538442aafeb73c0946c"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "grounding",
+      "fixtureId": "galton-values/count/grounding-only",
+      "responseId": "resp_0a04a32558f4e6ae016a67c0792554819bab5fae53e8e6faf2",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 355,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 0
+        },
+        "output_tokens": 16,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 371
+      },
+      "estimatedUsd": 0.000451,
+      "latencyMs": 737,
+      "rawOutputSha256": "4fc5fa4367adf5d671f36647483094920a174a9e10a32538442aafeb73c0946c"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "line-push",
+      "responseId": "resp_0ad2850a98f9310b016a67c07a26c4819aad3f65084cd95173",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27328,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27325
+        },
+        "output_tokens": 76,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27404
+      },
+      "estimatedUsd": 0.0031915,
+      "latencyMs": 1338,
+      "rawOutputSha256": "adbe5eb93fae232f64471799bd44d15f845a3d8fc6eacd5a2e895d29d9861732"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "scatter-push",
+      "responseId": "resp_05d40a0589929a21016a67c07a2a84819a835589ca89e49171",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27334,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27331
+        },
+        "output_tokens": 135,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27469
+      },
+      "estimatedUsd": 0.0035461,
+      "latencyMs": 1452,
+      "rawOutputSha256": "6c7b1155823d8695afef1d6670766e7a45e27571ebd32ba406f748f1a12a6967"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "bubble-static",
+      "responseId": "resp_054157c08b3d9ad8016a67c07ba2b081999de9901dbf26f6c3",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27279,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27276
+        },
+        "output_tokens": 159,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27438
+      },
+      "estimatedUsd": 0.0036846,
+      "latencyMs": 1823,
+      "rawOutputSha256": "987c556777683533d03c2cbad1fa5a278f8bfe68c20becc86f266089abfd2b3b"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "gauge-static",
+      "responseId": "resp_0be64d27c33914f3016a67c07ba490819a9083a4b53cdfc0b5",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27281,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27278
+        },
+        "output_tokens": 90,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27371
+      },
+      "estimatedUsd": 0.0032708,
+      "latencyMs": 1345,
+      "rawOutputSha256": "2768e6be348aa0e12f3b0ab8f1ec948ad657495c4a37937d3b97e3f90dbf63a4"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "symbol-map-static",
+      "responseId": "resp_0335f03b962a02bf016a67c07d7448819ba35434b4a19e3fc0",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27294,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27291
+        },
+        "output_tokens": 102,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27396
+      },
+      "estimatedUsd": 0.0033441,
+      "latencyMs": 1309,
+      "rawOutputSha256": "ad24651613cc32bb1d985f9b720d7709628bca2d19c4ffee0240543e78d278c4"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "galton-static",
+      "responseId": "resp_01e05b37b956a466016a67c07d76408199bebfe370a3bac835",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27260,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27257
+        },
+        "output_tokens": 62,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27322
+      },
+      "estimatedUsd": 0.0031007,
+      "latencyMs": 1486,
+      "rawOutputSha256": "991ca987758a3d66c30df0a4dd882b4635a3245c7651c0c03e15f5cc707ab4a9"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "resolvedModel": "gpt-5.6-luna",
+      "suite": "first-try",
+      "fixtureId": "unit-pile-push",
+      "responseId": "resp_05c1475431025edb016a67c07eee30819a83736b420572bb87",
+      "status": "completed",
+      "usage": {
+        "input_tokens": 27325,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 27322
+        },
+        "output_tokens": 54,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 27379
+      },
+      "estimatedUsd": 0.0030592,
+      "latencyMs": 1164,
+      "rawOutputSha256": "7d33cb5803e4071baf8ff03cd5e7bcf04d43b41e1b104dd5d94091b2341df0e9"
+    }
+  ],
+  "estimatedUsd": 0.5486552,
+  "requestCount": 201
+}

--- a/evals/reports/openai-gpt-5.6-2026-07-27/README.md
+++ b/evals/reports/openai-gpt-5.6-2026-07-27/README.md
@@ -108,15 +108,16 @@ locked rate table, not an OpenAI billing ledger.
 
 ## Evidence-led follow-up
 
-1. Inspect `buildReaderGrounding` for the answerable lookups lost in the
-   combined and payload-only conditions, especially value, hierarchy, and
-   physics projections. Revise the payload before making a reception claim.
-2. Add schema behavior metadata and AI-facing examples for serializable
-   formatting, push data, geo inputs, physics modes, and value-chart selection;
-   then publish a new fixture revision before rerunning.
-3. Add repeated trials only after a payload revision. This single-response
-   baseline is sufficient to find contract failures, not to estimate small
-   model differences precisely.
+The payload and generation-contract revisions were tested in three repeated,
+targeted trials after merge. The follow-up preserves this baseline and reports
+only the changed cases:
+
+- [post-merge repeated evaluation](../openai-follow-up/README.md)
+
+The repeat recovered every targeted answerable lookup when grounding was
+present and resolved six of the seven generation fixtures across every model
+and trial. The remaining `gauge-static` misses are retained as failures rather
+than repaired in place.
 
 The per-model compatibility reports are the scored source of truth:
 

--- a/package.json
+++ b/package.json
@@ -310,7 +310,7 @@
     "eval:ai": "node scripts/run-ai-evals.mjs",
     "eval:ai:openai": "node scripts/run-openai-ai-evals.mjs",
     "eval:ai:trials": "node scripts/summarize-openai-ai-eval-trials.mjs",
-    "test:ai-evals": "node --test scripts/ai-eval-scoring.test.mjs scripts/run-openai-ai-evals.test.mjs scripts/summarize-openai-ai-eval-trials.test.mjs",
+    "test:ai-evals": "node --test scripts/ai-eval-scoring.test.mjs scripts/ai-eval-report-summary.test.mjs scripts/run-openai-ai-evals.test.mjs scripts/summarize-openai-ai-eval-trials.test.mjs",
     "test:ai:openai": "node --test scripts/run-openai-ai-evals.test.mjs",
     "prepare:ai-evals": "node scripts/prepare-ai-evals.mjs",
     "check:ai-contracts": "node scripts/generate-ai-behavior-contracts.mjs --check",

--- a/scripts/ai-eval-report-summary.test.mjs
+++ b/scripts/ai-eval-report-summary.test.mjs
@@ -77,12 +77,12 @@ test("targeted grounding summaries count only submitted scored rows", () => {
         passed: false,
         answerable: true
       }
-    ],
-    true
+    ]
   )
 
   assert.equal(summary.trials, 2)
   assert.equal(summary.availableTrials, 4)
+  assert.equal(summary.missing, 2)
   assert.deepEqual(summary.conditions["png-only"], {
     trials: 1,
     availableTrials: 2,
@@ -93,4 +93,36 @@ test("targeted grounding summaries count only submitted scored rows", () => {
     unanswerableTrials: 0
   })
   assert.equal(summary.conditions["grounding-only"].unanswerableTrials, 1)
+})
+
+test("grounding trials stay consistent with their conditions before results land", () => {
+  const summary = summarizeGroundingRows(
+    ["png-only", "grounding-only"],
+    [
+      {
+        condition: "png-only",
+        status: "pending",
+        passed: null,
+        answerable: true
+      },
+      {
+        condition: "grounding-only",
+        status: "pending",
+        passed: null,
+        answerable: false
+      }
+    ]
+  )
+
+  assert.equal(summary.trials, 0)
+  assert.equal(
+    summary.trials,
+    Object.values(summary.conditions).reduce(
+      (total, condition) => total + condition.trials,
+      0
+    )
+  )
+  assert.equal(summary.availableTrials, 2)
+  assert.equal(summary.missing, 2)
+  assert.equal(summary.conditions["png-only"].accuracy, null)
 })

--- a/scripts/ai-eval-report-summary.test.mjs
+++ b/scripts/ai-eval-report-summary.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import {
+  summarizeFirstTryRows,
+  summarizeGroundingRows
+} from "./lib/ai-eval-report-summary.mjs"
+
+test("targeted first-try summaries exclude omitted model fixtures", () => {
+  const rows = [
+    {
+      kind: "generation",
+      mode: "static",
+      source: "model-submission",
+      firstAttempt: { passed: true },
+      postRepair: null
+    },
+    {
+      kind: "generation",
+      mode: "push",
+      source: "model-submission",
+      firstAttempt: { passed: false },
+      postRepair: { passed: true }
+    },
+    {
+      kind: "generation",
+      mode: "static",
+      source: "committed-reference",
+      firstAttempt: { passed: false },
+      postRepair: null
+    },
+    {
+      kind: "guard",
+      mode: "static",
+      source: "committed-reference",
+      firstAttempt: { passed: true },
+      postRepair: null
+    }
+  ]
+
+  assert.deepEqual(summarizeFirstTryRows(rows, true), {
+    generationFixtures: 2,
+    availableGenerationFixtures: 3,
+    guardFixtures: 1,
+    staticFixtures: 1,
+    pushFixtures: 1,
+    firstAttemptPassed: 1,
+    postRepairAttempted: 1,
+    postRepairPassed: 1
+  })
+})
+
+test("targeted grounding summaries count only submitted scored rows", () => {
+  const summary = summarizeGroundingRows(
+    ["png-only", "grounding-only"],
+    [
+      {
+        condition: "png-only",
+        status: "scored",
+        passed: true,
+        answerable: true
+      },
+      {
+        condition: "png-only",
+        status: "missing",
+        passed: false,
+        answerable: false
+      },
+      {
+        condition: "grounding-only",
+        status: "scored",
+        passed: true,
+        answerable: false
+      },
+      {
+        condition: "grounding-only",
+        status: "missing",
+        passed: false,
+        answerable: true
+      }
+    ],
+    true
+  )
+
+  assert.equal(summary.trials, 2)
+  assert.equal(summary.availableTrials, 4)
+  assert.deepEqual(summary.conditions["png-only"], {
+    trials: 1,
+    availableTrials: 2,
+    missing: 1,
+    scored: 1,
+    passed: 1,
+    accuracy: 1,
+    unanswerableTrials: 0
+  })
+  assert.equal(summary.conditions["grounding-only"].unanswerableTrials, 1)
+})

--- a/scripts/lib/ai-eval-report-summary.mjs
+++ b/scripts/lib/ai-eval-report-summary.mjs
@@ -21,7 +21,7 @@ export function summarizeFirstTryRows(rows, hasSubmission) {
   }
 }
 
-export function summarizeGroundingRows(conditions, rows, hasSubmission) {
+export function summarizeGroundingRows(conditions, rows) {
   const conditionSummary = Object.fromEntries(
     conditions.map((condition) => {
       const available = rows.filter((entry) => entry.condition === condition)
@@ -45,14 +45,15 @@ export function summarizeGroundingRows(conditions, rows, hasSubmission) {
     })
   )
 
+  const trials = Object.values(conditionSummary).reduce(
+    (total, condition) => total + condition.trials,
+    0
+  )
+
   return {
-    trials: hasSubmission
-      ? Object.values(conditionSummary).reduce(
-          (total, condition) => total + condition.trials,
-          0
-        )
-      : rows.length,
+    trials,
     availableTrials: rows.length,
+    missing: rows.length - trials,
     conditions: conditionSummary
   }
 }

--- a/scripts/lib/ai-eval-report-summary.mjs
+++ b/scripts/lib/ai-eval-report-summary.mjs
@@ -1,0 +1,58 @@
+export function summarizeFirstTryRows(rows, hasSubmission) {
+  const generationRows = rows.filter(({ kind }) => kind === "generation")
+  const reportedRows = hasSubmission
+    ? generationRows.filter(({ source }) => source === "model-submission")
+    : generationRows
+
+  return {
+    generationFixtures: reportedRows.length,
+    availableGenerationFixtures: generationRows.length,
+    guardFixtures: rows.length - generationRows.length,
+    staticFixtures: reportedRows.filter(({ mode }) => mode === "static").length,
+    pushFixtures: reportedRows.filter(({ mode }) => mode === "push").length,
+    firstAttemptPassed: reportedRows.filter(
+      ({ firstAttempt }) => firstAttempt.passed
+    ).length,
+    postRepairAttempted: reportedRows.filter(({ postRepair }) => postRepair)
+      .length,
+    postRepairPassed: reportedRows.filter(
+      ({ postRepair }) => postRepair?.passed
+    ).length
+  }
+}
+
+export function summarizeGroundingRows(conditions, rows, hasSubmission) {
+  const conditionSummary = Object.fromEntries(
+    conditions.map((condition) => {
+      const available = rows.filter((entry) => entry.condition === condition)
+      const scored = available.filter((entry) => entry.status === "scored")
+      return [
+        condition,
+        {
+          trials: scored.length,
+          availableTrials: available.length,
+          missing: available.length - scored.length,
+          scored: scored.length,
+          passed: scored.filter(({ passed }) => passed).length,
+          accuracy:
+            scored.length > 0
+              ? scored.filter(({ passed }) => passed).length / scored.length
+              : null,
+          unanswerableTrials: scored.filter(({ answerable }) => !answerable)
+            .length
+        }
+      ]
+    })
+  )
+
+  return {
+    trials: hasSubmission
+      ? Object.values(conditionSummary).reduce(
+          (total, condition) => total + condition.trials,
+          0
+        )
+      : rows.length,
+    availableTrials: rows.length,
+    conditions: conditionSummary
+  }
+}

--- a/scripts/run-ai-evals.mjs
+++ b/scripts/run-ai-evals.mjs
@@ -10,8 +10,12 @@ import { renderChartWithEvidence } from "semiotic/server"
 import Ajv2020 from "ajv/dist/2020.js"
 import {
   groundingScoringRevision,
-  scoreGroundingAnswer,
+  scoreGroundingAnswer
 } from "./ai-eval-scoring.mjs"
+import {
+  summarizeFirstTryRows,
+  summarizeGroundingRows
+} from "./lib/ai-eval-report-summary.mjs"
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 const readJson = async (path) => JSON.parse(await readFile(path, "utf8"))
@@ -40,7 +44,7 @@ const publicTools = new Set([
   "improveChart",
   "explainChart",
   "auditChart",
-  "getChartSchema",
+  "getChartSchema"
 ])
 
 const generationFixtureIds = firstTry.fixtures
@@ -84,7 +88,7 @@ function validateSubmission(schema, submission, label) {
   const ajv = new Ajv2020({
     allErrors: true,
     strict: false,
-    validateFormats: false,
+    validateFormats: false
   })
   const validate = ajv.compile(schema)
   if (validate(submission)) return
@@ -118,8 +122,8 @@ function mergedProposal(fixture, proposal) {
     ...proposal,
     props: {
       ...proposal.props,
-      data: [...data, ...fixture.push.rows],
-    },
+      data: [...data, ...fixture.push.rows]
+    }
   }
 }
 
@@ -128,16 +132,15 @@ function scoreProposal(fixture, proposal) {
     const candidate = mergedProposal(fixture, proposal)
     const result = prepareChart(candidate, {
       data: candidate?.props?.data,
-      render: (component, props) =>
-        renderChartWithEvidence(component, props),
+      render: (component, props) => renderChartWithEvidence(component, props)
     })
     const actual = {
       validated: result.validation.valid,
       renderProven: Boolean(
         result.validation.valid &&
         result.evidence &&
-          !result.evidence.empty &&
-          result.evidence.markCount > 0
+        !result.evidence.empty &&
+        result.evidence.markCount > 0
       ),
       noErrorDiagnostics: !result.diagnostics.some(
         ({ severity }) => severity === "error"
@@ -146,9 +149,9 @@ function scoreProposal(fixture, proposal) {
       empty: result.evidence?.empty ?? null,
       diagnostics: result.diagnostics.map(({ code, severity }) => ({
         code,
-        severity,
+        severity
       })),
-      repairStatus: result.repair?.status ?? null,
+      repairStatus: result.repair?.status ?? null
     }
     const checks = Object.entries(fixture.expect)
       .filter(([key]) =>
@@ -166,7 +169,7 @@ function scoreProposal(fixture, proposal) {
       diagnostics: [],
       repairStatus: null,
       error: error instanceof Error ? error.message : String(error),
-      passed: fixture.expect.validated === false,
+      passed: fixture.expect.validated === false
     }
   }
 }
@@ -176,16 +179,8 @@ const firstTrySubmission = firstTryResultsPath
   ? await readJson(resolve(firstTryResultsPath))
   : null
 if (firstTrySubmission) {
-  validateSubmission(
-    firstTryResultSchema,
-    firstTrySubmission,
-    "First-try"
-  )
-  validateMetadata(
-    firstTrySubmission,
-    firstTry.fixtureRevision,
-    "First-try"
-  )
+  validateSubmission(firstTryResultSchema, firstTrySubmission, "First-try")
+  validateMetadata(firstTrySubmission, firstTry.fixtureRevision, "First-try")
 }
 const submittedProposals = uniqueSubmissionMap(
   firstTrySubmission?.results ?? [],
@@ -207,7 +202,7 @@ const firstTryRaw = firstTry.fixtures.map((fixture) => {
           diagnostics: [],
           repairStatus: null,
           error: "Missing model submission",
-          passed: false,
+          passed: false
         }
       : scoreProposal(fixture, submitted?.proposal ?? fixture.proposal)
   const postRepair = submitted?.repairProposal
@@ -220,10 +215,9 @@ const firstTryRaw = firstTry.fixtures.map((fixture) => {
     mode: fixture.mode,
     source: submitted ? "model-submission" : "committed-reference",
     firstAttempt,
-    postRepair,
+    postRepair
   }
 })
-const generationRows = firstTryRaw.filter(({ kind }) => kind === "generation")
 if (!firstTrySubmission) {
   const failedReferences = firstTryRaw.filter(
     ({ firstAttempt }) => !firstAttempt.passed
@@ -247,7 +241,7 @@ const groundingCases = grounding.charts.flatMap((chart) =>
       chartId: chart.id,
       questionId: question.id,
       condition,
-      expected: question.expected,
+      expected: question.expected
     }))
   )
 )
@@ -272,9 +266,7 @@ for (const chart of grounding.charts) {
     bytes.byteLength !== groundingManifest.jobs.bytes ||
     hash !== groundingManifest.jobs.sha256
   ) {
-    throw new Error(
-      `Grounding artifact drift: ${groundingManifest.jobs.path}`
-    )
+    throw new Error(`Grounding artifact drift: ${groundingManifest.jobs.path}`)
   }
 }
 
@@ -283,21 +275,11 @@ const groundingSubmission = groundingResultsPath
   ? await readJson(resolve(groundingResultsPath))
   : null
 if (groundingSubmission) {
-  validateSubmission(
-    groundingResultSchema,
-    groundingSubmission,
-    "Grounding"
-  )
-  validateMetadata(
-    groundingSubmission,
-    grounding.fixtureRevision,
-    "Grounding"
-  )
+  validateSubmission(groundingResultSchema, groundingSubmission, "Grounding")
+  validateMetadata(groundingSubmission, grounding.fixtureRevision, "Grounding")
 }
 const groundingCaseIds = new Set(
-  groundingCases.map(
-    ({ fixtureId, condition }) => `${fixtureId}/${condition}`
-  )
+  groundingCases.map(({ fixtureId, condition }) => `${fixtureId}/${condition}`)
 )
 const submittedAnswers = uniqueSubmissionMap(
   groundingSubmission?.responses ?? [],
@@ -317,28 +299,18 @@ const groundingRaw = groundingCases.map((entry) => {
       entry.expected,
       answer,
       Boolean(groundingSubmission)
-    ),
+    )
   }
 })
 
-const conditionSummary = Object.fromEntries(
-  grounding.conditions.map((condition) => {
-    const rows = groundingRaw.filter((entry) => entry.condition === condition)
-    const scored = rows.filter((entry) => entry.status !== "pending")
-    return [
-      condition,
-      {
-        trials: rows.length,
-        scored: scored.length,
-        passed: scored.filter(({ passed }) => passed).length,
-        accuracy:
-          scored.length > 0
-            ? scored.filter(({ passed }) => passed).length / scored.length
-            : null,
-        unanswerableTrials: rows.filter(({ answerable }) => !answerable).length,
-      },
-    ]
-  })
+const firstTrySummary = summarizeFirstTryRows(
+  firstTryRaw,
+  Boolean(firstTrySubmission)
+)
+const groundingSummary = summarizeGroundingRows(
+  grounding.conditions,
+  groundingRaw,
+  Boolean(groundingSubmission)
 )
 
 const report = {
@@ -353,40 +325,25 @@ const report = {
       negativeCases: discovery.cases.filter(
         (entry) => entry.expectedTools.length === 0
       ).length,
-      publicTools: [...publicTools],
+      publicTools: [...publicTools]
     },
-    raw: discovery.cases,
+    raw: discovery.cases
   },
   firstTry: {
     metadata: firstTrySubmission?.metadata ?? {
       fixtureRevision: firstTry.fixtureRevision,
-      source: "committed-reference",
+      source: "committed-reference"
     },
-    summary: {
-      generationFixtures: generationRows.length,
-      guardFixtures: firstTryRaw.length - generationRows.length,
-      staticFixtures: generationRows.filter(({ mode }) => mode === "static")
-        .length,
-      pushFixtures: generationRows.filter(({ mode }) => mode === "push")
-        .length,
-      firstAttemptPassed: generationRows.filter(
-        ({ firstAttempt }) => firstAttempt.passed
-      ).length,
-      postRepairAttempted: generationRows.filter(({ postRepair }) => postRepair)
-        .length,
-      postRepairPassed: generationRows.filter(
-        ({ postRepair }) => postRepair?.passed
-      ).length,
-    },
-    raw: firstTryRaw,
+    summary: firstTrySummary,
+    raw: firstTryRaw
   },
   grounding: {
     metadata: {
       ...(groundingSubmission?.metadata ?? {
         fixtureRevision: grounding.fixtureRevision,
-        status: "awaiting-model-results",
+        status: "awaiting-model-results"
       }),
-      scoringRevision: groundingScoringRevision,
+      scoringRevision: groundingScoringRevision
     },
     summary: {
       charts: grounding.charts.length,
@@ -394,11 +351,10 @@ const report = {
         (total, chart) => total + chart.questions.length,
         0
       ),
-      trials: groundingRaw.length,
-      conditions: conditionSummary,
+      ...groundingSummary
     },
-    raw: groundingRaw,
-  },
+    raw: groundingRaw
+  }
 }
 
 const outputPath = argValue("output")
@@ -409,7 +365,7 @@ process.stderr.write(
   [
     `first-try ${report.firstTry.summary.firstAttemptPassed}/${report.firstTry.summary.generationFixtures}`,
     `grounding ${report.grounding.summary.trials} trials`,
-    groundingSubmission ? "scored" : "awaiting model results",
+    groundingSubmission ? "scored" : "awaiting model results"
   ].join(" · ") + "\n"
 )
 process.stdout.write(`${JSON.stringify(report, null, 2)}\n`)

--- a/scripts/run-ai-evals.mjs
+++ b/scripts/run-ai-evals.mjs
@@ -309,8 +309,7 @@ const firstTrySummary = summarizeFirstTryRows(
 )
 const groundingSummary = summarizeGroundingRows(
   grounding.conditions,
-  groundingRaw,
-  Boolean(groundingSubmission)
+  groundingRaw
 )
 
 const report = {
@@ -364,7 +363,9 @@ if (outputPath) {
 process.stderr.write(
   [
     `first-try ${report.firstTry.summary.firstAttemptPassed}/${report.firstTry.summary.generationFixtures}`,
-    `grounding ${report.grounding.summary.trials} trials`,
+    groundingSubmission
+      ? `grounding ${report.grounding.summary.trials} trials`
+      : `grounding ${report.grounding.summary.availableTrials} trials`,
     groundingSubmission ? "scored" : "awaiting model results"
   ].join(" · ") + "\n"
 )


### PR DESCRIPTION
This pull request enhances the model evaluation example by adding a new section that documents and visualizes repeated follow-up trials after the initial GPT-5.6 compatibility baseline. The changes improve both the data model and the UI to clarify the distinction between the original baseline and the targeted follow-up, update the run ledger and summary statistics, and ensure the test suite covers the new follow-up content.

**Major additions and improvements:**

**1. Follow-up trial data and reporting**
- Added `FOLLOW_UP_RUN`, `FOLLOW_UP_FIRST_TRY_FIXTURES`, `FOLLOW_UP_FIRST_TRY_MODELS`, and related constants to `modelEvaluationRun.js` to represent the repeated follow-up run and aggregate totals for requests and cost.
- Updated the UI in `ModelEvaluationExamplePage.jsx` to include a new "Post-merge repeated trials" section with charts and summaries for the follow-up run, including repeated answerable outcomes and first-attempt generation results. [[1]](diffhunk://#diff-37266e76f240869a6cf0152e9aa1f251be574b334d50c57709118813234a8ebaR98-R234) [[2]](diffhunk://#diff-37266e76f240869a6cf0152e9aa1f251be574b334d50c57709118813234a8ebaL207-R327)
- The run ledger and summary now show both baseline and follow-up statistics, including total recorded requests and costs. [[1]](diffhunk://#diff-37266e76f240869a6cf0152e9aa1f251be574b334d50c57709118813234a8ebaL58-R79) [[2]](diffhunk://#diff-37266e76f240869a6cf0152e9aa1f251be574b334d50c57709118813234a8ebaL397-R520)

**2. UI and content clarity**
- Improved section headings, descriptions, and margin notes throughout the page to clarify the difference between the original baseline and the repeated follow-up, and to explain what the repeat establishes. [[1]](diffhunk://#diff-37266e76f240869a6cf0152e9aa1f251be574b334d50c57709118813234a8ebaL207-R327) [[2]](diffhunk://#diff-37266e76f240869a6cf0152e9aa1f251be574b334d50c57709118813234a8ebaL329-R433) [[3]](diffhunk://#diff-37266e76f240869a6cf0152e9aa1f251be574b334d50c57709118813234a8ebaL341-R444) [[4]](diffhunk://#diff-37266e76f240869a6cf0152e9aa1f251be574b334d50c57709118813234a8ebaL367-R478) [[5]](diffhunk://#diff-37266e76f240869a6cf0152e9aa1f251be574b334d50c57709118813234a8ebaL386-R490)
- Updated the summary and conclusion to reflect the new findings from the repeated trials and to highlight the separation of repaired contracts from residual risks.

**3. Test coverage**
- Updated tests in `ModelEvaluationExamplePage.test.jsx` to check for the presence of follow-up run data, the new chart, and updated statistics in the UI. [[1]](diffhunk://#diff-c4f4ae65cc20c42cfe82838ae6063b27bf671644141cc1bc0caf0aa026ec7ca7L14-R16) [[2]](diffhunk://#diff-c4f4ae65cc20c42cfe82838ae6063b27bf671644141cc1bc0caf0aa026ec7ca7L36-R49) [[3]](diffhunk://#diff-c4f4ae65cc20c42cfe82838ae6063b27bf671644141cc1bc0caf0aa026ec7ca7R58-R59)

**4. Documentation**
- Updated the `CHANGELOG.md` to describe the new high-touch evaluation example and how the repeated follow-up is now presented and interpreted.

These changes make the model evaluation example more transparent and informative by showing both the original baseline and targeted follow-up results, improving clarity for readers and users.