### PR TITLE
Post Tier Work Niceties

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,62 @@ jobs:
       - name: Verify every committed visual baseline without updates
         run: npx playwright test --project=${{ matrix.project }} --update-snapshots=none
 
+  docs-examples:
+    name: Docs examples (Chromium)
+    runs-on: ubuntu-latest
+    # The suite is serial to keep source-route behavior deterministic. Give
+    # legitimate cold transforms room to finish, but bound a stalled Vite or
+    # browser worker so publication cannot wait indefinitely.
+    timeout-minutes: 25
+    # Authored example routes use their own Vite/source-alias server and are
+    # intentionally excluded from the package visual matrix above. Re-run
+    # them independently on the tagged source so a green PR requirement is
+    # not the only protection before publication.
+    container: mcr.microsoft.com/playwright:v1.61.1-noble
+    env:
+      HOME: /root
+      DOCKER_CONFIG: /tmp/semiotic-docker-config
+
+    steps:
+      - name: Checkout tagged source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Use Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22.x
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run docs example source tests
+        run: npm run test:examples:source
+
+      - name: Upload local docs example contract evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-docs-example-local-contract-evidence
+          path: test-results/**/docs-example-local-contract-evidence.v2.json
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload docs example test artifacts
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-playwright-report-docs-examples
+          path: |
+            test-results/
+            integration-tests/test-results/
+          retention-days: 7
+
   publish:
-    needs: visual-contracts
+    needs: [visual-contracts, docs-examples]
     runs-on: ubuntu-latest
     outputs:
       dist_tag: ${{ steps.dist-tag.outputs.tag }}

--- a/ai/reference.md
+++ b/ai/reference.md
@@ -270,7 +270,7 @@ All HOCs accept `annotations`. Coordinates use data field names.
 
 ## Theming
 
-CSS custom properties: `--semiotic-{bg, text, text-secondary, border, grid, primary, secondary, surface, success, danger, warning, error, info, focus, font-family, annotation-color, legend-font-size, title-font-size, tick-font-family, tick-font-size (12px), axis-label-font-size (12px), tooltip-{bg, text, radius, font-size, shadow}}`.
+CSS custom properties: `--semiotic-{bg, text, text-secondary, border, grid, primary, secondary, surface, success, danger, warning, error, info, focus, font-family, annotation-color, legend-font-size, legend-font-family, legend-font-weight, title-font-size, title-font-family, title-font-weight, tick-font-family, tick-font-size (12px), axis-label-font-size (12px), tooltip-{bg, text, radius, font-size, shadow}}`.
 
 ```jsx
 <ThemeProvider theme="tufte">                                            {/* named preset */}
@@ -279,7 +279,7 @@ CSS custom properties: `--semiotic-{bg, text, text-secondary, border, grid, prim
 
 **Color priority** (with `colorBy`): CategoryColorProvider/LinkedCharts map > `colorScheme` > ThemeProvider `colors.categorical` > `"category10"`. `colorScheme` accepts a named scheme (`"tableau10"`), an array, or a `{category: color}` **object map** for exact per-category colors (no array ordering to keep in sync).
 Presets: `light`, `dark`, `high-contrast`, `pastels`(-dark), `bi-tool`(-dark), `italian`(-dark), `tufte`(-dark), `journalist`(-dark), `playful`(-dark), `carbon`(-dark).
-Serialization: `themeToCSS(theme, selector)`, `themeToTokens(theme)`, `resolveThemePreset(name)`.
+Serialization: `themeToCSS(theme, selector)`, `themeToTokens(theme)`, `designTokensToTheme(tokens)`, `resolveThemePreset(name)`. Native `semiotic.*` tokens round-trip title/legend size, family, and weight along with the base typography and color roles.
 
 **Semantic status roles** (every preset): `colors.success/danger/warning/error/info` + `secondary`/`surface`. Each emits as `--semiotic-{role}`. Use for status-driven charts: `<Waterfall positiveColor="var(--semiotic-success)" negativeColor="var(--semiotic-danger)" />`, `<Swimlane color="var(--semiotic-warning)" />`, status annotations.
 
@@ -308,7 +308,7 @@ Heuristic chart-suggestion engine — no LLM required. Charts ship capability de
 - **`rederiveProfile(profile, { primary? })`** → a new coherent `ChartDataProfile` after candidate edits or explicit primary-role changes. It revalidates assignments and recomputes category/series/x counts, repeated/monotonic x, provenance, and stackability together; assigning an identifier or non-candidate throws.
 - **`deriveProfileFields(data, candidates, fieldRoles, { primary? })`** → the lower-level derived-field projection used by `rederiveProfile`; use it when a profiler adapter owns candidates separately from the complete profile object.
 - **`suggestCharts(data, { intent?, allow?, deny?, maxResults?, includeVariants?, minScore?, audience?, identifiers?, fieldRoles? })`** → ranked `Suggestion[]` with `{ component, family, importPath, variant?, score, intentScores, rubric, reasons, caveats, props, propContract }`. `props` is spreadable directly. `propContract` declares `componentKind`, whether chart-HOC defaults apply, the heading prop, and the valid mode vocabulary; the same per-component contracts live in `ai/surface-manifest.json#components.suggestionPropContracts`. Capability `fieldPolicy` declarations are enforced after `buildProps`, so custom accessor vocabularies and direct values cannot reintroduce an identifier as a measure. **Receivability**: set `audience.receptionModality` (`visual` default | `screen-reader` | `sonified` | `agent`); a non-visual channel audits each candidate and down-ranks charts the audience can't receive there (8-slice pie for a screen reader), adding the audit's findings to `caveats[]` (familiarity and receivability are separate axes). `accessibilityCaveats(auditResult)` distils any audit into the same caveat strings.
-- **`scoreChart(component, data, { intent?, variantKey? })`** → evaluate a specific chart for a dataset.
+- **`scoreChart(component, data, { intent?, variantKey?, audience?, identifiers?, fieldRoles? })`** → evaluate a specific chart for a dataset. It applies the same audience familiarity, target, and non-visual receivability policy as `suggestCharts`, so a direct fit score and a ranked recommendation cannot disagree about the intended audience.
 - **`useChartSuggestions(data, options)`** → memoized React hook returning `{ suggestions, profile }`.
 - **`registerChartCapability(capability)`** / **`unregisterChartCapability(name)`** — runtime registration for custom charts.
 - **Intent taxonomy** (13 built-in): `trend`, `compare-series`, `compare-categories`, `rank`, `part-to-whole`, `distribution`, `correlation`, `flow`, `hierarchy`, `geo`, `outlier-detection`, `composition-over-time`, `change-detection`. Extend via `registerIntent`. A registered descriptor may declare `composes` plus optional `weights`; requested custom scores are blended from existing capability scores without changing no-intent/default rankings. `inferIntent(query, { mode: "schema", fields?, minimumConfidence? })` opts into whole-token field signals and typed data-shape signals; natural-language prose remains the default mode.

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -270,7 +270,7 @@ All HOCs accept `annotations`. Coordinates use data field names.
 
 ## Theming
 
-CSS custom properties: `--semiotic-{bg, text, text-secondary, border, grid, primary, secondary, surface, success, danger, warning, error, info, focus, font-family, annotation-color, legend-font-size, title-font-size, tick-font-family, tick-font-size (12px), axis-label-font-size (12px), tooltip-{bg, text, radius, font-size, shadow}}`.
+CSS custom properties: `--semiotic-{bg, text, text-secondary, border, grid, primary, secondary, surface, success, danger, warning, error, info, focus, font-family, annotation-color, legend-font-size, legend-font-family, legend-font-weight, title-font-size, title-font-family, title-font-weight, tick-font-family, tick-font-size (12px), axis-label-font-size (12px), tooltip-{bg, text, radius, font-size, shadow}}`.
 
 ```jsx
 <ThemeProvider theme="tufte">                                            {/* named preset */}
@@ -279,7 +279,7 @@ CSS custom properties: `--semiotic-{bg, text, text-secondary, border, grid, prim
 
 **Color priority** (with `colorBy`): CategoryColorProvider/LinkedCharts map > `colorScheme` > ThemeProvider `colors.categorical` > `"category10"`. `colorScheme` accepts a named scheme (`"tableau10"`), an array, or a `{category: color}` **object map** for exact per-category colors (no array ordering to keep in sync).
 Presets: `light`, `dark`, `high-contrast`, `pastels`(-dark), `bi-tool`(-dark), `italian`(-dark), `tufte`(-dark), `journalist`(-dark), `playful`(-dark), `carbon`(-dark).
-Serialization: `themeToCSS(theme, selector)`, `themeToTokens(theme)`, `resolveThemePreset(name)`.
+Serialization: `themeToCSS(theme, selector)`, `themeToTokens(theme)`, `designTokensToTheme(tokens)`, `resolveThemePreset(name)`. Native `semiotic.*` tokens round-trip title/legend size, family, and weight along with the base typography and color roles.
 
 **Semantic status roles** (every preset): `colors.success/danger/warning/error/info` + `secondary`/`surface`. Each emits as `--semiotic-{role}`. Use for status-driven charts: `<Waterfall positiveColor="var(--semiotic-success)" negativeColor="var(--semiotic-danger)" />`, `<Swimlane color="var(--semiotic-warning)" />`, status annotations.
 
@@ -308,7 +308,7 @@ Heuristic chart-suggestion engine — no LLM required. Charts ship capability de
 - **`rederiveProfile(profile, { primary? })`** → a new coherent `ChartDataProfile` after candidate edits or explicit primary-role changes. It revalidates assignments and recomputes category/series/x counts, repeated/monotonic x, provenance, and stackability together; assigning an identifier or non-candidate throws.
 - **`deriveProfileFields(data, candidates, fieldRoles, { primary? })`** → the lower-level derived-field projection used by `rederiveProfile`; use it when a profiler adapter owns candidates separately from the complete profile object.
 - **`suggestCharts(data, { intent?, allow?, deny?, maxResults?, includeVariants?, minScore?, audience?, identifiers?, fieldRoles? })`** → ranked `Suggestion[]` with `{ component, family, importPath, variant?, score, intentScores, rubric, reasons, caveats, props, propContract }`. `props` is spreadable directly. `propContract` declares `componentKind`, whether chart-HOC defaults apply, the heading prop, and the valid mode vocabulary; the same per-component contracts live in `ai/surface-manifest.json#components.suggestionPropContracts`. Capability `fieldPolicy` declarations are enforced after `buildProps`, so custom accessor vocabularies and direct values cannot reintroduce an identifier as a measure. **Receivability**: set `audience.receptionModality` (`visual` default | `screen-reader` | `sonified` | `agent`); a non-visual channel audits each candidate and down-ranks charts the audience can't receive there (8-slice pie for a screen reader), adding the audit's findings to `caveats[]` (familiarity and receivability are separate axes). `accessibilityCaveats(auditResult)` distils any audit into the same caveat strings.
-- **`scoreChart(component, data, { intent?, variantKey? })`** → evaluate a specific chart for a dataset.
+- **`scoreChart(component, data, { intent?, variantKey?, audience?, identifiers?, fieldRoles? })`** → evaluate a specific chart for a dataset. It applies the same audience familiarity, target, and non-visual receivability policy as `suggestCharts`, so a direct fit score and a ranked recommendation cannot disagree about the intended audience.
 - **`useChartSuggestions(data, options)`** → memoized React hook returning `{ suggestions, profile }`.
 - **`registerChartCapability(capability)`** / **`unregisterChartCapability(name)`** — runtime registration for custom charts.
 - **Intent taxonomy** (13 built-in): `trend`, `compare-series`, `compare-categories`, `rank`, `part-to-whole`, `distribution`, `correlation`, `flow`, `hierarchy`, `geo`, `outlier-detection`, `composition-over-time`, `change-detection`. Extend via `registerIntent`. A registered descriptor may declare `composes` plus optional `weights`; requested custom scores are blended from existing capability scores without changing no-intent/default rankings. `inferIntent(query, { mode: "schema", fields?, minimumConfidence? })` opts into whole-token field signals and typed data-shape signals; natural-language prose remains the default mode.

--- a/docs/src/pages/features/CapabilityAuthoringPage.jsx
+++ b/docs/src/pages/features/CapabilityAuthoringPage.jsx
@@ -135,8 +135,8 @@ suggestCharts(data, { intent: "forecast-vs-actual" })`}</CodeBlock>
 })
 // → { intent: "forecast-vs-actual", source: "field-name", ... }
 
-// With no fields array, schema mode treats whitespace-delimited input as
-// field names — useful for compact catalog/schema summaries.
+// With no fields array, schema mode treats the complete query as one unknown
+// field boundary, so compound signals can still match compact summaries.
 inferIntent("cloud region phase throughput partitions", { mode: "schema" })`}</CodeBlock>
 
       <h2 id="semantic-viability">Post-render semantic viability</h2>

--- a/package-surface.manifest.json
+++ b/package-surface.manifest.json
@@ -192,6 +192,16 @@
           "kind": "types",
           "path": "dist/semiotic-experimental.d.ts",
           "sourceMap": false
+        },
+        {
+          "kind": "node.import",
+          "path": "dist/semiotic-experimental-node.module.min.js",
+          "sourceMap": false
+        },
+        {
+          "kind": "node.require",
+          "path": "dist/semiotic-experimental.min.js",
+          "sourceMap": false
         }
       ],
       "esm": true,
