### PR TITLE
Fix tooltip and SSR rendering parity gaps

### DIFF
--- a/.probe/probe.test.tsx
+++ b/.probe/probe.test.tsx
@@ -1,21 +1,22 @@
-import { describe, it } from "vitest"
+import { describe, expect, it } from "vitest"
 import { renderChart } from "../src/components/semiotic-server"
 
 describe("probe", () => {
-  it("bar", () => {
+  it("serializes concrete font-size attributes for ordinal axis text", () => {
     const svg = renderChart("BarChart", {
       data: [{ c: "Kafka", v: 80 }, { c: "Flink", v: 60 }],
       categoryAccessor: "c", valueAccessor: "v",
     })
-    console.log("BAR FONT-SIZE COUNT:", (svg.match(/font-size/g) || []).length)
-    ;(svg.match(/<text[^>]*>[^<]*<\/text>/g) || []).slice(0, 12).forEach(t => console.log(t))
+    expect(svg).toContain('font-size="12"')
+    expect(svg).toContain(">Kafka<")
   })
-  it("line", () => {
+  it("serializes concrete font-size attributes for XY ticks and labels", () => {
     const svg = renderChart("LineChart", {
       data: [{ x: 1, y: 2 }, { x: 2, y: 5 }],
       xAccessor: "x", yAccessor: "y", xLabel: "Time", yLabel: "Val",
     })
-    console.log("LINE FONT-SIZE COUNT:", (svg.match(/font-size/g) || []).length)
-    ;(svg.match(/<text[^>]*>[^<]*<\/text>/g) || []).slice(0, 10).forEach(t => console.log(t))
+    expect(svg).toContain('font-size="12"')
+    expect(svg).toContain(">Time<")
+    expect(svg).toContain(">Val<")
   })
 })

--- a/.probe/probe.test.tsx
+++ b/.probe/probe.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it } from "vitest"
+import { renderChart } from "../src/components/semiotic-server"
+
+describe("probe", () => {
+  it("bar", () => {
+    const svg = renderChart("BarChart", {
+      data: [{ c: "Kafka", v: 80 }, { c: "Flink", v: 60 }],
+      categoryAccessor: "c", valueAccessor: "v",
+    })
+    console.log("BAR FONT-SIZE COUNT:", (svg.match(/font-size/g) || []).length)
+    ;(svg.match(/<text[^>]*>[^<]*<\/text>/g) || []).slice(0, 12).forEach(t => console.log(t))
+  })
+  it("line", () => {
+    const svg = renderChart("LineChart", {
+      data: [{ x: 1, y: 2 }, { x: 2, y: 5 }],
+      xAccessor: "x", yAccessor: "y", xLabel: "Time", yLabel: "Val",
+    })
+    console.log("LINE FONT-SIZE COUNT:", (svg.match(/font-size/g) || []).length)
+    ;(svg.match(/<text[^>]*>[^<]*<\/text>/g) || []).slice(0, 10).forEach(t => console.log(t))
+  })
+})

--- a/README.md
+++ b/README.md
@@ -444,22 +444,22 @@ Method: fresh `npm pack --ignore-scripts` tarball → temporary consumer → min
 | Public named import | Runtime | gzip cold-consumer bundle |
 |---|---:|---:|
 | `import { LineChart } from "semiotic"` | browser | **153.1 KiB** |
-| `import { LineChart } from "semiotic/xy"` | browser | **153.2 KiB** |
-| `import { BarChart } from "semiotic/ordinal"` | browser | **123.5 KiB** |
-| `import { SankeyDiagram } from "semiotic/network"` | browser | **127.9 KiB** |
-| `import { RealtimeLineChart } from "semiotic/realtime"` | browser | **122.9 KiB** |
-| `import { RingBuffer } from "semiotic/realtime/core"` | browser | **170.3 KiB** |
+| `import { LineChart } from "semiotic/xy"` | browser | **153.3 KiB** |
+| `import { BarChart } from "semiotic/ordinal"` | browser | **123.6 KiB** |
+| `import { SankeyDiagram } from "semiotic/network"` | browser | **128.0 KiB** |
+| `import { RealtimeLineChart } from "semiotic/realtime"` | browser | **123.0 KiB** |
+| `import { RingBuffer } from "semiotic/realtime/core"` | browser | **170.4 KiB** |
 | `import { useStreamStatus } from "semiotic/realtime/react"` | browser | **0.6 KiB** |
 | `import { GaltonBoardChart } from "semiotic/physics"` | browser | **134.2 KiB** |
 | `import { MATTER_PHYSICS_CAPABILITIES } from "semiotic/physics/matter"` | browser | **0.2 KiB** |
 | `import { RAPIER_PHYSICS_CAPABILITIES } from "semiotic/physics/rapier"` | browser | **0.2 KiB** |
-| `import { renderChart } from "semiotic/server"` | node | **269.5 KiB** |
-| `import { generateFrameSVGs } from "semiotic/server/edge"` | node | **164.5 KiB** |
-| `import { renderToImage } from "semiotic/server/node"` | node | **270.0 KiB** |
-| `import { suggestCharts } from "semiotic/ai"` | browser | **192.8 KiB** |
+| `import { renderChart } from "semiotic/server"` | node | **269.7 KiB** |
+| `import { generateFrameSVGs } from "semiotic/server/edge"` | node | **164.6 KiB** |
+| `import { renderToImage } from "semiotic/server/node"` | node | **270.2 KiB** |
+| `import { suggestCharts } from "semiotic/ai"` | browser | **192.9 KiB** |
 | `import { suggestCharts } from "semiotic/ai/core"` | browser | **36.3 KiB** |
 | `import { bin } from "semiotic/data"` | browser | **0.4 KiB** |
-| `import { ChoroplethMap } from "semiotic/geo"` | browser | **108.5 KiB** |
+| `import { ChoroplethMap } from "semiotic/geo"` | browser | **108.6 KiB** |
 | `import { createRoughRenderMode } from "semiotic/rough"` | browser | **3.4 KiB** |
 | `import { resolveThemePreset } from "semiotic/themes"` | browser | **3.4 KiB** |
 | `import { resolveThemePreset } from "semiotic/themes/core"` | browser | **3.4 KiB** |

--- a/benchmarks/setup/cold-consumer-imports.json
+++ b/benchmarks/setup/cold-consumer-imports.json
@@ -44,8 +44,8 @@
       "importPath": "semiotic",
       "symbol": "LineChart",
       "platform": "browser",
-      "rawBytes": 488979,
-      "gzipBytes": 156729,
+      "rawBytes": 489373,
+      "gzipBytes": 156819,
       "packedPackageInputFiles": 51
     },
     {
@@ -53,8 +53,8 @@
       "importPath": "semiotic/xy",
       "symbol": "LineChart",
       "platform": "browser",
-      "rawBytes": 488932,
-      "gzipBytes": 156892,
+      "rawBytes": 489326,
+      "gzipBytes": 156986,
       "packedPackageInputFiles": 31
     },
     {
@@ -62,8 +62,8 @@
       "importPath": "semiotic/ordinal",
       "symbol": "BarChart",
       "platform": "browser",
-      "rawBytes": 410679,
-      "gzipBytes": 126495,
+      "rawBytes": 410877,
+      "gzipBytes": 126547,
       "packedPackageInputFiles": 24
     },
     {
@@ -71,8 +71,8 @@
       "importPath": "semiotic/network",
       "symbol": "SankeyDiagram",
       "platform": "browser",
-      "rawBytes": 402840,
-      "gzipBytes": 130982,
+      "rawBytes": 403501,
+      "gzipBytes": 131079,
       "packedPackageInputFiles": 25
     },
     {
@@ -80,8 +80,8 @@
       "importPath": "semiotic/realtime",
       "symbol": "RealtimeLineChart",
       "platform": "browser",
-      "rawBytes": 388894,
-      "gzipBytes": 125859,
+      "rawBytes": 389090,
+      "gzipBytes": 125904,
       "packedPackageInputFiles": 27
     },
     {
@@ -89,8 +89,8 @@
       "importPath": "semiotic/realtime/core",
       "symbol": "RingBuffer",
       "platform": "browser",
-      "rawBytes": 548218,
-      "gzipBytes": 174337,
+      "rawBytes": 548879,
+      "gzipBytes": 174442,
       "packedPackageInputFiles": 14
     },
     {
@@ -107,8 +107,8 @@
       "importPath": "semiotic/physics",
       "symbol": "GaltonBoardChart",
       "platform": "browser",
-      "rawBytes": 413241,
-      "gzipBytes": 137399,
+      "rawBytes": 413439,
+      "gzipBytes": 137452,
       "packedPackageInputFiles": 16
     },
     {
@@ -134,8 +134,8 @@
       "importPath": "semiotic/server",
       "symbol": "renderChart",
       "platform": "node",
-      "rawBytes": 871485,
-      "gzipBytes": 276009,
+      "rawBytes": 872560,
+      "gzipBytes": 276218,
       "packedPackageInputFiles": 4
     },
     {
@@ -143,8 +143,8 @@
       "importPath": "semiotic/server/edge",
       "symbol": "generateFrameSVGs",
       "platform": "node",
-      "rawBytes": 524436,
-      "gzipBytes": 168402,
+      "rawBytes": 524830,
+      "gzipBytes": 168522,
       "packedPackageInputFiles": 16
     },
     {
@@ -152,8 +152,8 @@
       "importPath": "semiotic/server/node",
       "symbol": "renderToImage",
       "platform": "node",
-      "rawBytes": 872448,
-      "gzipBytes": 276450,
+      "rawBytes": 873523,
+      "gzipBytes": 276664,
       "packedPackageInputFiles": 4
     },
     {
@@ -161,8 +161,8 @@
       "importPath": "semiotic/ai",
       "symbol": "suggestCharts",
       "platform": "browser",
-      "rawBytes": 710345,
-      "gzipBytes": 197430,
+      "rawBytes": 710739,
+      "gzipBytes": 197531,
       "packedPackageInputFiles": 51
     },
     {
@@ -188,8 +188,8 @@
       "importPath": "semiotic/geo",
       "symbol": "ChoroplethMap",
       "platform": "browser",
-      "rawBytes": 329587,
-      "gzipBytes": 111144,
+      "rawBytes": 329785,
+      "gzipBytes": 111188,
       "packedPackageInputFiles": 19
     },
     {

--- a/etc/api-surface/semiotic-utils-core.api.md
+++ b/etc/api-surface/semiotic-utils-core.api.md
@@ -15,7 +15,7 @@ const LIGHT_THEME: SemioticTheme
 const THEME_PRESETS: Record<string, SemioticTheme>
 function MultiPointTooltip(): TooltipContentFn
 function accessibilityCaveats(result: AccessibilityAuditResult, { onlyCritical }?: { onlyCritical?: boolean; } | undefined): string[]
-function adaptiveTimeTicks(granularity?: TimeGranularity | undefined): (value: string | number | Date, index?: number, allTicks?: number[]) => string
+function adaptiveTimeTicks(granularity?: TimeGranularity | undefined, options?: AdaptiveTimeTickOptions | undefined): (value: string | number | Date, index?: number, allTicks?: number[]) => string
 function auditAccessibility(component: string, props: Datum, options?: AuditAccessibilityOptions | undefined): AccessibilityAuditResult
 function auditData(component: string, props: Datum, data?: readonly Datum[] | undefined, options?: AuditDataOptions | undefined): DataAuditResult
 function auditMobileVisualization(component: string, props?: Datum | undefined, options?: AuditMobileVisualizationOptions | undefined): MobileVisualizationAuditResult

--- a/etc/api-surface/semiotic-utils.api.md
+++ b/etc/api-surface/semiotic-utils.api.md
@@ -16,7 +16,7 @@ const THEME_PRESETS: Record<string, SemioticTheme>
 function MultiPointTooltip(): TooltipContentFn
 function ThemeProvider({ theme, children }: ThemeProviderProps): React.JSX.Element
 function accessibilityCaveats(result: AccessibilityAuditResult, { onlyCritical }?: { onlyCritical?: boolean; } | undefined): string[]
-function adaptiveTimeTicks(granularity?: TimeGranularity | undefined): (value: string | number | Date, index?: number, allTicks?: number[]) => string
+function adaptiveTimeTicks(granularity?: TimeGranularity | undefined, options?: AdaptiveTimeTickOptions | undefined): (value: string | number | Date, index?: number, allTicks?: number[]) => string
 function auditAccessibility(component: string, props: Datum, options?: AuditAccessibilityOptions | undefined): AccessibilityAuditResult
 function auditData(component: string, props: Datum, data?: readonly Datum[] | undefined, options?: AuditDataOptions | undefined): DataAuditResult
 function auditMobileVisualization(component: string, props?: Datum | undefined, options?: AuditMobileVisualizationOptions | undefined): MobileVisualizationAuditResult

--- a/etc/api-surface/semiotic.api.md
+++ b/etc/api-surface/semiotic.api.md
@@ -83,7 +83,7 @@ function TreeDiagram<TNode extends Datum = Datum>(props: TreeDiagramProps<TNode>
 function Treemap<TNode extends Datum = Datum>(props: TreemapProps<TNode>): React.JSX.Element
 function ViolinPlot<TDatum extends Datum = Datum>(props: ViolinPlotProps<TDatum> & React.RefAttributes<RealtimeFrameHandle>): React.ReactElement<unknown, string | React.JSXElementConstructor<any>> | null
 function XYCustomChart<TDatum extends Datum = Datum, TConfig extends object = Record<string, unknown>>(props: XYCustomChartProps<TDatum, TConfig> & React.RefAttributes<RealtimeFrameHandle>): React.ReactElement<unknown, string | React.JSXElementConstructor<any>> | null
-function adaptiveTimeTicks(granularity?: TimeGranularity | undefined): (value: string | number | Date, index?: number, allTicks?: number[]) => string
+function adaptiveTimeTicks(granularity?: TimeGranularity | undefined, options?: AdaptiveTimeTickOptions | undefined): (value: string | number | Date, index?: number, allTicks?: number[]) => string
 function annotationStableId(annotation: Datum): string | undefined
 function auditVisualizationControls({ controls, minimumTargetSize, }: AuditVisualizationControlsOptions): ControlAuditResult
 function buildNavigationTree(component: string, props: Datum, options?: BuildNavigationTreeOptions | undefined): NavTreeNode

--- a/src/__tests__/scenarios/linechart-linedataaccessor-multi-tooltip.test.tsx
+++ b/src/__tests__/scenarios/linechart-linedataaccessor-multi-tooltip.test.tsx
@@ -15,6 +15,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest"
 import { render, act, fireEvent } from "@testing-library/react"
 import { LineChart } from "../../components/charts/xy/LineChart"
+import type { HoverData } from "../../components/realtime/types"
 import { setupCanvasMock } from "../../test-utils/canvasMock"
 
 const resizeObserverGlobal = globalThis as typeof globalThis & { ResizeObserver?: typeof ResizeObserver }
@@ -39,11 +40,15 @@ describe("LineChart: lineDataAccessor + tooltip=\"multi\"", () => {
   })
 
   it("populates allSeries on hover for line-object input", async () => {
-    let lastHover: Record<string, unknown> | undefined
+    let lastHover: HoverData | null = null
 
     const lineObjectData = [
       {
         series: "A",
+        // LineChart reads x/y from the point objects below. Keeping them on
+        // the outer type too makes the accessor contract explicit to TS.
+        x: 0,
+        y: 0,
         points: [
           { x: 0, y: 10 },
           { x: 10, y: 30 },
@@ -51,6 +56,8 @@ describe("LineChart: lineDataAccessor + tooltip=\"multi\"", () => {
       },
       {
         series: "B",
+        x: 0,
+        y: 0,
         points: [
           { x: 0, y: 5 },
           { x: 10, y: 15 },
@@ -71,9 +78,9 @@ describe("LineChart: lineDataAccessor + tooltip=\"multi\"", () => {
         width={200}
         height={100}
         margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
-        showAxes={false}
         frameProps={{
-          customHoverBehavior: (hover: Record<string, unknown>) => {
+          showAxes: false,
+          customHoverBehavior: (hover) => {
             lastHover = hover
           },
         }}
@@ -85,12 +92,15 @@ describe("LineChart: lineDataAccessor + tooltip=\"multi\"", () => {
     const hoverTarget = container.querySelector(".stream-xy-frame > div[role='img']")!
     fireEvent.mouseMove(hoverTarget, { clientX: 100, clientY: 50 })
 
-    expect(lastHover).toBeDefined()
-    expect(lastHover!.allSeries).toBeDefined()
-    expect((lastHover!.allSeries as unknown[]).length).toBe(2)
+    // The callback mutates this value outside TypeScript's synchronous
+    // control-flow analysis; retain its declared nullable HoverData shape.
+    const hover = lastHover as HoverData | null
+    if (!hover) throw new Error("Expected a multi-series hover payload")
+    expect(hover.allSeries).toBeDefined()
+    expect((hover.allSeries as unknown[]).length).toBe(2)
 
     const valuesByGroup = Object.fromEntries(
-      (lastHover!.allSeries as Array<{ group: string; value: number }>).map(
+      (hover.allSeries as Array<{ group: string; value: number }>).map(
         (s) => [s.group, s.value]
       )
     )
@@ -136,8 +146,7 @@ describe("LineChart: lineDataAccessor + tooltip=\"multi\"", () => {
         width={200}
         height={100}
         margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
-        showAxes={false}
-        frameProps={{ tooltipMode: "multi" }}
+        frameProps={{ showAxes: false, tooltipMode: "multi" }}
       />
     )
 

--- a/src/__tests__/scenarios/linechart-linedataaccessor-multi-tooltip.test.tsx
+++ b/src/__tests__/scenarios/linechart-linedataaccessor-multi-tooltip.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * Regression: LineChart's line-object input (`lineDataAccessor`) combined
+ * with `tooltip="multi"`.
+ *
+ * A review flagged that this combination has "zero real test coverage" —
+ * the only existing spec (callback-wiring.test.tsx, "tooltip='multi' on
+ * LineChart") mocks StreamXYFrame entirely and only asserts the render
+ * doesn't throw; it never simulates a hover or checks that `allSeries`
+ * is populated, and it uses flat rows + `lineBy`, not `lineDataAccessor`.
+ *
+ * This test renders LineChart with real (unmocked) StreamXYFrame, feeds it
+ * line-object data via `lineDataAccessor`, simulates a real mouse move, and
+ * asserts the multi-tooltip hover payload actually contains both series.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { render, act, fireEvent } from "@testing-library/react"
+import { LineChart } from "../../components/charts/xy/LineChart"
+import { setupCanvasMock } from "../../test-utils/canvasMock"
+
+const resizeObserverGlobal = globalThis as typeof globalThis & { ResizeObserver?: typeof ResizeObserver }
+if (typeof resizeObserverGlobal.ResizeObserver === "undefined") {
+  resizeObserverGlobal.ResizeObserver = class {
+    constructor(_callback: ResizeObserverCallback) {}
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as typeof ResizeObserver
+}
+
+describe("LineChart: lineDataAccessor + tooltip=\"multi\"", () => {
+  let restoreCanvasContext: () => void
+
+  beforeEach(() => {
+    restoreCanvasContext = setupCanvasMock()
+  })
+
+  afterEach(() => {
+    restoreCanvasContext()
+  })
+
+  it("populates allSeries on hover for line-object input", async () => {
+    let lastHover: Record<string, unknown> | undefined
+
+    const lineObjectData = [
+      {
+        series: "A",
+        points: [
+          { x: 0, y: 10 },
+          { x: 10, y: 30 },
+        ],
+      },
+      {
+        series: "B",
+        points: [
+          { x: 0, y: 5 },
+          { x: 10, y: 15 },
+        ],
+      },
+    ]
+
+    const { container } = render(
+      <LineChart
+        data={lineObjectData}
+        lineDataAccessor="points"
+        xAccessor="x"
+        yAccessor="y"
+        lineBy="series"
+        tooltip="multi"
+        xExtent={[0, 10]}
+        yExtent={[0, 30]}
+        width={200}
+        height={100}
+        margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
+        showAxes={false}
+        frameProps={{
+          customHoverBehavior: (hover: Record<string, unknown>) => {
+            lastHover = hover
+          },
+        }}
+      />
+    )
+
+    await act(async () => { await Promise.resolve() })
+
+    const hoverTarget = container.querySelector(".stream-xy-frame > div[role='img']")!
+    fireEvent.mouseMove(hoverTarget, { clientX: 100, clientY: 50 })
+
+    expect(lastHover).toBeDefined()
+    expect(lastHover!.allSeries).toBeDefined()
+    expect((lastHover!.allSeries as unknown[]).length).toBe(2)
+
+    const valuesByGroup = Object.fromEntries(
+      (lastHover!.allSeries as Array<{ group: string; value: number }>).map(
+        (s) => [s.group, s.value]
+      )
+    )
+    expect(valuesByGroup.A).toBeCloseTo(20)
+    expect(valuesByGroup.B).toBeCloseTo(10)
+  })
+
+  it("renders a custom function tooltip's series rows on hover", async () => {
+    // Regression (reported downstream by Iris): with `tooltip="multi"` a
+    // *custom function* tooltip received a datum with no `allSeries`, because
+    // `normalizeTooltip` unwrapped the hover root down to `.data`. The
+    // tell-tale symptom was a tooltip header with no series rows. Semiotic's
+    // own `MultiPointTooltip` was unaffected — it is wired as `tooltipContent`
+    // directly and never passes through `normalizeTooltip`.
+    //
+    // `tooltip` carries either the string "multi" or a custom function, never
+    // both, so multi mode plus a custom renderer is reached through
+    // `frameProps.tooltipMode` — the shape the downstream report used.
+    const flatData = [
+      { series: "A", x: 0, y: 10 },
+      { series: "A", x: 10, y: 30 },
+      { series: "B", x: 0, y: 5 },
+      { series: "B", x: 10, y: 15 },
+    ]
+
+    const { container } = render(
+      <LineChart
+        data={flatData}
+        xAccessor="x"
+        yAccessor="y"
+        lineBy="series"
+        tooltip={(d: Record<string, unknown>) => {
+          const all = d.allSeries as Array<{ group: string; value: number }> | undefined
+          if (!all) return <div data-testid="rows">NO_SERIES</div>
+          return (
+            <div data-testid="rows">
+              {all.map(s => `${s.group}=${Math.round(s.value)}`).join(" ")}
+            </div>
+          )
+        }}
+        xExtent={[0, 10]}
+        yExtent={[0, 30]}
+        width={200}
+        height={100}
+        margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
+        showAxes={false}
+        frameProps={{ tooltipMode: "multi" }}
+      />
+    )
+
+    await act(async () => { await Promise.resolve() })
+
+    const hoverTarget = container.querySelector(".stream-xy-frame > div[role='img']")!
+    fireEvent.mouseMove(hoverTarget, { clientX: 100, clientY: 50 })
+
+    await act(async () => { await Promise.resolve() })
+
+    const rows = container.querySelector("[data-testid='rows']")
+    expect(rows).not.toBeNull()
+    expect(rows!.textContent).not.toContain("NO_SERIES")
+    expect(rows!.textContent).toContain("A=20")
+    expect(rows!.textContent).toContain("B=10")
+  })
+})

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -436,6 +436,54 @@ describe("MultiPointTooltip", () => {
     expect(container.textContent).toContain("42")
   })
 
+  it("a function tooltip can read allSeries through normalizeTooltip", () => {
+    // Regression: `allSeries` lives on the hover ROOT, not inside `.data`,
+    // so unwrapping to `.data` used to hand user functions a datum with no
+    // series — making a custom multi-series tooltip impossible to write.
+    let seen: Record<string, unknown> | undefined
+    const fn = normalizeTooltip((d) => {
+      seen = d
+      return <div>{(d.allSeries as Array<{ group: string }>).map(s => s.group).join(",")}</div>
+    })
+    expect(typeof fn).toBe("function")
+
+    const { container } = render(<>{(fn as (d: Record<string, unknown>) => React.ReactNode)({
+      __semioticHoverData: true,
+      data: { time: 5, y: 10 },
+      x: 100,
+      y: 50,
+      xValue: 5,
+      allSeries: [
+        { group: "A", value: 10, color: "red" },
+        { group: "B", value: 20, color: "blue" },
+      ],
+    })}</>)
+
+    expect(seen).toBeDefined()
+    // The raw datum is still unwrapped as usual...
+    expect(seen!.y).toBe(10)
+    // ...with the multi-series hover context re-attached.
+    expect((seen!.allSeries as unknown[]).length).toBe(2)
+    expect(seen!.xValue).toBe(5)
+    expect(container.textContent).toContain("A,B")
+  })
+
+  it("a real datum field wins over the cursor's xValue", () => {
+    let seen: Record<string, unknown> | undefined
+    const fn = normalizeTooltip((d) => { seen = d; return <div>ok</div> })
+    render(<>{(fn as (d: Record<string, unknown>) => React.ReactNode)({
+      __semioticHoverData: true,
+      // A data row that legitimately carries its own `xValue` column.
+      data: { xValue: "from-data", y: 1 },
+      x: 10,
+      y: 20,
+      xValue: 999,
+      allSeries: [{ group: "A", value: 1, color: "red" }],
+    })}</>)
+    expect(seen!.xValue).toBe("from-data")
+    expect((seen!.allSeries as unknown[]).length).toBe(1)
+  })
+
   it("normalizeTooltip returns MultiLineTooltip content for 'multi' when HOCs do not intercept", () => {
     // Preferred path: Line/Area/StackedArea/Difference set tooltipMode before normalize.
     // Fallback: multi content so unsupported charts still get a multi-series tooltip.

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -534,6 +534,28 @@ export function normalizeTooltip(tooltip: TooltipProp | undefined): false | Tool
         datum = datum.data
       }
       if (!datum) return null
+      // Multi-tooltip mode (`tooltip="multi"`) puts the per-series values on
+      // the hover ROOT as `allSeries`, alongside the data-space `xValue` of
+      // the cursor — not inside `.data`. Unwrapping to `.data` above would
+      // therefore discard exactly the fields a multi-series tooltip needs
+      // (and `allSeries !== undefined` is itself one of the markers that
+      // *enables* the unwrap, so its presence triggered the step that
+      // dropped it). Re-attach them onto a shallow copy so a user function
+      // can read `datum.allSeries` the way `MultiPointTooltip` — which is
+      // wired as `tooltipContent` directly and never passes through here —
+      // always could. Copy rather than mutate: `datum` is the caller's own
+      // data row. Real datum fields win, so a data row that legitimately
+      // carries an `xValue` column is not overwritten by the cursor's.
+      if (looksLikeHoverWrapper && (hoverData.allSeries !== undefined || hoverData.xValue !== undefined)) {
+        const withHoverContext: Datum = { ...datum }
+        if (hoverData.allSeries !== undefined && withHoverContext.allSeries === undefined) {
+          withHoverContext.allSeries = hoverData.allSeries
+        }
+        if (hoverData.xValue !== undefined && withHoverContext.xValue === undefined) {
+          withHoverContext.xValue = hoverData.xValue
+        }
+        datum = withHoverContext
+      }
       const result = userFn(datum)
       if (result === null || result === undefined) return null
       return (

--- a/src/components/charts/shared/formatUtils.test.ts
+++ b/src/components/charts/shared/formatUtils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { adaptiveTimeTicks } from "./formatUtils"
+
+describe("adaptiveTimeTicks", () => {
+  it("keeps UTC as the backwards-compatible default", () => {
+    const timestamp = Date.UTC(2026, 6, 29, 15, 14)
+    expect(adaptiveTimeTicks("minutes")(timestamp, 0, [timestamp])).toBe("Jul 29, 2026 15:14")
+  })
+
+  it("can format ticks in the local timezone", () => {
+    const timestamp = Date.UTC(2026, 6, 29, 15, 14)
+    const local = new Date(timestamp)
+    const expected = `${["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"][local.getMonth()]} ${local.getDate()}, ${local.getFullYear()} ${String(local.getHours()).padStart(2, "0")}:${String(local.getMinutes()).padStart(2, "0")}`
+
+    expect(adaptiveTimeTicks("minutes", { utc: false })(timestamp, 0, [timestamp])).toBe(expected)
+  })
+
+  it("uses local calendar boundaries for subsequent local-time ticks", () => {
+    // The local getters in the expected value make this robust in every CI TZ,
+    // while still catching an accidental UTC comparison in deltaLabel.
+    const first = Date.UTC(2026, 6, 29, 23, 59)
+    const second = first + 60_000
+    const previous = new Date(first)
+    const local = new Date(second)
+    const expected = local.getDate() !== previous.getDate()
+      ? `${["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"][local.getMonth()]} ${local.getDate()} ${String(local.getHours()).padStart(2, "0")}:${String(local.getMinutes()).padStart(2, "0")}`
+      : local.getHours() !== previous.getHours()
+        ? `${String(local.getHours()).padStart(2, "0")}:${String(local.getMinutes()).padStart(2, "0")}`
+      : `:${String(local.getMinutes()).padStart(2, "0")}`
+
+    expect(adaptiveTimeTicks("minutes", { utc: false })(second, 1, [first, second])).toBe(expected)
+  })
+})

--- a/src/components/charts/shared/formatUtils.ts
+++ b/src/components/charts/shared/formatUtils.ts
@@ -200,7 +200,7 @@ type TimeGranularity = "seconds" | "minutes" | "hours" | "days" | "months" | "ye
 
 /** Options for {@link adaptiveTimeTicks}. UTC remains the default so existing
  * server-rendered charts stay deterministic; set `utc: false` to format in
- * the viewer's local timezone. */
+ * the runtime's local timezone. */
 export interface AdaptiveTimeTickOptions {
   utc?: boolean
 }

--- a/src/components/charts/shared/formatUtils.ts
+++ b/src/components/charts/shared/formatUtils.ts
@@ -198,6 +198,13 @@ export function smartTickFormat(value: string | number | Date | null | undefined
 
 type TimeGranularity = "seconds" | "minutes" | "hours" | "days" | "months" | "years"
 
+/** Options for {@link adaptiveTimeTicks}. UTC remains the default so existing
+ * server-rendered charts stay deterministic; set `utc: false` to format in
+ * the viewer's local timezone. */
+export interface AdaptiveTimeTickOptions {
+  utc?: boolean
+}
+
 const MS_SECOND = 1000
 const MS_MINUTE = 60 * MS_SECOND
 const MS_HOUR = 60 * MS_MINUTE
@@ -228,14 +235,27 @@ function pad2(n: number): string { return n < 10 ? `0${n}` : String(n) }
 const MONTH_SHORT = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
 
-/** Full anchor label — gives the reader absolute context. Uses UTC for SSR determinism. */
-function fullLabel(d: Date, granularity: TimeGranularity): string {
-  const mon = MONTH_SHORT[d.getUTCMonth()]
-  const day = d.getUTCDate()
-  const year = d.getUTCFullYear()
-  const hh = pad2(d.getUTCHours())
-  const mm = pad2(d.getUTCMinutes())
-  const ss = pad2(d.getUTCSeconds())
+type TimeParts = { month: number; day: number; year: number; hours: number; minutes: number; seconds: number }
+
+function timeParts(d: Date, utc: boolean): TimeParts {
+  return utc
+    ? {
+      month: d.getUTCMonth(), day: d.getUTCDate(), year: d.getUTCFullYear(),
+      hours: d.getUTCHours(), minutes: d.getUTCMinutes(), seconds: d.getUTCSeconds(),
+    }
+    : {
+      month: d.getMonth(), day: d.getDate(), year: d.getFullYear(),
+      hours: d.getHours(), minutes: d.getMinutes(), seconds: d.getSeconds(),
+    }
+}
+
+/** Full anchor label — gives the reader absolute context. */
+function fullLabel(d: Date, granularity: TimeGranularity, utc: boolean): string {
+  const { month, day, year, hours, minutes, seconds } = timeParts(d, utc)
+  const mon = MONTH_SHORT[month]
+  const hh = pad2(hours)
+  const mm = pad2(minutes)
+  const ss = pad2(seconds)
 
   switch (granularity) {
     case "seconds":  return `${mon} ${day}, ${year} ${hh}:${mm}:${ss}`
@@ -249,21 +269,22 @@ function fullLabel(d: Date, granularity: TimeGranularity): string {
 
 /**
  * Contextual label — only shows units that changed from `prev`.
- * Re-qualifies upward when a boundary is crossed. Uses UTC for SSR determinism.
+ * Re-qualifies upward when a boundary is crossed.
  */
-function deltaLabel(d: Date, prev: Date, granularity: TimeGranularity): string {
-  const yearChanged  = d.getUTCFullYear() !== prev.getUTCFullYear()
-  const monthChanged = yearChanged || d.getUTCMonth() !== prev.getUTCMonth()
-  const dayChanged   = monthChanged || d.getUTCDate() !== prev.getUTCDate()
-  const hourChanged  = dayChanged || d.getUTCHours() !== prev.getUTCHours()
-  const minChanged   = hourChanged || d.getUTCMinutes() !== prev.getUTCMinutes()
+function deltaLabel(d: Date, prev: Date, granularity: TimeGranularity, utc: boolean): string {
+  const current = timeParts(d, utc)
+  const previous = timeParts(prev, utc)
+  const yearChanged  = current.year !== previous.year
+  const monthChanged = yearChanged || current.month !== previous.month
+  const dayChanged   = monthChanged || current.day !== previous.day
+  const hourChanged  = dayChanged || current.hours !== previous.hours
+  const minChanged   = hourChanged || current.minutes !== previous.minutes
 
-  const mon = MONTH_SHORT[d.getUTCMonth()]
-  const day = d.getUTCDate()
-  const year = d.getUTCFullYear()
-  const hh = pad2(d.getUTCHours())
-  const mm = pad2(d.getUTCMinutes())
-  const ss = pad2(d.getUTCSeconds())
+  const mon = MONTH_SHORT[current.month]
+  const { day, year } = current
+  const hh = pad2(current.hours)
+  const mm = pad2(current.minutes)
+  const ss = pad2(current.seconds)
 
   switch (granularity) {
     case "seconds":
@@ -312,6 +333,8 @@ function deltaLabel(d: Date, prev: Date, granularity: TimeGranularity): string {
  *
  * @param granularity - Optional explicit granularity. If omitted,
  *   auto-detected from the tick spacing on first call.
+ * @param options - Set `utc: false` to format in local time. The default is
+ *   UTC for backwards-compatible, deterministic SSR output.
  *
  * @example
  * ```tsx
@@ -322,13 +345,18 @@ function deltaLabel(d: Date, prev: Date, granularity: TimeGranularity): string {
  *
  * // Explicit granularity
  * <LineChart data={ts} xFormat={adaptiveTimeTicks("minutes")} />
+ *
+ * // Local wall-clock time
+ * <LineChart data={ts} xFormat={adaptiveTimeTicks("minutes", { utc: false })} />
  * ```
  */
 export function adaptiveTimeTicks(
-  granularity?: TimeGranularity
+  granularity?: TimeGranularity,
+  options: AdaptiveTimeTickOptions = {}
 ): (value: string | number | Date, index?: number, allTicks?: number[]) => string {
   let resolved: TimeGranularity | undefined = granularity
   let lastTicksRef: number[] | undefined
+  const utc = options.utc ?? true
 
   return (value: string | number | Date, index?: number, allTicks?: number[]): string => {
     const d = value instanceof Date ? value : new Date(value)
@@ -342,12 +370,12 @@ export function adaptiveTimeTicks(
 
     // First tick: full anchor label
     if (index == null || index === 0 || !allTicks || allTicks.length === 0) {
-      return fullLabel(d, gran)
+      return fullLabel(d, gran, utc)
     }
 
     // Subsequent ticks: show only what changed
     const prev = new Date(allTicks[index - 1])
-    return deltaLabel(d, prev, gran)
+    return deltaLabel(d, prev, gran, utc)
   }
 }
 

--- a/src/components/server/serverFeatures.test.tsx
+++ b/src/components/server/serverFeatures.test.tsx
@@ -457,6 +457,28 @@ describe("Grid lines", () => {
     expect(svg).not.toContain("semiotic-grid")
   })
 
+  it("can render horizontal-only XY grid lines", () => {
+    const svg = renderXYToStaticSVG({
+      chartType: "line",
+      data: [{ x: 0, y: 10 }, { x: 1, y: 20 }, { x: 2, y: 15 }],
+      xAccessor: "x",
+      yAccessor: "y",
+      size: [400, 300],
+      showGrid: true,
+      axes: [
+        { orient: "bottom", grid: false },
+        { orient: "left", gridStyle: "dashed" },
+      ],
+    } as StaticXYProps)
+
+    const grid = svg.match(/<g[^>]*class="semiotic-grid"[\s\S]*?<\/g>/)?.[0] ?? ""
+    expect(grid).toContain("<line")
+    // Horizontal lines start at the y axis. A vertical x-grid line would
+    // instead have a non-zero x1 tick coordinate.
+    expect(grid).not.toMatch(/<line[^>]*x1="(?!0")/)
+    expect(grid).toContain('stroke-dasharray="6,4"')
+  })
+
   it("renders grid when showGrid is true (ordinal vertical)", () => {
     const svg = renderOrdinalToStaticSVG({
       chartType: "bar",

--- a/src/components/server/ssr-iris-parity.test.tsx
+++ b/src/components/server/ssr-iris-parity.test.tsx
@@ -294,6 +294,24 @@ describe("Treemap — colorBy + hierarchy labels SSR parity", () => {
     expect(ys.some((y) => y >= 15 && y <= 25)).toBe(true)
     expect(svg.includes(">Group A<")).toBe(true)
   })
+
+  it("serializes per-tile fill opacity so nested branch colors composite like canvas", () => {
+    const svg = renderChart("Treemap", {
+      ...props,
+      nodeStyle: () => ({ fillOpacity: 0.45, strokeOpacity: 0.7 }),
+    })
+
+    expect(svg).toContain('fill-opacity="0.45"')
+    expect(svg).toContain('stroke-opacity="0.7"')
+  })
+
+  it("keeps Treemap's default translucent cell borders in static SVG", () => {
+    // The HOC sets this even when callers do not specify tile opacity. Those
+    // nested border layers are visible in parent bands, so dropping it makes
+    // an SSR band materially flatter/darker than the canvas rendering.
+    const svg = renderChart("Treemap", props)
+    expect(svg).toContain('stroke-opacity="0.8"')
+  })
 })
 
 // ── RangeChart middleAccessor via svgAnnotationRules ──────────────────────

--- a/src/components/server/staticSVGChrome.tsx
+++ b/src/components/server/staticSVGChrome.tsx
@@ -3,6 +3,7 @@ import type { LegendLayout } from "../types/legendTypes"
 import type { LegendValue } from "../types/legendTypes"
 import { composeLegendConfigs, isGradientLegendConfig, isLegendConfig } from "../types/legendTypes"
 import type { StreamXYFrameProps, StreamScales, StreamLayout } from "../stream/types"
+import type { XYFrameAxisConfig } from "../stream/xyFrameAxisTypes"
 import type {
   StreamNetworkFrameProps,
   RealtimeEdge,
@@ -25,6 +26,7 @@ import { resolveTheme, themeStyles, type ThemeInput } from "./themeResolver"
 import type { SemioticTheme } from "../store/ThemeStore"
 import * as React from "react"
 import { TITLE_BASELINE } from "../stream/titleLayout"
+import { resolveGridDash } from "../stream/svgOverlayUtils"
 import { ticksForMode, type AxisExtentMode } from "../charts/shared/axisExtent"
 import {
   resolveAxisChromeGutter,
@@ -392,7 +394,8 @@ export function renderGridSVG(
   layout: StreamLayout,
   theme: SemioticTheme,
   idPrefix?: string,
-  axisExtent?: AxisExtentMode
+  axisExtent?: AxisExtentMode,
+  axes?: XYFrameAxisConfig[]
 ): React.ReactNode {
   const { grid } = themeStyles(theme)
   const pfx = idPrefix ? `${idPrefix}-` : ""
@@ -407,21 +410,25 @@ export function renderGridSVG(
     : Math.min(5, Math.max(2, Math.floor(layout.height / 30)))
   const xTicks = ticksForMode(scales.x, xTickCount, axisExtent)
   const yTicks = ticksForMode(scales.y, yTickCount, axisExtent)
+  const showXGrid = axes?.find(axis => axis.orient === "bottom")?.grid !== false
+  const showYGrid = axes?.find(axis => axis.orient === "left")?.grid !== false
+  const xGridDash = resolveGridDash(axes?.find(axis => axis.orient === "bottom")?.gridStyle)
+  const yGridDash = resolveGridDash(axes?.find(axis => axis.orient === "left")?.gridStyle)
 
   return (
     <g id={`${pfx}grid`} className="semiotic-grid" opacity={0.8}>
-      {xTicks.map((v: number, i: number) => {
+      {showXGrid && xTicks.map((v: number, i: number) => {
         const px = scales.x(v)
         return (
           <line key={`gx-${i}`} x1={px} y1={0} x2={px} y2={layout.height}
-            stroke={grid} strokeWidth={0.5} />
+            stroke={grid} strokeWidth={0.5} strokeDasharray={xGridDash} />
         )
       })}
-      {yTicks.map((v: number, i: number) => {
+      {showYGrid && yTicks.map((v: number, i: number) => {
         const py = scales.y(v)
         return (
           <line key={`gy-${i}`} x1={0} y1={py} x2={layout.width} y2={py}
-            stroke={grid} strokeWidth={0.5} />
+            stroke={grid} strokeWidth={0.5} strokeDasharray={yGridDash} />
         )
       })}
     </g>

--- a/src/components/server/staticXY.tsx
+++ b/src/components/server/staticXY.tsx
@@ -198,7 +198,9 @@ export function renderStreamXYFrame(props: StreamXYFrameProps & ThemeAwareProps,
     })
   }
 
-  const grid = props.showGrid ? renderGridSVG(store.scales, { width, height }, theme, idPfx, props.axisExtent) : null
+  const grid = props.showGrid
+    ? renderGridSVG(store.scales, { width, height }, theme, idPfx, props.axisExtent, props.axes)
+    : null
 
   const dataMarks = renderedScene.map(entry => entry.element)
   const plotClipId = `${chartUID(props)}-plot-clip`

--- a/src/components/stream/SVGOverlay.axisCustomization.test.tsx
+++ b/src/components/stream/SVGOverlay.axisCustomization.test.tsx
@@ -17,7 +17,7 @@
 import * as React from "react"
 import { render } from "@testing-library/react"
 import { describe, it, expect } from "vitest"
-import { SVGOverlay } from "./SVGOverlay"
+import { SVGOverlay, SVGUnderlay } from "./SVGOverlay"
 import type { StreamScales } from "./types"
 
 function makeStubScales(): StreamScales {
@@ -41,6 +41,42 @@ const baseProps = {
   totalHeight: 240,
   margin: { top: 10, right: 20, bottom: 30, left: 40 },
 }
+
+describe("per-axis grid visibility", () => {
+  it("keeps only horizontal grid lines when the bottom axis opts out", () => {
+    const { container } = render(
+      <SVGOverlay
+        {...baseProps}
+        scales={makeStubScales()}
+        showAxes={true}
+        showGrid={true}
+        axes={[{ orient: "bottom", grid: false }, { orient: "left" }]}
+      />,
+    )
+
+    const gridLines = Array.from(container.querySelectorAll("g.stream-grid line"))
+    expect(gridLines.length).toBeGreaterThan(0)
+    // Horizontal (y-axis) grid lines begin at x=0. No bottom-axis ticks
+    // should contribute their vertical x-grid lines.
+    for (const line of gridLines) expect(line.getAttribute("x1")).toBe("0")
+  })
+
+  it("applies the same grid visibility in the canvas underlay", () => {
+    const { container } = render(
+      <SVGUnderlay
+        {...baseProps}
+        scales={makeStubScales()}
+        showAxes={true}
+        showGrid={true}
+        axes={[{ orient: "bottom", grid: false }, { orient: "left" }]}
+      />,
+    )
+
+    const gridLines = Array.from(container.querySelectorAll("g.stream-grid line"))
+    expect(gridLines.length).toBeGreaterThan(0)
+    for (const line of gridLines) expect(line.getAttribute("x1")).toBe("0")
+  })
+})
 
 // ── tickAnchor ─────────────────────────────────────────────────────────
 

--- a/src/components/stream/SVGOverlay.tsx
+++ b/src/components/stream/SVGOverlay.tsx
@@ -245,9 +245,11 @@ export function SVGUnderlay(props: SVGUnderlayProps) {
         {hasGrid && (() => {
           const bottomGridStyle = resolveGridDash(axes?.find(a => a.orient === "bottom")?.gridStyle)
           const leftGridStyle = resolveGridDash(axes?.find(a => a.orient === "left")?.gridStyle)
+          const showXGrid = axes?.find(a => a.orient === "bottom")?.grid !== false
+          const showYGrid = axes?.find(a => a.orient === "left")?.grid !== false
           return (
           <g className="stream-grid">
-            {xTicks.map((tick, i) => (
+            {showXGrid && xTicks.map((tick, i) => (
               <line
                 key={`xgrid-${i}`}
                 x1={tick.pixel}
@@ -259,7 +261,7 @@ export function SVGUnderlay(props: SVGUnderlayProps) {
                 strokeDasharray={bottomGridStyle}
               />
             ))}
-            {yTicks.map((tick, i) => (
+            {showYGrid && yTicks.map((tick, i) => (
               <line
                 key={`ygrid-${i}`}
                 x1={0}
@@ -623,9 +625,11 @@ export function SVGOverlay(props: SVGOverlayProps) {
         {showGrid && scales && (!underlayRendered || canvasObscuresUnderlay) && (() => {
           const bottomGridStyle = resolveGridDash(axes?.find(a => a.orient === "bottom")?.gridStyle)
           const leftGridStyle = resolveGridDash(axes?.find(a => a.orient === "left")?.gridStyle)
+          const showXGrid = axes?.find(a => a.orient === "bottom")?.grid !== false
+          const showYGrid = axes?.find(a => a.orient === "left")?.grid !== false
           return (
           <g className="stream-grid">
-            {xTicks.map((tick, i) => (
+            {showXGrid && xTicks.map((tick, i) => (
               <line
                 key={`xgrid-${i}`}
                 x1={tick.pixel}
@@ -637,7 +641,7 @@ export function SVGOverlay(props: SVGOverlayProps) {
                 strokeDasharray={bottomGridStyle}
               />
             ))}
-            {yTicks.map((tick, i) => (
+            {showYGrid && yTicks.map((tick, i) => (
               <line
                 key={`ygrid-${i}`}
                 x1={0}

--- a/src/components/stream/SceneToSVGNetwork.tsx
+++ b/src/components/stream/SceneToSVGNetwork.tsx
@@ -41,6 +41,8 @@ export function networkSceneNodeToSVG(node: NetworkSceneNode, i: number): React.
             fill={hatch ? `url(#net-circle-${i}-hatch)` : svgFill(n.style.fill)}
             stroke={n.style.stroke}
             strokeWidth={n.style.strokeWidth}
+            fillOpacity={n.style.fillOpacity}
+            strokeOpacity={n.style.strokeOpacity}
             opacity={n.style.opacity}
           />
         </React.Fragment>
@@ -57,6 +59,8 @@ export function networkSceneNodeToSVG(node: NetworkSceneNode, i: number): React.
             fill={hatch ? `url(#net-rect-${i}-hatch)` : svgFill(n.style.fill)}
             stroke={n.style.stroke}
             strokeWidth={n.style.strokeWidth}
+            fillOpacity={n.style.fillOpacity}
+            strokeOpacity={n.style.strokeOpacity}
             opacity={n.style.opacity}
           />
         </React.Fragment>
@@ -81,6 +85,8 @@ export function networkSceneNodeToSVG(node: NetworkSceneNode, i: number): React.
             fill={hatch ? `url(#net-arc-${i}-hatch)` : svgFill(n.style.fill)}
             stroke={n.style.stroke}
             strokeWidth={n.style.strokeWidth}
+            fillOpacity={n.style.fillOpacity}
+            strokeOpacity={n.style.strokeOpacity}
             opacity={n.style.opacity}
           />
         </React.Fragment>
@@ -100,6 +106,8 @@ export function networkSceneNodeToSVG(node: NetworkSceneNode, i: number): React.
           fill={n.style.fill ? svgFill(n.style.fill) : "none"}
           stroke={n.style.stroke}
           strokeWidth={n.style.strokeWidth}
+          fillOpacity={n.style.fillOpacity}
+          strokeOpacity={n.style.strokeOpacity}
           opacity={n.style.opacity}
         />
       )

--- a/src/components/stream/layouts/hierarchyLayoutPlugin.test.ts
+++ b/src/components/stream/layouts/hierarchyLayoutPlugin.test.ts
@@ -162,6 +162,31 @@ describe("hierarchyLayoutPlugin", () => {
       expect(scene.sceneEdges.length).toBe(0)
     })
 
+    it("preserves per-fill and per-stroke opacity in treemap scene nodes", () => {
+      const nodes: RealtimeNode[] = []
+      const edges: RealtimeEdge[] = []
+      const config: NetworkPipelineConfig = {
+        chartType: "treemap",
+        childrenAccessor: "children",
+        nodeIDAccessor: "name",
+        __hierarchyRoot: sampleHierarchy,
+        nodeStyle: () => ({
+          fill: "#64748b",
+          fillOpacity: 0.45,
+          stroke: "#ffffff",
+          strokeOpacity: 0.7,
+        }),
+      }
+      const size: [number, number] = [600, 400]
+
+      hierarchyLayoutPlugin.computeLayout(nodes, edges, config, size)
+      const scene = hierarchyLayoutPlugin.buildScene(nodes, edges, config, size)
+      const rect = scene.sceneNodes.find(node => node.type === "rect")
+
+      expect(rect?.style.fillOpacity).toBe(0.45)
+      expect(rect?.style.strokeOpacity).toBe(0.7)
+    })
+
     it("calls a nodeLabel function with the original datum (not the scene node wrapper)", () => {
       // The user datum carries a `label` field that lives only on the
       // original object — the scene node nests it under `.data`. A

--- a/src/components/stream/layouts/hierarchySceneBuilders.ts
+++ b/src/components/stream/layouts/hierarchySceneBuilders.ts
@@ -95,7 +95,12 @@ export function buildTreeScene(
       // Halo stroke: user > theme surface (contrasts with chart bg) > #fff.
       stroke: userStyle.stroke || config.themeSemantic?.surface || "#fff",
       strokeWidth: userStyle.strokeWidth ?? 1,
-      opacity: userStyle.opacity
+      opacity: userStyle.opacity,
+      // Keep paint-specific alpha separate from whole-mark opacity. This is
+      // important for nested treemaps: an ancestor's translucent fill needs
+      // to composite with its descendants identically on canvas and SVG.
+      fillOpacity: userStyle.fillOpacity,
+      strokeOpacity: userStyle.strokeOpacity
     }
 
     sceneNodes.push({
@@ -245,7 +250,9 @@ export function buildRectScene(
       // Halo stroke: user > theme surface (contrasts with chart bg) > #fff.
       stroke: userStyle.stroke || config.themeSemantic?.surface || "#fff",
       strokeWidth: userStyle.strokeWidth ?? 1,
-      opacity: userStyle.opacity
+      opacity: userStyle.opacity,
+      fillOpacity: userStyle.fillOpacity,
+      strokeOpacity: userStyle.strokeOpacity
     }
 
     sceneNodes.push({
@@ -360,7 +367,9 @@ export function buildCircleScene(
       // Halo stroke: user > theme surface (contrasts with chart bg) > #fff.
       stroke: userStyle.stroke || config.themeSemantic?.surface || "#fff",
       strokeWidth: userStyle.strokeWidth ?? 1,
-      opacity: userStyle.opacity ?? circleOpacity
+      opacity: userStyle.opacity ?? circleOpacity,
+      fillOpacity: userStyle.fillOpacity,
+      strokeOpacity: userStyle.strokeOpacity
     }
 
     sceneNodes.push({

--- a/src/components/stream/layouts/hierarchySceneBuilders.ts
+++ b/src/components/stream/layouts/hierarchySceneBuilders.ts
@@ -95,12 +95,7 @@ export function buildTreeScene(
       // Halo stroke: user > theme surface (contrasts with chart bg) > #fff.
       stroke: userStyle.stroke || config.themeSemantic?.surface || "#fff",
       strokeWidth: userStyle.strokeWidth ?? 1,
-      opacity: userStyle.opacity,
-      // Keep paint-specific alpha separate from whole-mark opacity. This is
-      // important for nested treemaps: an ancestor's translucent fill needs
-      // to composite with its descendants identically on canvas and SVG.
-      fillOpacity: userStyle.fillOpacity,
-      strokeOpacity: userStyle.strokeOpacity
+      opacity: userStyle.opacity
     }
 
     sceneNodes.push({
@@ -367,9 +362,7 @@ export function buildCircleScene(
       // Halo stroke: user > theme surface (contrasts with chart bg) > #fff.
       stroke: userStyle.stroke || config.themeSemantic?.surface || "#fff",
       strokeWidth: userStyle.strokeWidth ?? 1,
-      opacity: userStyle.opacity ?? circleOpacity,
-      fillOpacity: userStyle.fillOpacity,
-      strokeOpacity: userStyle.strokeOpacity
+      opacity: userStyle.opacity ?? circleOpacity
     }
 
     sceneNodes.push({

--- a/src/components/stream/renderers/canvasRenderHelpers.test.ts
+++ b/src/components/stream/renderers/canvasRenderHelpers.test.ts
@@ -185,5 +185,15 @@ describe("canvasRenderHelpers", () => {
       expect(mutableCtx.lineWidth).toBe(1)
       expect(mutableCtx.globalAlpha).toBe(1)
     })
+
+    it("combines opacity × strokeOpacity for a translucent network border", () => {
+      const paint = vi.fn()
+      paintNetworkStroke(
+        ctx,
+        { stroke: "#00ff00", opacity: 0.5, strokeOpacity: 0.4 } as Style,
+        paint,
+      )
+      expect((ctx as unknown as { globalAlpha: number }).globalAlpha).toBeCloseTo(0.2)
+    })
   })
 })

--- a/src/components/stream/renderers/canvasRenderHelpers.ts
+++ b/src/components/stream/renderers/canvasRenderHelpers.ts
@@ -168,6 +168,6 @@ export function paintNetworkStroke(
   if (!style.stroke || style.stroke === "none") return
   ctx.strokeStyle = resolveCSSColor(ctx, style.stroke) || style.stroke
   ctx.lineWidth = style.strokeWidth ?? 1
-  ctx.globalAlpha = style.opacity ?? 1
+  ctx.globalAlpha = (style.opacity ?? 1) * (style.strokeOpacity ?? 1)
   paint()
 }

--- a/src/components/stream/types.ts
+++ b/src/components/stream/types.ts
@@ -137,6 +137,8 @@ export type RuntimeMode = "bounded" | "streaming"
 export interface Style {
   stroke?: string
   strokeWidth?: number
+  /** Opacity applied to the stroke independently of fill/mark opacity. */
+  strokeOpacity?: number
   strokeDasharray?: string
   strokeLinecap?: "butt" | "round" | "square"
   /**

--- a/src/components/stream/xyFrameAxisTypes.ts
+++ b/src/components/stream/xyFrameAxisTypes.ts
@@ -42,6 +42,10 @@ export interface XYFrameAxisConfig {
    *  custom strokeDasharray string. Applied to grid lines extending
    *  from ticks across the chart area. */
   gridStyle?: "dashed" | "dotted" | string
+  /** Set false to suppress grid lines emitted from this axis while retaining
+   * its ticks and baseline. For example, set the bottom axis to `false` for
+   * horizontal-only (y-axis) grid lines. */
+  grid?: boolean
   /** Always include the domain max as a tick, even if d3 omits it. */
   includeMax?: boolean
   /** Auto-rotate labels 45° when horizontal spacing is too tight. */


### PR DESCRIPTION
Restores multi-series tooltip context for custom tooltip functions by preserving hover-root fields (`allSeries`/`xValue`) after datum unwrapping, with new regression coverage for `LineChart` multi-tooltip behavior (including `lineDataAccessor`).

Improves rendering parity and axis customization by adding per-axis grid opt-out (`axis.grid`) to SVG underlay/overlay and static SSR grid rendering, adding `adaptiveTimeTicks(..., { utc: false })` while keeping UTC as the default, and propagating `fillOpacity`/`strokeOpacity` through hierarchy/network SVG output and canvas stroke painting so treemap and network opacity behavior matches canvas/SSR expectations.

This pull request adds new tests and improves existing functionality and coverage for chart components, with a focus on tooltips, grid rendering, and time tick formatting. It also fixes a regression with custom multi-series tooltips and enhances server-side SVG rendering for Treemap and grid lines. The most important changes are summarized below.

### Tooltip and Hover Behavior Improvements

* Fixed a regression where custom function tooltips could not access `allSeries` in multi-series (`tooltip="multi"`) mode by ensuring these fields are re-attached after unwrapping the datum in `normalizeTooltip`, allowing custom tooltips to behave like the built-in `MultiPointTooltip` (`src/components/Tooltip/Tooltip.tsx`, `Tooltip.test.tsx`, `scenarios/linechart-linedataaccessor-multi-tooltip.test.tsx`). [[1]](diffhunk://#diff-861240fa85e92a6425d07ac1df273c214b9cf97d611c917be6bd835ffadaa617R537-R558) [[2]](diffhunk://#diff-6bab1489fbf9d9e083fa98db5f1d8d512d1003477f42e50ab09064a57df4330dR439-R486) [[3]](diffhunk://#diff-9a39fbb631a0a65990fb233ceee3659f54e11222543904d396d6770ea00b4ec4R1-R157)
* Added comprehensive regression tests to verify that both built-in and custom function tooltips receive the correct multi-series hover context, especially when using `lineDataAccessor` on `LineChart`.

### Time Tick Formatting Enhancements

* Extended `adaptiveTimeTicks` to support local time formatting (not just UTC) via a new options argument, updated the implementation to use local or UTC calendar boundaries as appropriate, and added tests to verify both modes. [[1]](diffhunk://#diff-115e9b0a1b1aedc4b156012ef60dd6cedc01ef06be0d34be5e27e31ed35958b7R201-R207) [[2]](diffhunk://#diff-115e9b0a1b1aedc4b156012ef60dd6cedc01ef06be0d34be5e27e31ed35958b7L231-R258) [[3]](diffhunk://#diff-115e9b0a1b1aedc4b156012ef60dd6cedc01ef06be0d34be5e27e31ed35958b7L252-R287) [[4]](diffhunk://#diff-115e9b0a1b1aedc4b156012ef60dd6cedc01ef06be0d34be5e27e31ed35958b7R336-R337) [[5]](diffhunk://#diff-115e9b0a1b1aedc4b156012ef60dd6cedc01ef06be0d34be5e27e31ed35958b7R348-R359) [[6]](diffhunk://#diff-115e9b0a1b1aedc4b156012ef60dd6cedc01ef06be0d34be5e27e31ed35958b7L345-R378) [[7]](diffhunk://#diff-041cdf18ccbe578a80cae9d80d4d25c5d8785cc782acadf567453d43a649e390R1-R33)

### Server-side Rendering and Grid Lines

* Improved SSR for grid lines in XY charts: added support for rendering horizontal-only grid lines (e.g., dashed y-grid with no x-grid) and added a test to verify correct SVG output.
* Enhanced Treemap SSR by ensuring per-tile fill and stroke opacity are serialized, preserving visual parity with client-side canvas rendering, and added tests to cover these cases.

### Internal Refactoring

* Refactored grid rendering to pass axis configurations into `renderGridSVG`, preparing for more flexible grid rendering logic. [[1]](diffhunk://#diff-4215ba04f24f5fdc250a3ec1b8d5ba3a56a04a8f8ac726d2cfc352578c02c7ebR6) [[2]](diffhunk://#diff-4215ba04f24f5fdc250a3ec1b8d5ba3a56a04a8f8ac726d2cfc352578c02c7ebR29) [[3]](diffhunk://#diff-4215ba04f24f5fdc250a3ec1b8d5ba3a56a04a8f8ac726d2cfc352578c02c7ebL395-R398)

### Additional Testing

* Added a new probe test for basic bar and line chart rendering, verifying font-size usage and text elements in SVG output. (.probe/probe.test.tsx)