### PR TITLE
Handle docs lazy-load failures gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Docs routes recover from interrupted lazy-module loads** — failed Vite
+  preloads now trigger one guarded refresh, and repeated failures show a usable
+  reload action instead of leaving examples or other documentation routes on a
+  blank page in Safari.
 - **Automatic network legends now match in static rendering** —
   `renderChart()` and direct network SSR flatten hierarchy data when deriving
   legend categories, so Tree, Treemap, CirclePack, and Orbit output reserves

--- a/docs/public/docs-entry.jsx
+++ b/docs/public/docs-entry.jsx
@@ -1,1 +1,4 @@
+import { installVitePreloadRecovery } from "../src/preloadRecovery"
+
+installVitePreloadRecovery()
 import("../src/index.jsx")

--- a/docs/public/docs-entry.jsx
+++ b/docs/public/docs-entry.jsx
@@ -1,4 +1,4 @@
-import { installVitePreloadRecovery } from "../src/preloadRecovery"
+import { installVitePreloadRecovery, renderEntryLoadFallback } from "../src/preloadRecovery"
 
 installVitePreloadRecovery()
-import("../src/index.jsx")
+import("../src/index.jsx").catch(() => renderEntryLoadFallback())

--- a/docs/src/components/RouteLoadErrorBoundary.jsx
+++ b/docs/src/components/RouteLoadErrorBoundary.jsx
@@ -1,0 +1,57 @@
+import React from "react"
+
+export default class RouteLoadErrorBoundary extends React.Component {
+  state = { error: null }
+
+  static getDerivedStateFromError(error) {
+    return { error }
+  }
+
+  componentDidUpdate(previousProps) {
+    if (this.state.error && previousProps.resetKey !== this.props.resetKey) {
+      this.setState({ error: null })
+    }
+  }
+
+  render() {
+    if (!this.state.error) return this.props.children
+
+    const reloadHref =
+      typeof window === "undefined" ? this.props.resetKey || "/" : window.location.href
+
+    return (
+      <main
+        role="alert"
+        style={{
+          minHeight: "60vh",
+          padding: "72px 28px",
+          boxSizing: "border-box",
+          background: "var(--surface-0)",
+          color: "var(--text-primary)",
+        }}
+      >
+        <div style={{ width: "100%", maxWidth: 680, margin: "0 auto" }}>
+          <h1 style={{ marginTop: 0 }}>This page didn&apos;t finish loading</h1>
+          <p style={{ color: "var(--text-secondary)", lineHeight: 1.6 }}>
+            A site file may have changed during your visit or the network request was interrupted.
+          </p>
+          <a
+            href={reloadHref}
+            style={{
+              display: "inline-block",
+              marginTop: 12,
+              padding: "10px 16px",
+              borderRadius: 6,
+              background: "var(--accent)",
+              color: "var(--surface-0)",
+              fontWeight: 600,
+              textDecoration: "none",
+            }}
+          >
+            Reload page
+          </a>
+        </div>
+      </main>
+    )
+  }
+}

--- a/docs/src/components/RouteLoadErrorBoundary.jsx
+++ b/docs/src/components/RouteLoadErrorBoundary.jsx
@@ -1,4 +1,12 @@
 import React from "react"
+import { useLocation } from "react-router-dom"
+
+export function LocationAwareRouteLoadErrorBoundary({ children }) {
+  const location = useLocation()
+  const resetKey = `${location.pathname}${location.search}${location.hash}`
+
+  return <RouteLoadErrorBoundary resetKey={resetKey}>{children}</RouteLoadErrorBoundary>
+}
 
 export default class RouteLoadErrorBoundary extends React.Component {
   state = { error: null }

--- a/docs/src/components/RouteLoadErrorBoundary.test.jsx
+++ b/docs/src/components/RouteLoadErrorBoundary.test.jsx
@@ -1,0 +1,28 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import RouteLoadErrorBoundary from "./RouteLoadErrorBoundary"
+
+function FailedRoute() {
+  throw new TypeError("Importing a module script failed.")
+}
+
+describe("RouteLoadErrorBoundary", () => {
+  it("replaces a rejected route with a visible reload action", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    render(
+      <RouteLoadErrorBoundary resetKey="/examples/insight-forge">
+        <FailedRoute />
+      </RouteLoadErrorBoundary>,
+    )
+
+    expect(screen.getByRole("alert")).toBeTruthy()
+    expect(screen.getByRole("heading", { name: "This page didn't finish loading" })).toBeTruthy()
+    expect(screen.getByRole("link", { name: "Reload page" }).getAttribute("href")).toBe(
+      window.location.href,
+    )
+
+    vi.restoreAllMocks()
+  })
+})

--- a/docs/src/components/RouteLoadErrorBoundary.test.jsx
+++ b/docs/src/components/RouteLoadErrorBoundary.test.jsx
@@ -25,4 +25,31 @@ describe("RouteLoadErrorBoundary", () => {
 
     vi.restoreAllMocks()
   })