@@ -702,6 +712,16 @@
         {
           "kind": "types",
           "path": "dist/semiotic-server-edge.d.ts",
+          "sourceMap": false
+        },
+        {
+          "kind": "node.import",
+          "path": "dist/semiotic-server-edge-node.module.min.js",
+          "sourceMap": false
+        },
+        {
+          "kind": "node.require",
+          "path": "dist/semiotic-server-edge.min.js",
           "sourceMap": false
         }
       ],

--- a/package.json
+++ b/package.json
@@ -332,7 +332,7 @@
     "check:mcp-registry": "node scripts/check-mcp-registry.mjs",
     "check:mcp-registry-live": "node scripts/check-mcp-registry-live.mjs",
     "check:surface": "node scripts/check-surface-parity.js",
-    "check:package-surface": "node scripts/generate-package-surface-manifest.mjs --check && node scripts/check-public-entrypoints.mjs",
+    "check:package-surface": "node scripts/generate-package-surface-manifest.mjs --check && node --test scripts/public-entrypoints.test.mjs && node scripts/check-public-entrypoints.mjs",
     "check:ai-surface": "node scripts/generate-ai-surface-manifest.mjs --check && node --test scripts/ai-surface-manifest.test.mjs",
     "check:agent-skill": "node scripts/check-agent-skill.mjs",
     "eval:ai": "node scripts/run-ai-evals.mjs",

--- a/package.json
+++ b/package.json
@@ -332,7 +332,7 @@
     "check:mcp-registry": "node scripts/check-mcp-registry.mjs",
     "check:mcp-registry-live": "node scripts/check-mcp-registry-live.mjs",
     "check:surface": "node scripts/check-surface-parity.js",
-    "check:package-surface": "node scripts/generate-package-surface-manifest.mjs --check",
+    "check:package-surface": "node scripts/generate-package-surface-manifest.mjs --check && node scripts/check-public-entrypoints.mjs",
     "check:ai-surface": "node scripts/generate-ai-surface-manifest.mjs --check && node --test scripts/ai-surface-manifest.test.mjs",
     "check:agent-skill": "node scripts/check-agent-skill.mjs",
     "eval:ai": "node scripts/run-ai-evals.mjs",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -8,6 +8,7 @@ import {
   writeFileSync
 } from "fs"
 import { build as tsupBuild } from "tsup"
+import { publicJavaScriptEntrypoints } from "./lib/public-entrypoints.mjs"
 
 const args = process.argv.slice(2)
 const isProduction = args.includes("--production")
@@ -786,39 +787,7 @@ function buildDeclarations() {
   // include the missing `components/` segment so consumers using Node-style
   // module resolution (TypeScript with `moduleResolution: "node"`) can follow
   // the re-export graph through the leaf declaration files.
-  const entryPoints = [
-    "semiotic",
-    "semiotic-ai",
-    "semiotic-ai-core",
-    "semiotic-data",
-    "semiotic-xy",
-    "semiotic-ordinal",
-    "semiotic-network",
-    "semiotic-realtime",
-    "semiotic-realtime-core",
-    "semiotic-realtime-react",
-    "semiotic-server",
-    "semiotic-server-node",
-    "semiotic-server-edge",
-    "semiotic-geo",
-    "semiotic-rough",
-    "semiotic-controls",
-    "semiotic-physics",
-    "semiotic-physics-matter",
-    "semiotic-physics-rapier",
-    "semiotic-themes",
-    "semiotic-themes-core",
-    "semiotic-themes-react",
-    "semiotic-utils",
-    "semiotic-utils-core",
-    "semiotic-utils-react",
-    "semiotic-recipes",
-    "semiotic-recipes-core",
-    "semiotic-recipes-react",
-    "semiotic-experimental",
-    "semiotic-experimental-vacp",
-    "semiotic-value"
-  ]
+  const entryPoints = publicJavaScriptEntrypoints(pkg).map((entry) => entry.sourceName)
   for (const name of entryPoints) {
     const src = `dist/components/${name}.d.ts`
     const dst = `dist/${name}.d.ts`
@@ -845,6 +814,58 @@ function buildDeclarations() {
     writeFileSync(dst, rewritten)
   }
   console.log("\u2705 declarations emitted")
+}
+
+function assertPublicBuildEntryParity(bundles) {
+  const expected = new Map(
+    publicJavaScriptEntrypoints(pkg).map((entry) => [entry.bundleName, entry])
+  )
+  const actual = new Map(bundles.map((bundle) => [bundle.name, bundle]))
+  const problems = []
+
+  for (const [name, entry] of expected) {
+    const bundle = actual.get(name)
+    if (!bundle) {
+      problems.push(`missing build entry ${name} for ${entry.specifier}`)
+    } else if (bundle.input !== entry.sourcePath) {
+      problems.push(
+        `${name} builds ${bundle.input}, expected ${entry.sourcePath} for ${entry.specifier}`
+      )
+    }
+  }
+  for (const name of actual.keys()) {
+    if (!expected.has(name)) problems.push(`build entry ${name} has no package export`)
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      "Public entry-point inventory drift:\n" + problems.map((problem) => `  - ${problem}`).join("\n")
+    )
+  }
+  console.log(`✅ public entry points aligned (${expected.size} package exports)`)
+}
+
+function assertPublicExportArtifacts() {
+  const required = new Map()
+  for (const entry of publicJavaScriptEntrypoints(pkg)) {
+    for (const artifact of entry.artifactTargets) {
+      if (!required.has(artifact.path)) {
+        required.set(artifact.path, [])
+      }
+      required.get(artifact.path).push(`${entry.specifier} (${artifact.condition})`)
+    }
+  }
+
+  const missing = [...required]
+    .filter(([path]) => !existsSync(path))
+    .map(([path, owners]) => `${path} required by ${owners.join(", ")}`)
+  if (missing.length > 0) {
+    throw new Error(
+      "Published JavaScript export artifacts are missing:\n" +
+        missing.map((entry) => `  - ${entry}`).join("\n")
+    )
+  }
+  console.log(`✅ public export artifacts verified (${required.size} files)`)
 }
 
 function cleanDist() {
@@ -1171,6 +1192,8 @@ async function build() {
     }
   ]
 
