### PR TITLE
Improve issue/PR templates and fix d3-geo floor

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report a bug in Semiotic
-labels: ["bug"]
+labels: ["bug :bug:"]
 body:
   - type: textarea
     id: description
@@ -10,14 +10,41 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: component
+    attributes:
+      label: Component or API
+      description:
+        Name the chart, Stream Frame, renderer, MCP tool, CLI command, or other
+        affected API.
+      placeholder: LineChart
+    validations:
+      required: true
+
+  - type: input
+    id: import-path
+    attributes:
+      label: Import path
+      description:
+        Include the exact public package subpath or executable you use.
+      placeholder: semiotic/xy
+    validations:
+      required: true
+
   - type: textarea
     id: reproduction
     attributes:
-      label: Steps to reproduce
-      description: Minimal code or steps to reproduce the issue.
+      label: Minimal reproduction
+      description:
+        Include the smallest data and props/config plus the steps needed to
+        reproduce. Remove sensitive data.
       placeholder: |
         ```jsx
-        <LineChart data={[...]} xAccessor="x" yAccessor="y" />
+        <LineChart
+          data={[{ x: 1, y: 2 }]}
+          xAccessor="x"
+          yAccessor="y"
+        />
         ```
     validations:
       required: true
@@ -36,36 +63,47 @@ body:
       label: React version
       placeholder: "18.2.0"
 
-  - type: dropdown
-    id: component
+  - type: input
+    id: runtime-version
     attributes:
-      label: Component
+      label: Runtime and toolchain versions
+      description:
+        Include the browser or Node version and relevant bundler, framework,
+        test runner, or MCP client versions.
+      placeholder: Node 22.14, Jest 30, Next 16
+    validations:
+      required: true
+
+  - type: dropdown
+    id: renderer
+    attributes:
+      label: Renderer or output path
+      description: Select the path where the problem is visible.
       options:
-        - LineChart
-        - AreaChart
-        - StackedAreaChart
-        - Scatterplot
-        - BubbleChart
-        - Heatmap
-        - BarChart
-        - StackedBarChart
-        - GroupedBarChart
-        - SwarmPlot
-        - BoxPlot
-        - DotPlot
-        - PieChart
-        - DonutChart
-        - ForceDirectedGraph
-        - ChordDiagram
-        - SankeyDiagram
-        - TreeDiagram
-        - Treemap
-        - CirclePack
-        - RealtimeLineChart
-        - RealtimeHistogram
-        - RealtimeSwarmChart
-        - RealtimeWaterfallChart
-        - StreamXYFrame
-        - StreamOrdinalFrame
-        - StreamNetworkFrame
-        - Other
+        - Canvas
+        - Live SVG
+        - Static SVG or SSR
+        - PNG or GIF export
+        - MCP or CLI
+        - Packaging or types
+        - Other or multiple paths
+    validations:
+      required: true
+
+  - type: textarea
+    id: doctor-output
+    attributes:
+      label: Diagnostic output
+      description:
+        If relevant, paste `npx semiotic-ai --doctor` output or explain why it
+        is not applicable.
+      render: shell
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Additional evidence
+      description:
+        Add screenshots, render evidence, accessibility findings, console
+        output, or a minimal repository. Note whether equivalent Canvas, live
+        SVG, and static output were checked.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -23,3 +23,35 @@ body:
     attributes:
       label: Alternatives considered
       description: Have you tried any workarounds or alternatives?
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Primary surface
+      description: Where should this capability live?
+      options:
+        - High-level chart component
+        - Stream Frame or renderer
+        - Server or export API
+        - AI, schema, MCP, or CLI
+        - Documentation or examples
+        - Other or multiple surfaces
+    validations:
+      required: true
+
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: API and compatibility expectations
+      description:
+        Describe proposed props/import paths, existing behavior that must remain
+        unchanged, and serialization or tree-shaking constraints.
+
+  - type: textarea
+    id: evidence-plan
+    attributes:
+      label: Evidence plan
+      description:
+        List applicable Canvas/live SVG/static rendering, dark-theme,
+        accessibility, visual-baseline, chart-spec/schema, MCP, and
+        golden-example checks. Mark non-applicable surfaces explicitly.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,16 +2,47 @@
 
 <!-- What does this PR do? Keep it to 1-3 bullet points. -->
 
-## Test plan
+## Surface and compatibility
 