+
+  it("clears a route error when its location key changes", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+    let routeFails = true
+
+    function Route() {
+      if (routeFails) throw new TypeError("Importing a module script failed.")
+      return <h1>Recovered route</h1>
+    }
+
+    const { rerender } = render(
+      <RouteLoadErrorBoundary resetKey="/examples/insight-forge">
+        <Route />
+      </RouteLoadErrorBoundary>,
+    )
+    expect(screen.getByRole("alert")).toBeTruthy()
+
+    routeFails = false
+    rerender(
+      <RouteLoadErrorBoundary resetKey="/examples">
+        <Route />
+      </RouteLoadErrorBoundary>,
+    )
+
+    expect(screen.getByRole("heading", { name: "Recovered route" })).toBeTruthy()
+    vi.restoreAllMocks()
+  })
 })

--- a/docs/src/index.jsx
+++ b/docs/src/index.jsx
@@ -3,7 +3,7 @@ import "./index.css"
 import "../public/semiotic.css"
 import App from "./App"
 import { createRoot } from "react-dom/client"
-import RouteLoadErrorBoundary from "./components/RouteLoadErrorBoundary"
+import { LocationAwareRouteLoadErrorBoundary } from "./components/RouteLoadErrorBoundary"
 
 import { BrowserRouter } from "react-router-dom"
 
@@ -11,8 +11,8 @@ const root = createRoot(document.getElementById("root"))
 
 root.render(
   <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-    <RouteLoadErrorBoundary resetKey={window.location.pathname}>
+    <LocationAwareRouteLoadErrorBoundary>
       <App />
-    </RouteLoadErrorBoundary>
+    </LocationAwareRouteLoadErrorBoundary>
   </BrowserRouter>,
 )

--- a/docs/src/index.jsx
+++ b/docs/src/index.jsx
@@ -3,6 +3,7 @@ import "./index.css"
 import "../public/semiotic.css"
 import App from "./App"
 import { createRoot } from "react-dom/client"
+import RouteLoadErrorBoundary from "./components/RouteLoadErrorBoundary"
 
 import { BrowserRouter } from "react-router-dom"
 
@@ -10,6 +11,8 @@ const root = createRoot(document.getElementById("root"))
 
 root.render(
   <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-    <App />
+    <RouteLoadErrorBoundary resetKey={window.location.pathname}>
+      <App />
+    </RouteLoadErrorBoundary>
   </BrowserRouter>,
 )

--- a/docs/src/preloadRecovery.js
+++ b/docs/src/preloadRecovery.js
@@ -1,6 +1,28 @@
 export const PRELOAD_RECOVERY_KEY = "semiotic:preload-recovery-at"
 export const PRELOAD_RECOVERY_WINDOW_MS = 30_000
 