+  assertPublicBuildEntryParity(bundles)
+
   const bundledEntries = bundles.map(applyGeneratedMetadata)
 
   buildDeclarations()
@@ -1370,6 +1393,7 @@ async function build() {
   await createPhysicsWorkerBundle({ minify })
   await createProcessSankeyLayoutWorkerBundle({ minify })
 
+  assertPublicExportArtifacts()
   assertNoEmptyJavaScriptArtifacts()
   assertDirectivePlacement(bundledEntries)
   assertBrowserCompatibleStaticMarkupImports()

--- a/scripts/check-public-entrypoints.mjs
+++ b/scripts/check-public-entrypoints.mjs
@@ -9,7 +9,6 @@
  */
 import { existsSync, readFileSync, readdirSync } from "node:fs"
 import { resolve } from "node:path"
-import { fileURLToPath } from "node:url"
 import { semioticSourceAliases } from "../vite.shared.mjs"
 import {
   REPO_ROOT,

--- a/scripts/check-public-entrypoints.mjs
+++ b/scripts/check-public-entrypoints.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Ensure all public-entry projections derive from one package-export inventory.
+ *
+ * `package.json#exports` is the only hand-authored publication list. Vite
+ * aliases and API snapshots are derived from scripts/lib/public-entrypoints;
+ * this check also reconciles that inventory with the generated package-surface
+ * manifest so a new subpath cannot silently miss one of those contracts.
+ */
+import { existsSync, readFileSync, readdirSync } from "node:fs"
+import { resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { semioticSourceAliases } from "../vite.shared.mjs"
+import {
+  REPO_ROOT,
+  publicJavaScriptEntrypoints,
+  stableApiEntrypoints
+} from "./lib/public-entrypoints.mjs"
+
+const repoRoot = REPO_ROOT
+const errors = []
+const entries = publicJavaScriptEntrypoints()
+const aliases = semioticSourceAliases(repoRoot)
+
+function sameSet(label, actual, expected) {
+  const actualSet = new Set(actual)
+  const expectedSet = new Set(expected)
+  const missing = [...expectedSet].filter((value) => !actualSet.has(value))
+  const extra = [...actualSet].filter((value) => !expectedSet.has(value))
+  if (missing.length > 0) errors.push(`${label} missing: ${missing.join(", ")}`)
+  if (extra.length > 0)
+    errors.push(`${label} has unexpected entries: ${extra.join(", ")}`)
+}
+
+for (const entry of entries) {
+  const source = resolve(repoRoot, entry.sourcePath)
+  if (!existsSync(source)) {
+    errors.push(
+      `${entry.specifier} source entry is missing: ${entry.sourcePath}`
+    )
+  }
+  const alias = aliases.find(({ find }) => find.test(entry.specifier))
+  if (!alias) {
+    errors.push(`${entry.specifier} has no Vite source alias`)
+  } else if (alias.replacement !== source) {
+    errors.push(
+      `${entry.specifier} alias resolves ${alias.replacement}, expected ${source}`
+    )
+  }
+}
+if (aliases.length !== entries.length) {
+  errors.push(
+    `Vite alias count is ${aliases.length}, expected ${entries.length}`
+  )
+}
+
+const packageSurfacePath = resolve(repoRoot, "package-surface.manifest.json")
+if (!existsSync(packageSurfacePath)) {
+  errors.push("package-surface.manifest.json is missing")
+} else {
+  const surface = JSON.parse(readFileSync(packageSurfacePath, "utf8"))
+  const surfaceEntries = (surface.entries ?? []).filter(
+    (entry) => entry.kind === "javascript-module"
+  )
+  sameSet(
+    "package-surface JavaScript subpaths",
+    surfaceEntries.map((entry) => entry.subpath),
+    entries.map((entry) => entry.subpath)
+  )
+  const surfaceBySubpath = new Map(
+    surfaceEntries.map((entry) => [entry.subpath, entry])
+  )
+  for (const entry of entries) {
+    const surfaceEntry = surfaceBySubpath.get(entry.subpath)
+    if (!surfaceEntry) continue
+    const actualArtifacts = (surfaceEntry.artifacts ?? [])
+      .filter((artifact) => /\.(?:[cm]?js)$/.test(artifact.path))
+      .map((artifact) => `${artifact.kind}:${artifact.path}`)
+    const expectedArtifacts = entry.artifactTargets.map(
+      (artifact) => `${artifact.condition}:${artifact.path}`
+    )
+    sameSet(
+      `${entry.specifier} package-surface artifacts`,
+      actualArtifacts,
+      expectedArtifacts
+    )
+  }
+}
+
+for (const entry of entries) {
+  if (entry.stableApi && !entry.declarationPath) {
+    errors.push(`${entry.specifier} is stable but has no exported types target`)
+  }
+}
+
+const snapshotDir = resolve(repoRoot, "etc/api-surface")
+const snapshots = existsSync(snapshotDir)
+  ? readdirSync(snapshotDir)
+      .filter((name) => name.endsWith(".api.md"))
+      .map((name) => name.replace(/\.api\.md$/, ""))
+  : []
+sameSet(
+  "API snapshots",
+  snapshots,
+  stableApiEntrypoints().map((entry) => entry.apiSnapshotName)
+)
+
+if (errors.length > 0) {
+  console.error("✗ public entry-point parity failed:")
+  for (const error of errors) console.error(`  - ${error}`)
+  console.error(
+    "\nUpdate package exports, source entry points, or regenerate the owning artifact."
+  )
+  process.exit(1)
+}
+
+console.log(
+  `✓ public entry points aligned (${entries.length} importable, ${stableApiEntrypoints().length} API snapshots)`
+)

--- a/scripts/generate-api-surface.mjs
+++ b/scripts/generate-api-surface.mjs
@@ -19,6 +19,7 @@ import { writeFileSync, mkdirSync, readdirSync, existsSync } from "node:fs"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import ts from "typescript"
+import { stableApiEntrypoints } from "./lib/public-entrypoints.mjs"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(__dirname, "..")
@@ -34,40 +35,13 @@ function argumentValue(name, fallback) {
   return value
 }
 
-// Map of entry-point name → its built `.d.ts` file.
-// `semiotic-experimental` is intentionally omitted: that sub-path is packaged
-// for collaborator previews, but is not a stable API contract for CI snapshots.
-const ENTRIES = {
-  semiotic: "dist/semiotic.d.ts",
-  "semiotic-xy": "dist/semiotic-xy.d.ts",
-  "semiotic-ordinal": "dist/semiotic-ordinal.d.ts",
-  "semiotic-network": "dist/semiotic-network.d.ts",
-  "semiotic-realtime": "dist/semiotic-realtime.d.ts",
-  "semiotic-realtime-core": "dist/semiotic-realtime-core.d.ts",
-  "semiotic-realtime-react": "dist/semiotic-realtime-react.d.ts",
-  "semiotic-server": "dist/semiotic-server.d.ts",
-  "semiotic-ai": "dist/semiotic-ai.d.ts",
-  "semiotic-ai-core": "dist/semiotic-ai-core.d.ts",
-  "semiotic-data": "dist/semiotic-data.d.ts",
-  "semiotic-geo": "dist/semiotic-geo.d.ts",
-  "semiotic-rough": "dist/semiotic-rough.d.ts",
-  "semiotic-physics": "dist/semiotic-physics.d.ts",
-  "semiotic-physics-matter": "dist/semiotic-physics-matter.d.ts",
-  "semiotic-physics-rapier": "dist/semiotic-physics-rapier.d.ts",
-  "semiotic-themes": "dist/semiotic-themes.d.ts",
-  "semiotic-themes-core": "dist/semiotic-themes-core.d.ts",
-  "semiotic-themes-react": "dist/semiotic-themes-react.d.ts",
-  "semiotic-utils": "dist/semiotic-utils.d.ts",
-  "semiotic-utils-core": "dist/semiotic-utils-core.d.ts",
-  "semiotic-utils-react": "dist/semiotic-utils-react.d.ts",
-  "semiotic-recipes": "dist/semiotic-recipes.d.ts",
-  "semiotic-recipes-core": "dist/semiotic-recipes-core.d.ts",
-  "semiotic-recipes-react": "dist/semiotic-recipes-react.d.ts",
-  "semiotic-value": "dist/semiotic-value.d.ts",
-  "semiotic-server-node": "dist/semiotic-server-node.d.ts",
-  "semiotic-server-edge": "dist/semiotic-server-edge.d.ts",
-  "semiotic-controls": "dist/semiotic-controls.d.ts",
-}
+// `package.json#exports` is the publishing authority. Derive every stable
+// declaration snapshot from the same inventory that Vite aliases and build
+// parity use; the experimental preview subpaths remain intentionally outside
+// the compatibility contract.
+const ENTRIES = Object.fromEntries(
+  stableApiEntrypoints().map((entry) => [entry.apiSnapshotName, entry.declarationPath])
+)
 
 // CI passes a temporary directory so surface verification never modifies
 // tracked snapshots. The default remains the checked-in location for the

--- a/scripts/generate-package-surface-manifest.mjs
+++ b/scripts/generate-package-surface-manifest.mjs
@@ -44,6 +44,37 @@ function isPrunedDeclarationPath(value) {
   return /(?:^|\/)(?:__tests__|test-utils|internal)(?:\/|$)/.test(value)
 }
 
+function collectConditionalArtifacts(value, prefix = "") {
+  if (!value || typeof value !== "object") return []
+  const artifacts = []
+  const directConditions = ["import", "default", "require", "types"]
+  for (const condition of directConditions) {
+    const target = value[condition]
+    if (typeof target !== "string") continue
+    const kind = prefix ? `${prefix}.${condition}` : condition
+    artifacts.push({
+      kind,
+      path: normalizeExportTarget(target),
+      sourceMap: PUBLISHED_SOURCE_MAP,
+    })
+  }
+  for (const [condition, target] of Object.entries(value)) {
+    if (directConditions.includes(condition) || typeof target !== "object" || !target) continue
+    const kind = prefix ? `${prefix}.${condition}` : condition
+    artifacts.push(...collectConditionalArtifacts(target, kind))
+  }
+  return artifacts
+}
+
+function terminalCondition(kind) {
+  return kind.split(".").at(-1)
+}
+
+function preferredArtifact(artifacts, condition) {
+  return artifacts.find(({ kind }) => kind === condition) ??
+    artifacts.find(({ kind }) => terminalCondition(kind) === condition)
+}
+
 /**
  * @typedef {"javascript-module"|"metadata"|"json-schema-resource"|"worker-asset"|"blocked-deep-path"} SurfaceKind
  */
@@ -134,35 +165,34 @@ function classifySubpath(subpath, value) {
     }
   }
 
-  const artifacts = []
+  const artifacts = collectConditionalArtifacts(value)
   let esm = false
   let cjs = false
 
-  for (const key of ["import", "default", "require", "types"]) {
-    if (typeof value[key] !== "string") continue
-    const normalized = normalizeExportTarget(value[key])
-    if (key === "require") cjs = true
-    if (key === "import" || key === "default") esm = true
-    artifacts.push({
-      kind: key,
-      path: normalized,
-      sourceMap: PUBLISHED_SOURCE_MAP,
-    })
+  for (const artifact of artifacts) {
+    const condition = terminalCondition(artifact.kind)
+    if (condition === "require") cjs = true
+    if (condition === "import" || condition === "default") esm = true
   }
 
   const jsLike = artifacts.some(({ path }) => path.endsWith(".js") || path.endsWith(".mjs"))
-  const hasTypes = artifacts.some(({ kind }) => kind === "types")
+  const primaryArtifact =
+    preferredArtifact(artifacts, "import") ??
+    preferredArtifact(artifacts, "default") ??
+    preferredArtifact(artifacts, "require") ??
+    artifacts.find(({ path }) => path.endsWith(".js") || path.endsWith(".mjs"))
+  const typesArtifact = preferredArtifact(artifacts, "types")
   return {
     kind: jsLike ? "javascript-module" : "metadata",
     subpath,
-    path: normalizeExportTarget(value.import || value.default || value.require || value.types || ""),
+    path: primaryArtifact?.path ?? typesArtifact?.path ?? "",
     reason: jsLike
       ? "Object export with ESM/CJS/module entries"
       : "Object-shaped metadata export",
     artifacts,
     esm,
     cjs,
-    types: hasTypes ? normalizeExportTarget(value.types) : undefined,
+    types: typesArtifact?.path,
   }
 }
 
@@ -190,9 +220,13 @@ function collectPublicDeclarations(exports) {
   for (const [subpath, value] of Object.entries(exports)) {
     if (subpath === "./package.json" || subpath === "./spec/*") continue
     if (typeof value !== "object" || value === null) continue
-    if (typeof value.types !== "string") continue
+    const typesArtifact = preferredArtifact(
+      collectConditionalArtifacts(value),
+      "types"
+    )
+    if (!typesArtifact) continue
 
-    const typesPath = normalizeExportTarget(value.types)
+    const typesPath = typesArtifact.path
     if (isPrunedDeclarationPath(typesPath)) {
       prunedDeclarations.add(typesPath)
       continue

--- a/scripts/lib/public-entrypoints.mjs
+++ b/scripts/lib/public-entrypoints.mjs
@@ -1,0 +1,114 @@
+/**
+ * Canonical public JavaScript entry-point inventory.
+ *
+ * `package.json#exports` remains the publication authority (npm requires it
+ * there). This module derives the corresponding source entry, package
+ * specifier, emitted bundle name, and API-snapshot name so Vite aliases,
+ * declarations, and release checks cannot each quietly maintain a different
+ * hand-written list.
+ */
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+export const REPO_ROOT = resolve(__dirname, "../..")
+
+function readPackageJson(repoRoot = REPO_ROOT) {
+  return JSON.parse(readFileSync(resolve(repoRoot, "package.json"), "utf8"))
+}
+
+function isJavaScriptTarget(value) {
+  return typeof value === "string" && /\.(?:[cm]?js)$/.test(value)
+}
+
+function conditionalTargets(value, conditions = []) {
+  if (typeof value === "string") return [{ conditions, target: value }]
+  if (!value || typeof value !== "object") return []
+  return Object.entries(value).flatMap(([condition, target]) =>
+    conditionalTargets(target, [...conditions, condition])
+  )
+}
+
+function preferredTarget(targets, condition) {
+  return (
+    targets.find(
+      (target) =>
+        target.conditions.length === 1 && target.conditions[0] === condition
+    ) ?? targets.find((target) => target.conditions.at(-1) === condition)
+  )
+}
+
+function sourceNameForSubpath(subpath) {
+  return subpath === "."
+    ? "semiotic"
+    : `semiotic-${subpath.slice(2).replaceAll("/", "-")}`
+}
+
+function bundleNameForTarget(target) {
+  return target.replace(/^\.\/dist\//, "").replace(/\.module\.min\.js$/, "")
+}
+
+/**
+ * Return every importable JavaScript public entry in package-export order.
+ * Experimental remains importable but is explicitly excluded from the stable
+ * API snapshot contract.
+ */
+export function publicJavaScriptEntrypoints(packageJson = readPackageJson()) {
+  return Object.entries(packageJson.exports ?? {}).flatMap(
+    ([subpath, value]) => {
+      const targets = conditionalTargets(value)
+      const javascriptTargets = targets.filter(({ target }) =>
+        isJavaScriptTarget(target)
+      )
+      if (javascriptTargets.length === 0) return []
+
+      // Prefer an ordinary browser import, but preserve node-only and
+      // condition-only exports in the inventory as well. A new public
+      // condition can therefore never quietly bypass Vite/build checks.
+      const entryTarget =
+        preferredTarget(javascriptTargets, "import") ??
+        preferredTarget(javascriptTargets, "default") ??
+        preferredTarget(javascriptTargets, "require") ??
+        javascriptTargets[0]
+      const typesTarget = preferredTarget(targets, "types")
+
+      const sourceName = sourceNameForSubpath(subpath)
+      return [
+        {
+          subpath,
+          specifier:
+            subpath === "."
+              ? packageJson.name
+              : `${packageJson.name}/${subpath.slice(2)}`,
+          sourceName,
+          sourcePath: `src/components/${sourceName}.ts`,
+          bundleName: bundleNameForTarget(entryTarget.target),
+          declarationPath: typesTarget?.target.replace(/^\.\//, ""),
+          artifactTargets: javascriptTargets.map(({ conditions, target }) => ({
+            condition: conditions.join("."),
+            path: target.replace(/^\.\//, "")
+          })),
+          apiSnapshotName: sourceName,
+          stableApi: !subpath.startsWith("./experimental")
+        }
+      ]
+    }
+  )
+}
+
+export function stableApiEntrypoints(packageJson = readPackageJson()) {
+  const stableEntries = publicJavaScriptEntrypoints(packageJson).filter(
+    (entry) => entry.stableApi
+  )
+  const missingDeclarations = stableEntries.filter(
+    (entry) => !entry.declarationPath
+  )
+  if (missingDeclarations.length > 0) {
+    throw new Error(
+      "Stable public entries must declare a types target: " +
+        missingDeclarations.map((entry) => entry.specifier).join(", ")
+    )
+  }
+  return stableEntries
+}

--- a/scripts/public-entrypoints.test.mjs
+++ b/scripts/public-entrypoints.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+import {
+  publicJavaScriptEntrypoints,
+  stableApiEntrypoints
+} from "./lib/public-entrypoints.mjs"
+
+test("derives every importable package subpath and keeps previews out of API snapshots", () => {
+  const entries = publicJavaScriptEntrypoints()
+  assert.equal(entries.length, 31)
+  assert.equal(
+    entries.find((entry) => entry.subpath === "./xy")?.sourcePath,
+    "src/components/semiotic-xy.ts"
+  )
+  assert.equal(
+    entries.find((entry) => entry.subpath === "./server/edge")?.bundleName,
+    "semiotic-server-edge"
+  )
+  assert.equal(
+    entries.find((entry) => entry.subpath === "./experimental")?.stableApi,
+    false
+  )
+  assert.equal(
+    entries.find((entry) => entry.subpath === "./experimental/vacp")?.stableApi,
+    false
+  )
+  assert.equal(stableApiEntrypoints().length, 29)
+})
+
+test("retains condition-only JavaScript exports in the inventory", () => {
+  const entries = publicJavaScriptEntrypoints({
+    name: "semiotic",
+    exports: {
+      "./node-only": {
+        node: {
+          import: "./dist/semiotic-node-only.module.min.js",
+          require: "./dist/semiotic-node-only.min.js"
+        },
+        types: "./dist/semiotic-node-only.d.ts"
+      }
+    }
+  })
+
+  assert.deepEqual(entries, [
+    {
+      subpath: "./node-only",
+      specifier: "semiotic/node-only",
+      sourceName: "semiotic-node-only",
+      sourcePath: "src/components/semiotic-node-only.ts",
+      bundleName: "semiotic-node-only",
+      declarationPath: "dist/semiotic-node-only.d.ts",
+      artifactTargets: [
+        {
+          condition: "node.import",
+          path: "dist/semiotic-node-only.module.min.js"
+        },
+        {
+          condition: "node.require",
+          path: "dist/semiotic-node-only.min.js"
+        }
+      ],
+      apiSnapshotName: "semiotic-node-only",
+      stableApi: true
+    }
+  ])
+})
+
+test("records nested Node export conditions in the generated package surface", () => {
+  const manifest = JSON.parse(
+    readFileSync("package-surface.manifest.json", "utf8")
+  )
+  const edge = manifest.entries.find(
+    (entry) => entry.subpath === "./server/edge"
+  )
+  const experimental = manifest.entries.find(
+    (entry) => entry.subpath === "./experimental"
+  )
+
+  assert.ok(edge?.artifacts.some((artifact) => artifact.kind === "node.import"))
+  assert.ok(
+    experimental?.artifacts.some((artifact) => artifact.kind === "node.import")
+  )
+})

--- a/src/components/ai/generativeChart.test.ts
+++ b/src/components/ai/generativeChart.test.ts
@@ -124,6 +124,31 @@ describe("prepareChart", () => {
     expect(render).toHaveBeenCalledTimes(3)
   })
 
+  it("memoizes network inputs and scalar value-component configurations", () => {
+    const render = vi.fn((_component: string, _props: Record<string, unknown>) => ({
+      svg: "<svg />",
+      evidence: evidence({}),
+    }))
+    const memo = createRenderEvidenceMemo(render)
+    const nodes = [{ id: "a" }, { id: "b" }]
+    const edges = [{ source: "a", target: "b", value: 3 }]
+
+    memo.render("ForceDirectedGraph", { nodes, edges })
+    memo.render("ForceDirectedGraph", { nodes, edges })
+    expect(render).toHaveBeenCalledTimes(1)
+
+    memo.render("ForceDirectedGraph", { nodes, edges: [...edges] })
+    memo.render("ForceDirectedGraph", { nodes: [...nodes], edges })
+    expect(render).toHaveBeenCalledTimes(3)
+
+    // BigNumber has no `data`/`nodes`/`edges` identity. Equivalent primitive
+    // configurations still share the small bounded value-config cache.
+    memo.render("BigNumber", { value: 42, label: "Revenue", format: "currency" })
+    memo.render("BigNumber", { value: 42, label: "Revenue", format: "currency" })
+    memo.render("BigNumber", { value: 43, label: "Revenue", format: "currency" })
+    expect(render).toHaveBeenCalledTimes(5)
+  })
+
   it("does not collide prop bags containing the legacy cache delimiters", () => {
     const render = vi.fn((_component: string, props: Record<string, unknown>) => ({
       svg: `<svg data-props="${Object.keys(props).join(",")}" />`,

--- a/src/components/ai/generativeChart.ts
+++ b/src/components/ai/generativeChart.ts
@@ -42,7 +42,7 @@ export type RenderFn = (
   props: Datum
 ) => { svg: string; evidence: RenderEvidence }
 
-/** A bounded-by-input-identity cache for injected render-evidence oracles. */
+/** A bounded cache for injected render-evidence oracles. */
 export interface RenderEvidenceMemo {
   /** Pass this function as `PrepareChartOptions.render` or `EvaluateChartOptions.render`. */
   render: RenderFn
@@ -80,44 +80,104 @@ function memoToken(
 /**
  * Memoize an injected `(component, props) → SVG + evidence` oracle safely.
  *
- * Results are scoped to the identity of `props.data` and to every other prop's
- * primitive value or object/function identity. That avoids serializing user
- * callbacks or accidentally sharing a result across distinct datasets. Treat
- * data as immutable; call `clear()` after an in-place mutation or whenever an
- * external renderer dependency changes.
+ * Results are scoped to the identity of the chart's primary input (`data`,
+ * `nodes`, or `edges`) and to every other prop's primitive value or
+ * object/function identity. Value-backed components (for example BigNumber)
+ * use a small bounded configuration cache because their input is commonly a
+ * scalar rather than an array. This avoids serializing user callbacks or
+ * accidentally sharing a result across distinct inputs. Treat inputs as
+ * immutable; call `clear()` after an in-place mutation or whenever an external
+ * renderer dependency changes.
  */
+const MEMO_INPUT_PROPS = ["data", "nodes", "edges"] as const
+const VALUE_CONFIG_CACHE_LIMIT = 64
+
+interface MemoInput {
+  prop: string
+  value: object
+}
+
+function primaryMemoInput(props: Datum): MemoInput | undefined {
+  for (const prop of MEMO_INPUT_PROPS) {
+    const value = props[prop]
+    if (value !== null && (typeof value === "object" || typeof value === "function")) {
+      return { prop, value: value as object }
+    }
+  }
+  return undefined
+}
+
+function memoCacheKey(
+  component: string,
+  props: Datum,
+  objectIds: WeakMap<object, number>,
+  nextObjectId: { value: number },
+  excludedProp?: string,
+): string {
+  const key = Object.keys(props)
+    .filter((name) => name !== excludedProp)
+    .sort()
+    .map((name) => [name, memoToken(props[name], objectIds, nextObjectId)])
+  // Keep the component and sorted prop pairs as a structured value. Raw
+  // delimiter joining let string-valued props manufacture a second pair and
+  // collide with a distinct configuration.
+  return JSON.stringify([component, key])
+}
+
 export function createRenderEvidenceMemo(render: RenderFn): RenderEvidenceMemo {
-  let byData = new WeakMap<object, Map<string, ReturnType<RenderFn>>>()
+  let byInput = new WeakMap<object, Map<string, ReturnType<RenderFn>>>()
+  let valueConfigurations = new Map<string, ReturnType<RenderFn>>()
   const objectIds = new WeakMap<object, number>()
   const nextObjectId = { value: 1 }
 
   return {
     render(component, props) {
-      const data = props.data
-      if (data === null || (typeof data !== "object" && typeof data !== "function")) {
-        return render(component, props)
+      const input = primaryMemoInput(props)
+      if (!input) {
+        // Value components usually receive a primitive `value`, so they cannot
+        // use a WeakMap identity key. Keep their fully-keyed configurations
+        // bounded rather than making every BigNumber render miss the cache.
+        if (!Object.prototype.hasOwnProperty.call(props, "value")) {
+          return render(component, props)
+        }
+        const cacheKey = memoCacheKey(component, props, objectIds, nextObjectId)
+        const cached = valueConfigurations.get(cacheKey)
+        if (cached !== undefined) {
+          // Refresh insertion order so this behaves as a compact LRU cache.
+          valueConfigurations.delete(cacheKey)
+          valueConfigurations.set(cacheKey, cached)
+          return cached
+        }
+        const result = render(component, props)
+        if (valueConfigurations.size >= VALUE_CONFIG_CACHE_LIMIT) {
+          const oldest = valueConfigurations.keys().next().value as string | undefined
+          if (oldest !== undefined) valueConfigurations.delete(oldest)
+        }
+        valueConfigurations.set(cacheKey, result)
+        return result
       }
-      const key = Object.keys(props)
-        .filter((name) => name !== "data")
-        .sort()
-        .map((name) => [name, memoToken(props[name], objectIds, nextObjectId)])
-      // Keep the component and sorted prop pairs as a structured value. Raw
-      // delimiter joining let string-valued props manufacture a second pair
-      // and collide with a distinct configuration.
-      const cacheKey = JSON.stringify([component, key])
-      let entries = byData.get(data)
+
+      const cacheKey = memoCacheKey(
+        component,
+        props,
+        objectIds,
+        nextObjectId,
+        input.prop,
+      )
+      let entries = byInput.get(input.value)
       if (!entries) {
         entries = new Map()
-        byData.set(data, entries)
+        byInput.set(input.value, entries)
       }
       const cached = entries.get(cacheKey)
-      if (cached) return cached
+      if (cached !== undefined) return cached
       const result = render(component, props)
       entries.set(cacheKey, result)
       return result
     },
     clear() {
-      byData = new WeakMap()
+      byInput = new WeakMap()
+      valueConfigurations = new Map()
     },
   }
 }

--- a/src/components/ai/inferIntent.test.ts
+++ b/src/components/ai/inferIntent.test.ts
@@ -81,6 +81,34 @@ describe("inferIntent", () => {
     expect(result?.confidence).toBeGreaterThan(3)
   })
 
+  it("requires multi-token field signals to occur within one field", () => {
+    registerIntent({
+      id: "operating-margin-test",
+      label: "Operating margin",
+      description: "Test-only compound field signal.",
+      signals: {
+        fieldNames: ["operating margin"],
+        minimumFieldMatches: 1,
+      },
+    })
+
+    expect(inferIntent("", {
+      mode: "schema",
+      fields: [{ name: "operating" }, { name: "margin" }],
+    })).toBeNull()
+
+    expect(inferIntent("", {
+      mode: "schema",
+      fields: [{ name: "operating_margin" }],
+    })?.intent).toBe("operating-margin-test")
+
+    // Schema-mode's query shorthand has no real field boundary, so preserve
+    // phrase matching there while the explicit-fields path stays strict.
+    expect(inferIntent("operating margin", {
+      mode: "schema",
+    })?.intent).toBe("operating-margin-test")
+  })
+
   it("uses typed data shape only in schema mode", () => {
     const result = inferIntent("", {
       mode: "schema",
@@ -93,6 +121,24 @@ describe("inferIntent", () => {
       intent: "trend",
       source: "data-shape",
     })
+  })
+
+  it("does not classify arbitrary temp-prefixed kinds as temporal", () => {
+    expect(inferIntent("", {
+      mode: "schema",
+      fields: [
+        { name: "recorded_at", kind: "temporal" },
+        { name: "throughput", kind: "number" },
+      ],
+    })?.intent).toBe("trend")
+
+    expect(inferIntent("", {
+      mode: "schema",
+      fields: [
+        { name: "temperature", kind: "temperature" },
+        { name: "throughput", kind: "number" },
+      ],
+    })).toBeNull()
   })
 
   it("honors a caller confidence floor for ambiguous schemas", () => {

--- a/src/components/ai/inferIntent.ts
+++ b/src/components/ai/inferIntent.ts
@@ -176,6 +176,13 @@ type AccumulatedMatch = [confidence: number, sourceMask: number]
 const PROSE_SOURCE = 1
 const FIELD_SOURCE = 2
 const SHAPE_SOURCE = 4
+const DATE_KIND_ALIASES = new Set([
+  "date",
+  "time",
+  "datetime",
+  "timestamp",
+  "temporal",
+])
 
 function addMatch(
   matches: Map<IntentId, AccumulatedMatch>,
@@ -198,7 +205,10 @@ function normalizeKind(kind: string | undefined): IntentFieldKind {
   const value = kind?.trim().toLowerCase() ?? ""
   if (/^(num|int|float|double|decimal)/.test(value)) return "numeric"
   if (/^(cat|string|enum|nominal|ordinal)/.test(value)) return "categorical"
-  if (/^(date|time|temp)/.test(value)) return "date"
+  // Accept common date/time spellings, but do not turn unrelated schema
+  // types such as "temperature" or "template" into temporal fields.
+  const dateAlias = value.replace(/[\s_-]/g, "")
+  if (DATE_KIND_ALIASES.has(dateAlias)) return "date"
   if (/^bool/.test(value)) return "boolean"
   return "unknown"
 }
@@ -224,11 +234,21 @@ function collectSchemaMatches(
   fieldsInput: InferIntentOptions["fields"],
   matches: Map<IntentId, AccumulatedMatch>,
 ): void {
-  const source = fieldsInput?.length ? fieldsInput : query.trim().split(/\s+/)
+  // Without explicit schema fields, the query is one unknown field boundary
+  // rather than a list of one-word fields. This preserves phrase matching for
+  // callers using the schema-mode shorthand while explicit `fields` retain
+  // their real per-field boundaries below.
+  const source = fieldsInput?.length
+    ? fieldsInput
+    : query.trim()
+      ? [{ name: query }]
+      : []
   const fields = source.map((field) => (typeof field === "string" ? { name: field } : field))
   if (fields.length === 0) return
 
-  const fieldTokens = new Set(fields.flatMap((field) => normalizedFieldTokens(field.name)))
+  const fieldTokenSets = fields.map(
+    (field) => new Set(normalizedFieldTokens(field.name)),
+  )
   const kindCounts: Partial<Record<IntentFieldKind, number>> = {}
   for (const field of fields) {
     const kind = normalizeKind(field.kind)
@@ -245,7 +265,12 @@ function collectSchemaMatches(
         const signalTokens = normalizedFieldTokens(signal)
         return (
           signalTokens.length > 0 &&
-          signalTokens.every((token) => fieldTokens.has(token))
+          // A multi-token signal describes one field name. Pooling tokens
+          // across fields made { operating, margin } match "operating
+          // margin", even though no field actually carries that meaning.
+          fieldTokenSets.some((fieldTokens) =>
+            signalTokens.every((token) => fieldTokens.has(token)),
+          )
         )
       }).length
       const defaultMinimum = Math.min(2, names.length)

--- a/src/components/ai/intents.ts
+++ b/src/components/ai/intents.ts
@@ -211,18 +211,34 @@ const BUILT_IN_INTENTS: IntentDescriptor[] = [
   },
 ]
 
-const intentRegistry = new Map<IntentId, IntentDescriptor>(
-  BUILT_IN_INTENTS.map((intent) => [intent.id, intent])
-)
+interface IntentRegistryStore {
+  intents: Map<IntentId, IntentDescriptor>
+}
+
+// `semiotic/ai` and `semiotic/ai/core` are intentionally independent entry
+// bundles. Put the runtime extension point on the realm-global symbol registry
+// so registering an intent through either public entry is immediately visible
+// to the other (as recipe and numeric-contract registries already are).
+const REGISTRY_KEY = Symbol.for("semiotic.intentRegistry")
+
+function registryStore(): IntentRegistryStore {
+  const root = globalThis as typeof globalThis & {
+    [REGISTRY_KEY]?: IntentRegistryStore
+  }
+  root[REGISTRY_KEY] ??= {
+    intents: new Map(BUILT_IN_INTENTS.map((intent) => [intent.id, intent])),
+  }
+  return root[REGISTRY_KEY]
+}
 
 /** Get an intent descriptor by id, or undefined if not registered. */
 export function getIntent(id: IntentId): IntentDescriptor | undefined {
-  return intentRegistry.get(id)
+  return registryStore().intents.get(id)
 }
 
 /** All currently-registered intents (built-in + user-added). */
 export function listIntents(): IntentDescriptor[] {
-  return Array.from(intentRegistry.values())
+  return Array.from(registryStore().intents.values())
 }
 
 /**
@@ -230,7 +246,7 @@ export function listIntents(): IntentDescriptor[] {
  * replaces the descriptor.
  */
 export function registerIntent(intent: IntentDescriptor): void {
-  intentRegistry.set(intent.id, intent)
+  registryStore().intents.set(intent.id, intent)
 }
 
 function resolveComposedScore(
@@ -241,7 +257,7 @@ function resolveComposedScore(
   const direct = scores[id]
   if (Number.isFinite(direct)) return direct
 
-  const descriptor = intentRegistry.get(id)
+  const descriptor = registryStore().intents.get(id)
   if (!descriptor?.composes?.length || visiting.has(id)) return undefined
   visiting.add(id)
 

--- a/src/components/ai/publicEntryIntentRegistry.test.ts
+++ b/src/components/ai/publicEntryIntentRegistry.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest"
+import { execFile } from "node:child_process"
+import { promisify } from "node:util"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..")
+const execFileAsync = promisify(execFile)
+
+describe("custom intent registry across public entry bundles", () => {
+  it("shares registrations from semiotic/ai with semiotic/ai/core", async () => {
+    // Vitest's DOM setup patches TextEncoder, which esbuild rightly rejects.
+    // Bundle in a clean Node realm instead; the script still evaluates two
+    // independently emitted public-entry bundles in one globalThis.
+    const script = `
+      import { build } from "esbuild"
+      import { resolve } from "node:path"
+
+      const repoRoot = ${JSON.stringify(repoRoot)}
+      async function bundlePublicEntry(source) {
+        const result = await build({
+          stdin: {
+            contents: source,
+            resolveDir: repoRoot,
+            sourcefile: "intent-registry-public-entry.ts",
+            loader: "ts",
+          },
+          bundle: true,
+          format: "esm",
+          platform: "node",
+          target: "node20",
+          treeShaking: true,
+          write: false,
+          plugins: [{
+            name: "semiotic-public-entry-source",
+            setup(pluginBuild) {
+              pluginBuild.onResolve({ filter: /^semiotic\\/ai$/ }, () => ({
+                path: resolve(repoRoot, "src/components/semiotic-ai.ts"),
+              }))
+              pluginBuild.onResolve({ filter: /^semiotic\\/ai\\/core$/ }, () => ({
+                path: resolve(repoRoot, "src/components/semiotic-ai-core.ts"),
+              }))
+            },
+          }],
+        })
+        const output = result.outputFiles[0]?.text
+        if (!output) throw new Error("Expected an in-memory public-entry bundle")
+        return import("data:text/javascript;base64," + Buffer.from(output).toString("base64"))
+      }
+
+      const ai = await bundlePublicEntry(
+        'import { registerIntent } from "semiotic/ai"; export { registerIntent }',
+      )
+      const core = await bundlePublicEntry(
+        'import { getIntent } from "semiotic/ai/core"; export { getIntent }',
+      )
+      const id = "public-entry-intent-registry-test"
+      ai.registerIntent({
+        id,
+        label: "Public entry intent",
+        description: "Test-only intent registered through the AI catalog entry.",
+        composes: ["trend"],
+      })
+      console.log(JSON.stringify(core.getIntent(id)))
+    `
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      ["--input-type=module", "--eval", script],
+      { cwd: repoRoot, timeout: 30_000 },
+    )
+
+    expect(JSON.parse(stdout)).toMatchObject({
+      id: "public-entry-intent-registry-test",
+      label: "Public entry intent",
+    })
+  }, 30_000)
+})

--- a/src/components/ai/suggestCharts.test.ts
+++ b/src/components/ai/suggestCharts.test.ts
@@ -470,4 +470,38 @@ describe("scoreChart", () => {
     expect(result.status).toBe("rejected")
     if (result.status === "rejected") expect(result.reason).toMatch(/no capability/i)
   })
+
+  it("applies audience policy and receivability to built-in scores", () => {
+    const eightCategories = Array.from(
+      { length: 8 },
+      (_, i) => ({ vendor: `V${i}`, share: 20 - i }),
+    )
+    const baseline = scoreChart("PieChart", eightCategories, {
+      intent: "part-to-whole",
+    })
+    const audienceAdjusted = scoreChart("PieChart", eightCategories, {
+      intent: "part-to-whole",
+      audience: {
+        familiarity: { PieChart: 1 },
+        targets: {
+          PieChart: {
+            direction: "decrease",
+            weight: 2,
+            reason: "Prefer a more precise ranked view.",
+          },
+        },
+        receptionModality: "screen-reader",
+      },
+    })
+
+    expect(baseline.status).toBe("ok")
+    expect(audienceAdjusted.status).toBe("ok")
+    if (baseline.status !== "ok" || audienceAdjusted.status !== "ok") return
+
+    expect(audienceAdjusted.score).toBeLessThan(baseline.score - 2)
+    expect(audienceAdjusted.rubric.familiarity).toBe(1)
+    expect(audienceAdjusted.reasons).toContain("Prefer a more precise ranked view.")
+    expect(audienceAdjusted.reasons.some((reason) => reason.includes("screen reader"))).toBe(true)
+    expect(audienceAdjusted.caveats.some((caveat) => /slice|density/i.test(caveat))).toBe(true)
+  })
 })

--- a/src/components/ai/suggestCharts.ts
+++ b/src/components/ai/suggestCharts.ts
@@ -545,19 +545,36 @@ export function scoreChart(
   )
   const composite = compositeScore(intentScores, intents)
   const rubric = applyVariantToRubric(capability.rubric, variant)
-  const reasons = buildReasons(capability, profile, intentScores, intents)
   const recipeBias = recipeScoreAdjustment(capability, options)
   if (recipeBias.excluded) return { status: "rejected", reason: recipeBias.excluded }
+  const props = capability.buildProps(profile, variant)
+  const policyFailure = identifierMeasureViolation(capability, profile, props, variant)
+  if (policyFailure) return { status: "rejected", reason: policyFailure }
+
+  // Keep single-chart evaluation aligned with the ranked suggestion path:
+  // familiarity/target policy applies to every capability, while a non-visual
+  // audience also gets the same paint-independent receivability audit.
+  const modality = options.audience?.receptionModality
+  const receivability = modality && modality !== "visual"
+    ? receivabilityBias(auditAccessibility(capability.component, props as Datum), modality)
+    : undefined
+  const biased = applyAudienceBias(
+    composite,
+    rubric,
+    capability.component,
+    options.audience,
+    receivability,
+  )
+  const reasons = buildReasons(capability, profile, intentScores, intents)
+  if (biased.appliedReason) reasons.push(biased.appliedReason)
+  if (biased.receivabilityReason) reasons.push(biased.receivabilityReason)
   reasons.push(...recipeBias.reasons)
   const caveats = [
     ...(capability.caveats ? capability.caveats(profile, variant) : []),
     ...(variant?.caveats ?? []),
+    ...(receivability?.caveats.slice(0, 3) ?? []),
     ...recipeBias.caveats,
   ]
-
-  const props = capability.buildProps(profile, variant)
-  const policyFailure = identifierMeasureViolation(capability, profile, props, variant)
-  if (policyFailure) return { status: "rejected", reason: policyFailure }
 
   const resolvedComponent = variant?.component ?? capability.component
   return {
@@ -569,9 +586,9 @@ export function scoreChart(
     family: capability.family,
     importPath: capability.importPath,
     variant,
-    score: composite + recipeBias.delta,
+    score: biased.score + recipeBias.delta,
     intentScores,
-    rubric,
+    rubric: biased.rubric,
     reasons,
     caveats,
     props,

--- a/src/components/store/designTokens.test.ts
+++ b/src/components/store/designTokens.test.ts
@@ -29,6 +29,53 @@ describe("designTokensToTheme", () => {
     expect(recovered.colors.categorical).toEqual(theme.colors.categorical)
   })
 
+  it("round-trips title and legend typography through native tokens", () => {
+    const base = resolveThemePreset("tufte")!
+    const theme = {
+      ...base,
+      typography: {
+        ...base.typography,
+        legendSize: 13,
+        legendFontFamily: "Inter, sans-serif",
+        legendFontWeight: "500",
+        titleFontSize: 23,
+        titleFontFamily: "Merriweather, serif",
+        titleFontWeight: 650,
+      },
+    }
+
+    const tokens = themeToTokens(theme)
+    expect(tokens.semiotic["legend-font-family"]).toEqual({
+      $value: "Inter, sans-serif",
+      $type: "fontFamily",
+    })
+    expect(tokens.semiotic["legend-font-weight"]).toEqual({
+      $value: "500",
+      $type: "fontWeight",
+    })
+    expect(tokens.semiotic["title-font-family"]).toEqual({
+      $value: "Merriweather, serif",
+      $type: "fontFamily",
+    })
+    expect(tokens.semiotic["title-font-weight"]).toEqual({
+      $value: 650,
+      $type: "fontWeight",
+    })
+
+    expect(designTokensToTheme(tokens).typography).toMatchObject(theme.typography)
+  })
+
+  it("retains a preset's effective title size when titleFontSize is unset", () => {
+    for (const preset of ["high-contrast", "journalist"]) {
+      const theme = resolveThemePreset(preset)!
+      const recovered = designTokensToTheme(themeToTokens(theme))
+
+      expect(theme.typography.titleFontSize).toBeUndefined()
+      expect(recovered.typography.titleFontSize ?? recovered.typography.titleSize)
+        .toBe(theme.typography.titleSize)
+    }
+  })
+
   it("maps a foreign brand token file to roles by leaf name", () => {
     const brand = {
       color: {

--- a/src/components/store/designTokens.ts
+++ b/src/components/store/designTokens.ts
@@ -130,6 +130,25 @@ function isColor(t: FlatToken): boolean {
   return typeof t.value === "string" && (t.type === "color" || looksLikeColor(t.value))
 }
 
+function resolveFontFamily(value: unknown): string | undefined {
+  if (Array.isArray(value) && value.every((entry) => typeof entry === "string")) {
+    return value.join(", ")
+  }
+  return typeof value === "string" ? value : undefined
+}
+
+function resolvePixelDimension(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value !== "string") return undefined
+  const match = value.trim().match(/^(-?(?:\d+|\d*\.\d+))px$/)
+  return match ? Number(match[1]) : undefined
+}
+
+function resolveFontWeight(value: unknown): string | number | undefined {
+  if (typeof value === "string") return value
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
 // ── Mode detection ───────────────────────────────────────────────────────────
 
 /** Relative luminance of a hex or rgb(a) color (0 dark … 1 light); null if not parseable. */
@@ -229,13 +248,21 @@ export function designTokensToTheme(tokens: Datum, options: DesignTokensToThemeO
     (options.mapping?.fontFamily ? byPath.get(options.mapping.fontFamily) : undefined) ??
     byPath.get("semiotic.font-family") ??
     flat.find((t) => (t.type === "fontFamily" || /font-?family|typeface/i.test(t.leaf)) && (typeof t.value === "string" || Array.isArray(t.value)))
-  const fontFamily = fontToken
-    ? Array.isArray(fontToken.value)
-      ? fontToken.value.join(", ")
-      : typeof fontToken.value === "string"
-        ? fontToken.value
-        : undefined
-    : undefined
+  const fontFamily = fontToken ? resolveFontFamily(fontToken.value) : undefined
+
+  // Typography tokens are native-only by design. Unlike a generic brand
+  // font-family, title/legend treatments have no reliable leaf-name heuristic;
+  // preserving them here makes `designTokensToTheme(themeToTokens(theme))` an
+  // exact inverse for the public title/legend typography controls.
+  const legendSize = resolvePixelDimension(byPath.get("semiotic.legend-font-size")?.value)
+  const legendFontFamily = resolveFontFamily(byPath.get("semiotic.legend-font-family")?.value)
+  const legendFontWeight = resolveFontWeight(byPath.get("semiotic.legend-font-weight")?.value)
+  const titleFontSize = resolvePixelDimension(byPath.get("semiotic.title-font-size")?.value)
+  const titleFontFamily = resolveFontFamily(byPath.get("semiotic.title-font-family")?.value)
+  const titleFontWeight = resolveFontWeight(byPath.get("semiotic.title-font-weight")?.value)
+  const tickFontFamily = resolveFontFamily(byPath.get("semiotic.tick-font-family")?.value)
+  const tickSize = resolvePixelDimension(byPath.get("semiotic.tick-font-size")?.value)
+  const labelSize = resolvePixelDimension(byPath.get("semiotic.axis-label-font-size")?.value)
 
   // Mode + base theme.
   const bgLum = luminance(resolved.background)
@@ -253,6 +280,15 @@ export function designTokensToTheme(tokens: Datum, options: DesignTokensToThemeO
     typography: {
       ...base.typography,
       ...(fontFamily ? { fontFamily } : {}),
+      ...(legendSize != null ? { legendSize } : {}),
+      ...(legendFontFamily != null ? { legendFontFamily } : {}),
+      ...(legendFontWeight != null ? { legendFontWeight } : {}),
+      ...(titleFontSize != null ? { titleFontSize } : {}),
+      ...(titleFontFamily != null ? { titleFontFamily } : {}),
+      ...(titleFontWeight != null ? { titleFontWeight } : {}),
+      ...(tickFontFamily != null ? { tickFontFamily } : {}),
+      ...(tickSize != null ? { tickSize } : {}),
+      ...(labelSize != null ? { labelSize } : {}),
     },
   }
 }

--- a/src/components/store/themeSerialization.ts
+++ b/src/components/store/themeSerialization.ts
@@ -85,8 +85,24 @@ export function themeToTokens(theme: SemioticTheme): Datum {
       ...(theme.typography.legendSize != null ? {
         "legend-font-size": { $value: `${theme.typography.legendSize}px`, $type: "dimension" },
       } : {}),
-      ...(theme.typography.titleFontSize != null ? {
-        "title-font-size": { $value: `${theme.typography.titleFontSize}px`, $type: "dimension" },
+      ...(theme.typography.legendFontFamily != null ? {
+        "legend-font-family": { $value: theme.typography.legendFontFamily, $type: "fontFamily" },
+      } : {}),
+      ...(theme.typography.legendFontWeight != null ? {
+        "legend-font-weight": { $value: theme.typography.legendFontWeight, $type: "fontWeight" },
+      } : {}),
+      // titleSize is required and is the established fallback for the newer
+      // titleFontSize control. Serialize the effective value so a preset with
+      // no explicit override retains its visible title treatment on import.
+      "title-font-size": {
+        $value: `${theme.typography.titleFontSize ?? theme.typography.titleSize}px`,
+        $type: "dimension",
+      },
+      ...(theme.typography.titleFontFamily != null ? {
+        "title-font-family": { $value: theme.typography.titleFontFamily, $type: "fontFamily" },
+      } : {}),
+      ...(theme.typography.titleFontWeight != null ? {
+        "title-font-weight": { $value: theme.typography.titleFontWeight, $type: "fontWeight" },
       } : {}),
       ...(theme.typography.tickFontFamily != null ? {
         "tick-font-family": { $value: theme.typography.tickFontFamily, $type: "fontFamily" },

--- a/vite.shared.mjs
+++ b/vite.shared.mjs
@@ -1,45 +1,17 @@
 import { resolve } from "node:path"
+import { publicJavaScriptEntrypoints } from "./scripts/lib/public-entrypoints.mjs"
 
 export function semioticSourceAliases(repoRoot) {
-  return [
-    { find: /^semiotic\/ai$/, replacement: resolve(repoRoot, "src/components/semiotic-ai.ts") },
-    { find: /^semiotic\/ai\/core$/, replacement: resolve(repoRoot, "src/components/semiotic-ai-core.ts") },
-    { find: /^semiotic\/controls$/, replacement: resolve(repoRoot, "src/components/semiotic-controls.ts") },
-    { find: /^semiotic\/data$/, replacement: resolve(repoRoot, "src/components/semiotic-data.ts") },
-    { find: /^semiotic\/experimental\/vacp$/, replacement: resolve(repoRoot, "src/components/semiotic-experimental-vacp.ts") },
-    { find: /^semiotic\/experimental$/, replacement: resolve(repoRoot, "src/components/semiotic-experimental.ts") },
-    { find: /^semiotic\/geo$/, replacement: resolve(repoRoot, "src/components/semiotic-geo.ts") },
-    { find: /^semiotic\/network$/, replacement: resolve(repoRoot, "src/components/semiotic-network.ts") },
-    { find: /^semiotic\/ordinal$/, replacement: resolve(repoRoot, "src/components/semiotic-ordinal.ts") },
-    { find: /^semiotic\/physics$/, replacement: resolve(repoRoot, "src/components/semiotic-physics.ts") },
-    { find: /^semiotic\/physics\/matter$/, replacement: resolve(repoRoot, "src/components/semiotic-physics-matter.ts") },
-    { find: /^semiotic\/physics\/rapier$/, replacement: resolve(repoRoot, "src/components/semiotic-physics-rapier.ts") },
-    { find: /^semiotic\/realtime$/, replacement: resolve(repoRoot, "src/components/semiotic-realtime.ts") },
-    { find: /^semiotic\/realtime\/core$/, replacement: resolve(repoRoot, "src/components/semiotic-realtime-core.ts") },
-    { find: /^semiotic\/realtime\/react$/, replacement: resolve(repoRoot, "src/components/semiotic-realtime-react.ts") },
-    { find: /^semiotic\/recipes$/, replacement: resolve(repoRoot, "src/components/semiotic-recipes.ts") },
-    { find: /^semiotic\/recipes\/core$/, replacement: resolve(repoRoot, "src/components/semiotic-recipes-core.ts") },
-    { find: /^semiotic\/recipes\/react$/, replacement: resolve(repoRoot, "src/components/semiotic-recipes-react.ts") },
-    { find: /^semiotic\/rough$/, replacement: resolve(repoRoot, "src/components/semiotic-rough.ts") },
-    { find: /^semiotic\/server$/, replacement: resolve(repoRoot, "src/components/semiotic-server.ts") },
-    { find: /^semiotic\/server\/edge$/, replacement: resolve(repoRoot, "src/components/semiotic-server-edge.ts") },
-    { find: /^semiotic\/server\/node$/, replacement: resolve(repoRoot, "src/components/semiotic-server-node.ts") },
-    { find: /^semiotic\/themes$/, replacement: resolve(repoRoot, "src/components/semiotic-themes.ts") },
-    { find: /^semiotic\/themes\/core$/, replacement: resolve(repoRoot, "src/components/semiotic-themes-core.ts") },
-    { find: /^semiotic\/themes\/react$/, replacement: resolve(repoRoot, "src/components/semiotic-themes-react.ts") },
-    { find: /^semiotic\/utils$/, replacement: resolve(repoRoot, "src/components/semiotic-utils.ts") },
-    { find: /^semiotic\/utils\/core$/, replacement: resolve(repoRoot, "src/components/semiotic-utils-core.ts") },
-    { find: /^semiotic\/utils\/react$/, replacement: resolve(repoRoot, "src/components/semiotic-utils-react.ts") },
-    { find: /^semiotic\/value$/, replacement: resolve(repoRoot, "src/components/semiotic-value.ts") },
-    { find: /^semiotic\/xy$/, replacement: resolve(repoRoot, "src/components/semiotic-xy.ts") },
-    { find: /^semiotic$/, replacement: resolve(repoRoot, "src/components/semiotic.ts") },
-  ]
+  return publicJavaScriptEntrypoints().map(({ specifier, sourcePath }) => ({
+    find: new RegExp(`^${specifier.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`),
+    replacement: resolve(repoRoot, sourcePath)
+  }))
 }
 
 export function browserProcessDefines(mode) {
   const nodeEnv = mode === "production" ? "production" : "development"
   return {
     "process.env.NODE_ENV": JSON.stringify(nodeEnv),
-    "process.env.ANTHROPIC_API_KEY": JSON.stringify(process.env.ANTHROPIC_API_KEY ?? ""),
+    "process.env.ANTHROPIC_API_KEY": JSON.stringify(process.env.ANTHROPIC_API_KEY ?? "")
   }
 }


### PR DESCRIPTION
Resolves the following:

- Live y-band treats fillOpacity: 0 as 0.1; static correctly preserves zero.
 - Live/static frame-text defaults differ by one pixel.
 - Theme token serialization does not round-trip the new title/legend typography
  fields.

 - scoreChart accepts audience but ignores it for built-in scoring.
 - Intent inference can match a multi-token signal across separate fields and can
  classify arbitrary "temp..." kinds as temporal.

 - Generative memoization only recognizes props.data, missing node/edge and value-
  component configurations.

 - The custom-intent registry is entry-bundle-local.
 - Release CI does not independently rerun the docs example-source suite.
 - Package exports, Vite aliases, build entries, API snapshots, and generated
  artifacts need a more canonical shared manifest.