-<!-- How did you verify this works? Check all that apply. -->
+<!-- Name the affected components, family subpaths, renderer/runtime paths, and public API or schema changes. Write "None" where applicable. -->
 
-- [ ] `npm test` passes
-- [ ] `npm run dist` builds successfully
-- [ ] Tested in browser (if UI change)
-- [ ] Added/updated tests (if new behavior)
+- Components and import paths:
+- Renderers and runtimes:
+- Public API, schema, or generated artifacts:
+
+## Evidence
+
+<!-- Check the evidence required for the surfaces you changed. For an unchecked item, explain why it is not applicable. -->
+
+### Chart or rendering changes
+
+- [ ] Canvas and live SVG behavior were checked
+- [ ] Static/server rendering was checked
+- [ ] Light and dark themes were checked
+- [ ] Keyboard, screen-reader text/table, and other accessibility behavior were
+      checked
+- [ ] Visual baselines were added or reviewed
+- [ ] Not applicable — reason:
+
+### AI, schema, or MCP changes
+
+- [ ] Chart specs and generated schema/artifacts are synchronized
+- [ ] Relevant MCP/CLI smoke tests pass
+- [ ] Golden prompt/example coverage was added or reviewed
+- [ ] Not applicable — reason:
+
+## Verification
+
+<!-- List the exact commands and manual checks you ran, with any important output. -->
+
+- [ ] Focused tests cover new or changed behavior
+- [ ] Relevant lint and TypeScript checks pass
+- [ ] Relevant build, package, browser, or generated-artifact checks pass
+- [ ] Any check not run is listed with a reason
 
 ## Checklist
 
 - [ ] No unrelated changes included
 - [ ] CHANGELOG.md updated (if user-facing change)
+- [ ] Public API compatibility was preserved or the breaking change was
+      explicitly approved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cover Chromium, Firefox, and WebKit on macOS and pinned Linux.
 
 ### Changed
+- **Contribution templates ask for release-gate evidence** — bug reports now
+  capture the affected API/import, renderer, runtime/toolchain, minimal data and
+  props, and doctor output when relevant. Feature and pull-request templates
+  distinguish chart/rendering evidence from AI/schema/MCP evidence and provide
+  an explicit not-applicable path.
 - **Built-in recipe layouts load with the recipe renderer** — the browser AI
   entry still registers portable manifests for discovery, while
   `ParallelCoordinatesRecipe` and `CalendarHeatmapRecipe` layout implementations
@@ -202,6 +207,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returns the authored input shape.
 
 ### Fixed
+- **CommonJS recipe consumers can share d3 v7's geographic dependency** — the
+  declared `d3-geo` floor now matches the `geoBounds` and `geoContains` APIs
+  actually used, allowing a consumer-owned 3.1.0 resolution instead of a nested
+  ESM copy. Packed-consumer coverage now verifies the `require` condition and
+  touches every non-geographic recipe export before loading the lazy dot-grid
+  implementation.
 - **Constant-value heatmaps remain visible across renderers** — static,
   realtime, canvas, and server heatmaps resolve collapsed sequential domains
   at the palette midpoint instead of mapping every occupied cell to the

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "d3-brush": "^3.0.0",
         "d3-chord": "^3.0.1",
         "d3-force": "^3.0.0",
-        "d3-geo": "^3.1.1",
+        "d3-geo": "^3.1.0",
         "d3-hierarchy": "^3.1.2",
         "d3-interpolate": "^3.0.1",
         "d3-quadtree": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -548,7 +548,7 @@
     "d3-brush": "^3.0.0",
     "d3-chord": "^3.0.1",
     "d3-force": "^3.0.0",
-    "d3-geo": "^3.1.1",
+    "d3-geo": "^3.1.0",
     "d3-hierarchy": "^3.1.2",
     "d3-interpolate": "^3.0.1",
     "d3-quadtree": "^3.0.1",

--- a/scripts/smoke-pack.mjs
+++ b/scripts/smoke-pack.mjs
@@ -496,13 +496,36 @@ function checkCjsRecipeGeoIsolation(proj, failures) {
       if (request === "d3-geo") loaded = true
       return originalLoad.call(this, request, ...args)
     }