+export function renderEntryLoadFallback(target = document, location = window.location) {
+  const root = target.getElementById("root")
+  if (!root) return
+
+  const fallback = target.createElement("main")
+  fallback.setAttribute("role", "alert")
+
+  const heading = target.createElement("h1")
+  heading.textContent = "This page didn't finish loading"
+
+  const message = target.createElement("p")
+  message.textContent =
+    "A site file may have changed during your visit or the network request was interrupted."
+
+  const reloadLink = target.createElement("a")
+  reloadLink.href = location.href
+  reloadLink.textContent = "Reload page"
+
+  fallback.append(heading, message, reloadLink)
+  root.replaceChildren(fallback)
+}
+
 export function installVitePreloadRecovery(
   target = window,
   {
@@ -15,19 +37,20 @@ export function installVitePreloadRecovery(
     try {
       lastRecoveryAt = Number(target.sessionStorage.getItem(PRELOAD_RECOVERY_KEY) || 0)
     } catch {
-      // Safari can deny sessionStorage in restricted browsing contexts.
+      // Without persistent state, reloading could loop forever.
+      return
     }
 
     const recoveryAt = now()
     if (recoveryAt - lastRecoveryAt < recoveryWindowMs) return
 
-    event.preventDefault()
     try {
       target.sessionStorage.setItem(PRELOAD_RECOVERY_KEY, String(recoveryAt))
     } catch {
-      // Reload recovery still works when storage is unavailable; it just
-      // cannot apply the loop guard in that browsing context.
+      // Leave the rejection unhandled so the route or entry fallback renders.
+      return
     }
+    event.preventDefault()
     reload()
   }
 

--- a/docs/src/preloadRecovery.js
+++ b/docs/src/preloadRecovery.js
@@ -1,0 +1,36 @@
+export const PRELOAD_RECOVERY_KEY = "semiotic:preload-recovery-at"
+export const PRELOAD_RECOVERY_WINDOW_MS = 30_000
+
+export function installVitePreloadRecovery(
+  target = window,
+  {
+    now = Date.now,
+    reload = () => target.location.reload(),
+    recoveryWindowMs = PRELOAD_RECOVERY_WINDOW_MS,
+  } = {},
+) {
+  const handlePreloadError = (event) => {
+    let lastRecoveryAt = 0
+
+    try {
+      lastRecoveryAt = Number(target.sessionStorage.getItem(PRELOAD_RECOVERY_KEY) || 0)
+    } catch {
+      // Safari can deny sessionStorage in restricted browsing contexts.
+    }
+
+    const recoveryAt = now()
+    if (recoveryAt - lastRecoveryAt < recoveryWindowMs) return
+
+    event.preventDefault()
+    try {
+      target.sessionStorage.setItem(PRELOAD_RECOVERY_KEY, String(recoveryAt))
+    } catch {
+      // Reload recovery still works when storage is unavailable; it just
+      // cannot apply the loop guard in that browsing context.
+    }
+    reload()
+  }
+
+  target.addEventListener("vite:preloadError", handlePreloadError)
+  return () => target.removeEventListener("vite:preloadError", handlePreloadError)
+}

--- a/docs/src/preloadRecovery.test.js
+++ b/docs/src/preloadRecovery.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  PRELOAD_RECOVERY_KEY,
+  PRELOAD_RECOVERY_WINDOW_MS,
+  installVitePreloadRecovery,
+} from "./preloadRecovery"
+
+function createTarget() {
+  const listeners = new Map()
+  const values = new Map()
+  return {
+    addEventListener: (type, listener) => listeners.set(type, listener),
+    removeEventListener: (type) => listeners.delete(type),
+    sessionStorage: {
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => values.set(key, value),
+    },
+    dispatch: (type, event) => listeners.get(type)?.(event),
+    storedValue: (key) => values.get(key),
+  }
+}
+
+describe("installVitePreloadRecovery", () => {
+  it("prevents the failed import and reloads once", () => {
+    const target = createTarget()
+    const reload = vi.fn()
+    const preventDefault = vi.fn()
+
+    installVitePreloadRecovery(target, { now: () => 50_000, reload })
+    target.dispatch("vite:preloadError", { preventDefault })
+
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(reload).toHaveBeenCalledOnce()
+    expect(target.storedValue(PRELOAD_RECOVERY_KEY)).toBe("50000")
+  })
+
+  it("lets a repeated failure reach the route error boundary instead of reloading forever", () => {
+    const target = createTarget()
+    const reload = vi.fn()
+    const firstEvent = { preventDefault: vi.fn() }
+    const repeatedEvent = { preventDefault: vi.fn() }
+    let currentTime = 50_000
+
+    installVitePreloadRecovery(target, { now: () => currentTime, reload })
+    target.dispatch("vite:preloadError", firstEvent)
+    currentTime += PRELOAD_RECOVERY_WINDOW_MS - 1
+    target.dispatch("vite:preloadError", repeatedEvent)
+
+    expect(reload).toHaveBeenCalledOnce()
+    expect(repeatedEvent.preventDefault).not.toHaveBeenCalled()
+  })
+})

--- a/docs/src/preloadRecovery.test.js
+++ b/docs/src/preloadRecovery.test.js
@@ -3,6 +3,7 @@ import {
   PRELOAD_RECOVERY_KEY,
   PRELOAD_RECOVERY_WINDOW_MS,
   installVitePreloadRecovery,
+  renderEntryLoadFallback,
 } from "./preloadRecovery"
 
 function createTarget() {
@@ -48,5 +49,32 @@ describe("installVitePreloadRecovery", () => {
 
     expect(reload).toHaveBeenCalledOnce()
     expect(repeatedEvent.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it("does not reload when Safari denies session storage", () => {
+    const target = createTarget()
+    const reload = vi.fn()
+    const preventDefault = vi.fn()
+    target.sessionStorage.setItem = () => {
+      throw new DOMException("Access denied", "SecurityError")
+    }
+
+    installVitePreloadRecovery(target, { now: () => 50_000, reload })
+    target.dispatch("vite:preloadError", { preventDefault })
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(reload).not.toHaveBeenCalled()
+  })
+})
+
+describe("renderEntryLoadFallback", () => {
+  it("renders a reload action when the app entry module rejects", () => {
+    document.body.innerHTML = '<div id="root"></div>'
+
+    renderEntryLoadFallback(document, { href: "https://semiotic.nteract.io/examples/" })
+
+    expect(document.querySelector("main")?.getAttribute("role")).toBe("alert")
+    expect(document.querySelector("h1")?.textContent).toBe("This page didn't finish loading")
+    expect(document.querySelector("a")?.href).toBe("https://semiotic.nteract.io/examples/")
   })
 })


### PR DESCRIPTION
Add preload error recovery for the docs entrypoint so Vite preload failures trigger one guarded reload instead of leaving routes blank. Wrap docs, blog, and examples route trees in a new RouteLoadErrorBoundary that shows a usable reload UI after repeated failures, and add focused tests for both the preload loop guard and boundary fallback behavior.