-    const nonGeoEntries = [
+    const recipeEntries = [
       "semiotic/recipes",
       "semiotic/recipes/core",
       "semiotic/recipes/react",
     ]
-    for (const entry of nonGeoEntries) require(entry)
-    if (loaded) throw new Error("a non-geo CJS entry eagerly loaded d3-geo")
+    const expectedEntry = require("node:path").join(
+      "dist",
+      "semiotic-recipes.min.js",
+    )
+    const resolvedEntry = require.resolve("semiotic/recipes")
+    if (!resolvedEntry.endsWith(expectedEntry)) {
+      throw new Error("semiotic/recipes did not resolve through its packed require condition: " + resolvedEntry)
+    }
+    const namespaces = recipeEntries.map((entry) => [entry, require(entry)])
+    if (loaded) throw new Error("a CJS recipe namespace eagerly loaded d3-geo")
+    const geoExports = new Set([
+      "geographicDotGridLayout",
+      "sampleGeographicDotGrid",
+    ])
+    let checked = 0
+    for (const [entry, namespace] of namespaces) {
+      for (const name of Object.keys(namespace)) {
+        if (geoExports.has(name)) continue
+        void namespace[name]
+        checked += 1
+        if (loaded) {
+          throw new Error(entry + " export " + name + " loaded d3-geo")
+        }
+      }
+    }
     const recipes = require("semiotic/recipes")
     if (typeof recipes.dagreLayout !== "function") {
       throw new Error("semiotic/recipes lost its non-geo dagreLayout export")
@@ -511,13 +534,67 @@ function checkCjsRecipeGeoIsolation(proj, failures) {
     if (typeof dotGrid !== "function" || !loaded) {
       throw new Error("geographic dot-grid export was not lazy-loadable")
     }
-    console.log("non-geo entries stayed d3-geo-free; geo recipe loaded on demand")
+    const { geoEquirectangular, geoPath } = require("d3-geo")
+    const area = {
+      type: "Feature",
+      id: "compatibility-area",
+      properties: {},
+      geometry: {
+        type: "Polygon",
+        coordinates: [[[-20, -10], [-20, 10], [20, 10], [20, -10], [-20, -10]]],
+      },
+    }
+    const projection = geoEquirectangular().fitExtent([[0, 0], [120, 80]], area)
+    const sampled = recipes.sampleGeographicDotGrid(
+      [area],
+      {
+        geoPath: geoPath(projection),
+        invertedPoint: (x, y) => projection.invert([x, y]),
+      },
+      { width: 120, height: 80 },
+      { columns: 8 },
+    )
+    if (sampled.dots.length === 0) {
+      throw new Error("d3-geo 3.1.0 did not execute the geoBounds/geoContains recipe path")
+    }
+    console.log(checked + " non-geo exports stayed d3-geo-free; packed require condition and d3-geo 3.1.0 recipe execution passed")
   `
   try {
     const out = runNodeEval(code, { cwd: proj, inputType: "commonjs" })
     console.log(`  ✓ CommonJS recipe geo isolation: ${out.trim()}`)
   } catch (err) {
     failures.push(`CommonJS recipe geo isolation: ${firstLine(err)}`)
+  }
+}
+
+/**
+ * geographicDotGrid calls only geoBounds and geoContains. Both are available
+ * in d3-geo 3.1.0, which is also a common lockfile resolution for the d3 v7
+ * meta-package. Keep that compatible floor and prove the packed consumer can
+ * share its application-owned copy instead of installing a nested d3-geo.
+ */
+function checkCjsRecipeD3GeoDedupe(proj, failures) {
+  const code = `
+    const { createRequire } = require("node:module")
+    const appD3Geo = require.resolve("d3-geo")
+    const semioticRequire = createRequire(require.resolve("semiotic/package.json"))
+    const d3Require = createRequire(require.resolve("d3"))
+    const semioticD3Geo = semioticRequire.resolve("d3-geo")
+    const metaPackageD3Geo = d3Require.resolve("d3-geo")
+    if (semioticD3Geo !== appD3Geo || metaPackageD3Geo !== appD3Geo) {
+      throw new Error(
+        "d3-geo was nested: app=" + appD3Geo +
+        "; semiotic=" + semioticD3Geo +
+        "; d3=" + metaPackageD3Geo
+      )
+    }
+    console.log("semiotic and d3 share the consumer-owned d3-geo 3.1.0")
+  `
+  try {
+    const out = runNodeEval(code, { cwd: proj, inputType: "commonjs" })
+    console.log(`  ✓ CommonJS recipe d3-geo dedupe: ${out.trim()}`)
+  } catch (err) {
+    failures.push(`CommonJS recipe d3-geo dedupe: ${firstLine(err)}`)
   }
 }
 
@@ -963,6 +1040,11 @@ try {
         // runtime peers, while its public declarations import React types; a clean
         // TypeScript app needs both rather than borrowing this repository's tree.
         dependencies: {
+          // Pin the resolution an existing d3 v7 application can carry. The
+          // packed Semiotic install must accept this copy rather than place a
+          // second ESM-only d3-geo under node_modules/semiotic.
+          d3: "7.8.5",
+          "d3-geo": "3.1.0",
           react: sourcePackage.devDependencies.react,
           "react-dom": sourcePackage.devDependencies["react-dom"],
           // The smoke suite imports every public entry point, including the
@@ -1094,6 +1176,7 @@ try {
 
   checkCjsClientContextIdentity(proj, failures)
   checkCjsRecipeGeoIsolation(proj, failures)
+  checkCjsRecipeD3GeoDedupe(proj, failures)
   checkExperimentalFacadeParity(proj, failures)
 
   checkTypeScriptConsumer(proj, packageRoot, failures)


### PR DESCRIPTION
Expand bug report and feature request templates with renderer, runtime, diagnostic, and evidence fields. Overhaul PR template with surface/compatibility and structured evidence sections. Lower d3-geo peer floor from ^3.1.1 to ^3.1.0 so CJS consumers can share an application-owned copy. Add smoke-pack checks for packed require-condition resolution, per-export geo isolation, and d3-geo deduplication.

This pull request improves the project's bug reporting and contribution process, clarifies evidence and compatibility requirements, and fixes a dependency compatibility issue with `d3-geo` for CommonJS consumers. The most important changes are grouped below.

**Contribution and Issue Template Improvements**

* The bug report, feature request, and pull request templates were enhanced to require more precise information about affected components, APIs, import paths, runtime/toolchain, and evidence for both chart/rendering and AI/schema/MCP changes. There is now explicit support for marking evidence as not applicable, and new fields for diagnostic output and compatibility expectations. (.github/ISSUE_TEMPLATE/bug_report.yml, .github/ISSUE_TEMPLATE/feature_request.yml, .github/PULL_REQUEST_TEMPLATE.md) [[1]](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efL3-R3) [[2]](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efR13-R47) [[3]](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efR66-R109) [[4]](diffhunk://#diff-c6b098646bf32c644234bec14c2675ea2a3d9c2dc2df450a25aa0e7ff02323cdR26-R57) [[5]](diffhunk://#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35L5-R48) [[6]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR82-R86)

**Dependency and Packaging Fixes**

* The `d3-geo` dependency floor was lowered from `^3.1.1` to `^3.1.0` in `package.json` to match the actual APIs used and allow consumers to dedupe with their own `d3-geo` installation, avoiding nested ESM copies. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L551-R551) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR210-R215)
* The packaging smoke test was expanded to verify that all non-geographic recipe exports do not eagerly load `d3-geo`, that the packed `require` condition is used, and that the geographic dot-grid recipe works as expected with `d3-geo` 3.1.0. [[1]](diffhunk://#diff-abc8e49ab1b03cdb4243a585cb17334ca1071de09b07ec783c2e481b94e68baeL499-R528) [[2]](diffhunk://#diff-abc8e49ab1b03cdb4243a585cb17334ca1071de09b07ec783c2e481b94e68baeL514-R560)
* A new smoke test ensures that the consumer, Semiotic, and the d3 v7 meta-package all resolve to the same `d3-geo` copy, confirming deduplication. [[1]](diffhunk://#diff-abc8e49ab1b03cdb4243a585cb17334ca1071de09b07ec783c2e481b94e68baeR570-R600) [[2]](diffhunk://#diff-abc8e49ab1b03cdb4243a585cb17334ca1071de09b07ec783c2e481b94e68baeR1043-R1047) [[3]](diffhunk://#diff-abc8e49ab1b03cdb4243a585cb17334ca1071de09b07ec783c2e481b94e68baeR1179)

**Documentation**

* The changelog documents the new evidence requirements in contribution templates and the dependency fix for CommonJS recipe consumers. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR82-R86) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR210-R215)